### PR TITLE
Support text-completion within a `:refer`

### DIFF
--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -351,6 +351,10 @@
                    "file://d.clj" (parser/find-usages
                                     (str "(ns d (:require [alpaca.ns :as alpaca]))")
                                     :clj
+                                    {})
+                   "file://e.clj" (parser/find-usages
+                                    (str "(ns e (:require [alpaca.ns :refer [ba]]))")
+                                    :clj
                                     {})}}]
     (testing "complete-a"
       (reset! db/db db-state)
@@ -375,6 +379,12 @@
               {:label "alpaca/barr" :detail "alpaca.ns" :data "alpaca.ns/barr"}
               {:label "alpaca/bazz" :detail "alpaca.ns" :data "alpaca.ns/bazz"}]
              (handlers/completion "file://b.clj" 3 18))))
+    (testing "complete-within-refering"
+      (reset! db/db db-state)
+      (print (handlers/completion "file://e.clj" 1 38))
+      (is (= [{:label "barr" :detail "alpaca.ns/barr" :data "alpaca.ns/barr"}
+              {:label "bazz" :detail "alpaca.ns/bazz" :data "alpaca.ns/bazz"}]
+             (handlers/completion "file://e.clj" 1 38))))
     (testing "complete-core-stuff"
       (reset! db/db (update-in db-state [:file-envs "file://b.clj" 4] merge {:sym 'freq :str "freq"}))
       (is (= [{:label "frequencies" :data "clojure.core/frequencies"}]

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -381,7 +381,6 @@
              (handlers/completion "file://b.clj" 3 18))))
     (testing "complete-within-refering"
       (reset! db/db db-state)
-      (print (handlers/completion "file://e.clj" 1 38))
       (is (= [{:label "barr" :detail "alpaca.ns/barr" :data "alpaca.ns/barr"}
               {:label "bazz" :detail "alpaca.ns/bazz" :data "alpaca.ns/bazz"}]
              (handlers/completion "file://e.clj" 1 38))))


### PR DESCRIPTION
Initial shot at implementing support for text-completion for `:refer` blocks

For example:
![image](https://user-images.githubusercontent.com/15933322/101542744-56bf1200-39f7-11eb-9814-5f9dcdb4bab3.png)

I'm not convinced that my implementation is the cleanest it can be, so feel free to suggest edits and whatnot