### PR TITLE
Add version in server-info map

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,0 +1,21 @@
+{:remove-surrounding-whitespace? true
+ :remove-trailing-whitespace? true
+ :remove-consecutive-blank-lines? false
+ :insert-missing-whitespace? true
+ :align-associative? false
+ :indents {#"^reg-" [[:inner 0]]
+           #"^:(require|import)" [[:block 0]]}
+ :test-code
+ (comment
+   (:require
+    [])
+   (:require []
+             [])
+   (:clj
+    [])
+   (reg-event-fx
+    :foo
+    (fn [{db :db} _]))
+   (reg-sub
+    :foo
+    (fn [db [_]])))}

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -21,7 +21,8 @@
     [clojure.string :as string]
     [clojure.tools.logging :as log]
     [rewrite-clj.node :as n]
-    [rewrite-clj.zip :as z])
+    [rewrite-clj.zip :as z]
+    [trptcolin.versioneer.core :as version])
   (:import
     [java.net URL JarURLConnection]))
 
@@ -275,12 +276,14 @@
                                :version v})))
 
 (defn server-info []
-  (let [db @db/db]
+  (let [db @db/db
+        server-version (version/get-version "clojure-lsp" "clojure-lsp")]
     {:type :info
      :message (with-out-str (pprint/pprint {:project-root (:project-root db)
                                             :project-settings (:project-settings db)
                                             :client-settings (:client-settings db)
-                                            :port (:port db)}))}))
+                                            :port (:port db)
+                                            :version server-version}))}))
 
 (defn hover [doc-id line column]
   (let [file-envs (:file-envs @db/db)


### PR DESCRIPTION
Add version to server-info map

Fixes #228

Also adding `.cljfmt.edn` settings for indenting ns forms, so that Calva behaves politely.