### PR TITLE
Improve clean ns

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -32,18 +32,16 @@
          set
          (set/difference (set (map :ns declarations))))))
 
-(defn find-unused-aliases [uri]
-  (let [usages (f.references/safe-find-references uri (slurp uri) false false)
-        declarations (f.diagnostic/usages->declarations usages)
+(defn find-unused-aliases [usages]
+  (let [declarations (f.diagnostic/usages->declarations usages)
         excludes (-> (get-in @db/db [:settings :linters :unused-namespace :exclude] #{}) set)
         declared-aliases (->> declarations
                               (filter (comp #(contains? % :alias) :tags))
                               (remove (comp excludes :ns)))]
     (process-unused usages declared-aliases)))
 
-(defn find-unused-refers [uri]
-  (let [usages (f.references/safe-find-references uri (slurp uri) false false)
-        declarations (f.diagnostic/usages->declarations usages)
+(defn find-unused-refers [usages]
+  (let [declarations (f.diagnostic/usages->declarations usages)
         excludes (-> (get-in @db/db [:settings :linters :unused-namespace :exclude] #{}) set)
         declared-refers (->> declarations
                               (filter (comp #(contains? % :refer) :tags))

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -10,7 +10,8 @@
    [rewrite-clj.custom-zipper.core :as cz]
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]
-   [rewrite-clj.zip.subedit :as zsub]))
+   [rewrite-clj.zip.subedit :as zsub]
+   [clojure-lsp.feature.references :as f.references]))
 
 (defn result [zip-edits]
   (mapv (fn [zip-edit]
@@ -294,8 +295,9 @@
               4)
         sep (n/whitespace-node (apply str (repeat col " ")))
         single-space (n/whitespace-node " ")
-        unused-aliases (crawler/find-unused-aliases uri)
-        unused-refers (crawler/find-unused-refers uri)
+        usages (f.references/safe-find-references uri (slurp uri) false false)
+        unused-aliases (crawler/find-unused-aliases usages)
+        unused-refers (crawler/find-unused-refers usages)
         removed-nodes (->> require-loc
                            z/remove
                            (remove-unused-requires (set/union unused-aliases unused-refers)))

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure-lsp.crawler :as crawler]
    [clojure-lsp.db :as db]
+   [clojure-lsp.feature.references :as f.references]
    [clojure-lsp.parser :as parser]
    [clojure-lsp.refactor.edit :as edit]
    [clojure.set :as set]
@@ -10,8 +11,7 @@
    [rewrite-clj.custom-zipper.core :as cz]
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]
-   [rewrite-clj.zip.subedit :as zsub]
-   [clojure-lsp.feature.references :as f.references]))
+   [rewrite-clj.zip.subedit :as zsub]))
 
 (defn result [zip-edits]
   (mapv (fn [zip-edit]
@@ -254,30 +254,64 @@
                        (z/insert-child 'let)
                        (edit/join-let))}]))))))
 
+(defn ^:private safe-remove-node
+  [node]
+  (let [removed-node (-> node z/remove)]
+    (if (z/list? removed-node)
+      (z/down removed-node)
+      (z/up removed-node))))
+
+(defn ^:private remove-unused-refers
+  [node unused-refers]
+  (let [node-refers (-> node z/down (z/find-next-value ':refer) z/right z/sexpr set)
+        unused-refers-symbol (->> unused-refers (map (comp symbol name)) set)
+        removed-refers (set/difference node-refers unused-refers-symbol)]
+    (if (empty? removed-refers)
+      (safe-remove-node node)
+      (-> node
+          z/down
+          z/rightmost
+          (z/replace (n/vector-node (vec removed-refers)))
+          z/up))))
+
 (defn ^:private remove-unused-require
-  [node unused-aliases]
-  (if (z/vector? node)
-    (let [alias-node (-> node z/down z/leftmost)]
-      (if (contains? unused-aliases (z/sexpr alias-node))
-        (let [removed-node (-> node z/remove)]
-          (if (z/list? removed-node)
-            (z/down removed-node)
-            (z/up removed-node)))
-        node))
+  [node unused-aliases unused-refers]
+  (cond
+    (not (z/vector? node))
+    node
+
+    (contains? unused-aliases (-> node z/down z/leftmost z/sexpr))
+    (safe-remove-node node)
+
+    (contains? (->> unused-refers (map (comp symbol namespace)) set)
+               (-> node z/down z/leftmost z/sexpr))
+    (remove-unused-refers node unused-refers)
+
+    :else
     node))
 
 (defn ^:private remove-unused-requires
-  [unused-ns nodes]
+  [unused-aliases unused-refers nodes]
   (let [single-require? (= 1 (count (z/child-sexprs nodes)))
         first-node      (z/next nodes)
+        first-node-ns   (when (and single-require?
+                                   (z/vector? first-node))
+                          (-> first-node z/down z/leftmost z/sexpr))
+        first-node-refers (when (and single-require?
+                                     (z/vector? first-node))
+                            (->> (-> first-node
+                                     z/down
+                                     (z/find-next-value ':refer)
+                                     z/right
+                                     z/sexpr)
+                                 (map #(symbol (str first-node-ns) (str %)))
+                                 set))
         single-unused?  (when (and single-require? (z/vector? first-node))
-                          (contains? unused-ns (-> first-node
-                                                   z/down
-                                                   z/leftmost
-                                                   z/sexpr)))]
+                          (or (contains? unused-aliases first-node-ns)
+                              (set/subset? first-node-refers unused-refers)))]
     (if single-unused?
       (z/remove first-node)
-      (let [removed (z/map #(remove-unused-require % unused-ns) nodes)]
+      (let [removed (z/map #(remove-unused-require % unused-aliases unused-refers) nodes)]
         (if (= :vector (z/tag removed))
           (z/up removed)
           removed)))))
@@ -300,7 +334,7 @@
         unused-refers (crawler/find-unused-refers usages)
         removed-nodes (->> require-loc
                            z/remove
-                           (remove-unused-requires (set/union unused-aliases unused-refers)))
+                           (remove-unused-requires unused-aliases unused-refers))
         requires (->> removed-nodes
                       z/node
                       n/children

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -270,13 +270,16 @@
   (let [single-require? (= 1 (count (z/child-sexprs nodes)))
         first-node      (z/next nodes)
         single-unused?  (when (and single-require? (z/vector? first-node))
-                         (contains? unused-ns (-> first-node
-                                                       z/down
-                                                       z/leftmost
-                                                       z/sexpr)))]
+                          (contains? unused-ns (-> first-node
+                                                   z/down
+                                                   z/leftmost
+                                                   z/sexpr)))]
     (if single-unused?
       (z/remove first-node)
-      (z/map #(remove-unused-require % unused-ns) nodes))))
+      (let [removed (z/map #(remove-unused-require % unused-ns) nodes)]
+        (if (= :vector (z/tag removed))
+          (z/up removed)
+          removed)))))
 
 (defn clean-ns
   [zloc uri]

--- a/test/clojure_lsp/crawler_test.clj
+++ b/test/clojure_lsp/crawler_test.clj
@@ -1,6 +1,8 @@
 (ns clojure-lsp.crawler-test
-  (:require [clojure-lsp.crawler :as crawler]
-            [clojure.test :refer :all]))
+  (:require
+   [clojure-lsp.crawler :as crawler]
+   [clojure-lsp.feature.references :as f.references]
+   [clojure.test :refer :all]))
 
 (def unused-alias-code
   "(ns foo.bar
@@ -10,9 +12,9 @@
 
 (deftest find-unused-aliases-test
   (testing "When there is unused aliases"
-    (with-redefs [slurp (constantly unused-alias-code)]
+    (let [usages (f.references/safe-find-references "file://a.clj" unused-alias-code false false)]
       (is (= #{'foo.baz}
-             (crawler/find-unused-aliases "file://a.clj"))))))
+             (crawler/find-unused-aliases usages))))))
 
 (def unused-refer-code
   "(ns foo.bar
@@ -39,14 +41,14 @@
 
 (deftest find-unused-refers-test
   (testing "When there is a unused refer"
-    (with-redefs [slurp (constantly unused-refer-code)]
+    (let [usages (f.references/safe-find-references  "file://a.clj" unused-refer-code false false)]
       (is (= #{'foo.baz}
-             (crawler/find-unused-refers "file://a.clj")))))
+             (crawler/find-unused-refers usages)))))
   (testing "When there is a unused refer but used refers on other require"
-    (with-redefs [slurp (constantly unused-refer-with-used-refers-on-other-require-code)]
+    (let [usages (f.references/safe-find-references  "file://a.clj" unused-refer-with-used-refers-on-other-require-code false false)]
       (is (= #{'foo.baz}
-             (crawler/find-unused-refers "file://a.clj")))))
+             (crawler/find-unused-refers usages)))))
   (testing "When there is a unused refer but used refers on same require"
-    (with-redefs [slurp (constantly unused-refer-with-used-refers-on-same-require-code)]
+    (let [usages (f.references/safe-find-references  "file://a.clj" unused-refer-with-used-refers-on-same-require-code false false)]
       (is (= #{}
-             (crawler/find-unused-refers "file://a.clj"))))))
+             (crawler/find-unused-refers usages))))))

