### PR TITLE
Fix jar file URIs to be compatibile with Windows and Unix

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -189,7 +189,7 @@
                               (remove #(.isDirectory %))
                               (map (fn [entry]
                                      [(if (= "jar" dependency-scheme)
-                                        (str "jar:file://" jar-file "!/" (.getName entry))
+                                        (str "jar:file:///" jar-file "!/" (.getName entry))
                                         (str "zipfile://" jar-file "::" (.getName entry)))
                                       entry
                                       jar]))))))

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -61,7 +61,7 @@
                               (enumeration-seq)
                               (remove #(.isDirectory %))
                               (map (fn [entry]
-                                     [(if (= "jar" dependency-scheme)
+                                     [(if jar-dependency-scheme?
                                         (str "jar:file:///" jar-file "!/" (.getName entry))
                                         (str "zipfile://" jar-file "::" (.getName entry)))
                                       entry

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -11,7 +11,7 @@
 (defonce diagnostics-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 4)
+(def version 5)
 
 (defn make-spec [project-root]
   (let [lsp-db (io/file (str project-root) ".lsp" (str "sqlite." version ".db"))]

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -11,7 +11,7 @@
 (defonce diagnostics-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 2)
+(def version 3)
 
 (defn make-spec [project-root]
   (let [lsp-db (io/file (str project-root) ".lsp" "sqlite.1.db")]


### PR DESCRIPTION
Also bump db version so changes work with clients without removing db.

Fixes #223

This change seems to work on both Windows and Linux for jar lookups. Refactorings, however, still do not work on Windows. I'm investigating that now.
