### PR TITLE
Add flag to crawl jars async on startup

### DIFF
--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -5,4 +5,5 @@
                     are [[:inner 0]]}}
  :clj-kondo {:linters {:unused-namespace {:exclude [clojure.tools.logging]}}}
  :semantic-tokens? true
+ :async-scan-jars-on-startup? true
  :use-metadata-for-privacy? true}

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -184,18 +184,14 @@
                                    (crawl-source-dirs (:directory classpath-entries-by-type))))
         jar-envs-chan (async/go
                         (cond
-                          use-cp-cache
-                          (:jar-envs loaded)
-
-                          async-scan-jars-on-startup?
-                          (do (crawl-jars-async! jars dependency-scheme root-path project-hash classpath)
-                              {})
-
-                          :else
-                          (crawl-jars jars dependency-scheme)))
+                          use-cp-cache (:jar-envs loaded)
+                          async-scan-jars-on-startup? {}
+                          :else (crawl-jars jars dependency-scheme)))
         jar-envs (async/<!! jar-envs-chan)]
     (db/save-deps root-path project-hash classpath jar-envs)
     (start-clj-kondo-scan! use-cp-cache classpath)
+    (when start-clj-kondo-scan!
+      (crawl-jars-async! jars dependency-scheme root-path project-hash classpath))
     (merge (async/<!! source-envs-chan)
            (async/<!! file-envs-chan)
            jar-envs)))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -2,10 +2,11 @@
   (:require
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.refactor :as f.refactor]
+   [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
    [clojure-lsp.handlers :as handlers]
    [clojure-lsp.interop :as interop]
-   [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
    [clojure-lsp.shared :as shared]
+   [clojure-lsp.window :as window]
    [clojure.core.async :as async]
    [clojure.tools.logging :as log]
    [nrepl.server :as nrepl.server]
@@ -90,10 +91,6 @@
              (log/debug ~'_id duration# running#)))
          (catch Throwable ex#
            (log/error ex#))))))
-
-(defn ^:private execute-server-info []
-  (.showMessage (:client @db/db)
-                (interop/conform-or-log ::interop/show-message (#'handlers/server-info))))
 
 (defn ^:private execute-refactor [command args]
   (let [[doc-id line col & args] (map interop/json->clj args)]
@@ -384,7 +381,7 @@
               (log/info "Executing command" command "with args" args)
               (cond
                 (= command "server-info")
-                (execute-server-info)
+                (window/show-message (handlers/server-info))
 
                 (some #(= % command) f.refactor/available-refactors)
                 (execute-refactor command args))))))

--- a/src/clojure_lsp/window.clj
+++ b/src/clojure_lsp/window.clj
@@ -1,0 +1,14 @@
+(ns clojure-lsp.window
+  (:require
+    [clojure-lsp.db :as db]
+    [clojure-lsp.interop :as interop]
+    [clojure.tools.logging :as log]))
+
+(defn show-message
+  ([message type]
+   (show-message {:message message :type type}))
+  ([message-type]
+   (log/info message-type)
+   (->> message-type
+        (interop/conform-or-log ::interop/show-message)
+        (.showMessage (:client @db/db)))))


### PR DESCRIPTION
This PR make 2 important changes:

* Most important: add a `async-jars-on-startup?` flag which will allow start server without scan jars, this will alow user interact with everything from the project but going to jars/getting info from symbols of jars. After the async jar crawl is done, it will send a LSP info message to user saying that the jars were scanned successfully, with that, user can use jar features normally. i.e: `clojure-lsp` has **8** source-dirs and **120** jars, the jar scan is almost 4 times slower than src scan. 

* Use `clojure.core.async` on project crawling (source, file-envs and jar-crawling), crawling in parallel instead of waiting for source, file-envs and jar-crawling in this sync order.
This just starts async the 3 crawlers, but we still need to wait for all 3 to finish to respond to client. (unless above flag is one, then we just wait for source and file-envs crawls).