--- a/test/clojure_lsp/crawler_test.clj
+++ b/test/clojure_lsp/crawler_test.clj
@@ -33,7 +33,7 @@
 
 (def unused-refer-with-used-refers-on-same-require-code
   "(ns foo.bar
-     (:require [foo.baz :refer [other another]]
+     (:require [foo.baz :refer [other another some-other]]
                [foo.bah :as bah]))
    (def zas
      (bah/some)
@@ -42,13 +42,13 @@
 (deftest find-unused-refers-test
   (testing "When there is a unused refer"
     (let [usages (f.references/safe-find-references  "file://a.clj" unused-refer-code false false)]
-      (is (= #{'foo.baz}
+      (is (= #{'foo.baz/other}
              (crawler/find-unused-refers usages)))))
   (testing "When there is a unused refer but used refers on other require"
     (let [usages (f.references/safe-find-references  "file://a.clj" unused-refer-with-used-refers-on-other-require-code false false)]
-      (is (= #{'foo.baz}
+      (is (= #{'foo.baz/other}
              (crawler/find-unused-refers usages)))))
   (testing "When there is a unused refer but used refers on same require"
     (let [usages (f.references/safe-find-references  "file://a.clj" unused-refer-with-used-refers-on-same-require-code false false)]
-      (is (= #{}
+      (is (= #{'foo.baz/other 'foo.baz/some-other}
              (crawler/find-unused-refers usages))))))

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -230,6 +230,12 @@
                          "   baz))"
                          "(defn func []"
                          "  (f/some))")))
+  (testing "with refer as single require"
+    (test-clean-ns {}
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [bar :refer [some]]))")
+                   (code "(ns foo.bar)")))
   (testing "in any form"
     (let [to-clean (code "(ns foo.bar"
                          " (:require"
@@ -277,7 +283,26 @@
                          ""
                          "(defn func []"
                          "  b/some"
-                         "  (some))"))))
+                         "  (some))")))
+  (testing "unused refer from multiple refers"
+      (test-clean-ns {}
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "   [bar :refer [some other] ]))"
+                           "(some)")
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "   [bar :refer [some] ]))"
+                           "(some)")))
+  (testing "unused refer and alias"
+      (test-clean-ns {}
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "   [bar :refer [some] ]"
+                           "   [baz :as b]))")
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "   [baz :as b]))"))))
 
 (deftest add-missing-libspec
   (reset! db/db {:file-envs


### PR DESCRIPTION
* Fix bug where it was messing up require form if it the first unused require has a `:refer`
* Improve a little bit the performance calling `find-references` only one time instead of twice
* Now we finally remove unused refers even if it contains one used:

Before apply clean-ns
```clojure
(:require [clojure-sample.c :refer [foo bar]])
(foo)
```
After apply clean-ns
```clojure
(:require [clojure-sample.c :refer [foo]])
(foo)
```
