### PR TITLE
Improve "add missing namespace" code action

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -82,6 +82,9 @@
 
 (defn crawl-source-dirs [dirs]
   (let [xf (comp
+             (map (fn [dir]
+                    (log/info "Crawling dir" (.getPath dir))
+                    dir))
             (mapcat file-seq)
             (filter #(.isFile %))
             (map file->uri)

--- a/src/clojure_lsp/feature/code_actions.clj
+++ b/src/clojure_lsp/feature/code_actions.clj
@@ -23,14 +23,15 @@
                                                 :uri uri
                                                 :version 0
                                                 :row row
-                                                :col col}))]
+                                                :col col
+                                                :args {:source :code-action}}))]
     (cond-> []
 
-      missing-ns
-      (conj {:title          "Add missing namespace"
+      (:result missing-ns)
+      (conj {:title          (str "Add missing '" (-> missing-ns :code-action-data :ns-name) "' namespace")
              :kind           :quick-fix
              :preferred?     true
-             :workspace-edit missing-ns})
+             :workspace-edit (f.refactor/refactor-client-seq-changes uri 0 (:result missing-ns))})
 
       inline-symbol?
       (conj {:title   "Inline symbol"

--- a/src/clojure_lsp/feature/code_actions.clj
+++ b/src/clojure_lsp/feature/code_actions.clj
@@ -13,11 +13,11 @@
         inline-symbol? (r.transform/inline-symbol? def-uri definition)
         line (dec row)
         character (dec col)
-        has-unknow-ns? (some #(= (compare "unresolved-namespace" (some-> % .getCode .get)) 0) diagnostics)
+        has-unknown-ns? (some #(= (compare "unresolved-namespace" (some-> % .getCode .get)) 0) diagnostics)
         unresolved-symbol (first (filter #(= (compare "unresolved-symbol" (some-> % .getCode .get)) 0) diagnostics))
         known-refer? (when unresolved-symbol
                        (get r.transform/common-refers->info (z/sexpr zloc)))
-        missing-ns (when (or has-unknow-ns? known-refer?)
+        missing-ns (when (or has-unknown-ns? known-refer?)
                      (f.refactor/call-refactor {:loc zloc
                                                 :refactoring :add-missing-libspec
                                                 :uri uri

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -458,7 +458,7 @@
                                         (z/find-value z/next ':refer)
                                         z/right
                                         (cz/append-child (n/spaces 1))
-                                        (z/append-child 'testing))
+                                        (z/append-child (z/sexpr zloc)))
                            (z/subedit-> ns-loc
                                         (cond->
                                             add-require? (z/append-child (n/newlines 1))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -442,29 +442,29 @@
     (testing "Add missing namespace"
       (testing "when it has not unresolved-namespace diagnostic"
         (reset! db/db db-state)
-        (is (not-any? #(= (:title %) "Add missing namespace")
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
                       (handlers/code-actions "file://c.clj" [] 1 9))))
 
       (testing "when it has unresolved-namespace but cannot find namespace"
         (reset! db/db db-state)
         (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 1 10) (Position. 1 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unresolved-namespace")]
-          (is (not-any? #(= (:title %) "Add missing namespace")
+          (is (not-any? #(string/starts-with? (:title %) "Add missing")
                         (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 1 10)))))
 
       (testing "when it has unresolved-namespace and can find namespace"
         (reset! db/db db-state)
         (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 2 10) (Position. 2 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unresolved-namespace")]
-          (is (some #(= (:title %) "Add missing namespace")
+          (is (some #(= (:title %) "Add missing 'some-ns' namespace")
                     (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 2 10)))))
       (testing "when it has unresolved-symbol and it's a known refer"
         (reset! db/db db-state)
         (let [unknown-symbol-diagnostic (Diagnostic. (Range. (Position. 3 1) (Position. 3 8)) "Unresolved symbol deftest" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
-          (is (some #(= (:title %) "Add missing namespace")
+          (is (some #(= (:title %) "Add missing 'clojure.test' namespace")
                     (handlers/code-actions "file://c.clj" [unknown-symbol-diagnostic] 3 1)))))
       (testing "when it has unresolved-symbol but it's not a known refer"
         (reset! db/db db-state)
         (let [unknown-symbol-diagnostic (Diagnostic. (Range. (Position. 3 10) (Position. 3 18)) "Unresolved symbol some-test" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
-          (is (not-any? #(= (:title %) "Add missing namespace")
+          (is (not-any? #(string/starts-with? (:title %) "Add missing")
                         (handlers/code-actions "file://c.clj" [unknown-symbol-diagnostic] 3 10))))))
     (testing "Inline symbol"
       (testing "when in not a let/def symbol"

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -431,7 +431,8 @@
                       "  bar)")
         c-code   (str "(ns another-ns)\n"
                       "(def bar ons/bar)\n"
-                      "(def foo sns/foo)")
+                      "(def foo sns/foo)\n"
+                      "(deftest some-test)")
         db-state {:documents {"file://a.clj" {:text references-code}
                               "file://b.clj" {:text b-code}
                               "file://c.clj" {:text c-code}}
@@ -454,7 +455,17 @@
         (reset! db/db db-state)
         (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 2 10) (Position. 2 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unresolved-namespace")]
           (is (some #(= (:title %) "Add missing namespace")
-                    (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 2 10))))))
+                    (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 2 10)))))
+      (testing "when it has unresolved-symbol and it's a known refer"
+        (reset! db/db db-state)
+        (let [unknown-symbol-diagnostic (Diagnostic. (Range. (Position. 3 1) (Position. 3 8)) "Unresolved symbol deftest" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
+          (is (some #(= (:title %) "Add missing namespace")
+                    (handlers/code-actions "file://c.clj" [unknown-symbol-diagnostic] 3 1)))))
+      (testing "when it has unresolved-symbol but it's not a known refer"
+        (reset! db/db db-state)
+        (let [unknown-symbol-diagnostic (Diagnostic. (Range. (Position. 3 10) (Position. 3 18)) "Unresolved symbol some-test" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
+          (is (not-any? #(= (:title %) "Add missing namespace")
+                        (handlers/code-actions "file://c.clj" [unknown-symbol-diagnostic] 3 10))))))
     (testing "Inline symbol"
       (testing "when in not a let/def symbol"
         (reset! db/db db-state)

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -342,7 +342,13 @@
     (testing "we don't add existing refers"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [testing]])) testing") z/rightmost)]
-        (is (= nil (transform/add-missing-libspec zloc)))))))
+        (is (= nil (transform/add-missing-libspec zloc)))))
+    (testing "we can add multiple refers"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [deftest testing]])) is") z/rightmost)
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.test :refer [deftest testing is]])) (z/sexpr loc)))))))
 
 (deftest unwind-thread-test
   (let [zloc (z/of-string "(-> a b (c) d)")

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -305,19 +305,44 @@
                            "   [baz :as b]))"))))
 
 (deftest add-missing-libspec
-  (testing "simple"
-    (reset! db/db {:file-envs
-                   {"file://a.clj" (parser/find-usages "(ns a (:require [foo.s :as s]))" :clj {})}})
-    (let [zloc (-> (z/of-string "(ns foo) s/thing") z/rightmost)
-          [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
-      (is (some? range))
-      (is (= '(ns foo (:require [foo.s :as s])) (z/sexpr loc)))))
-  (testing "common aliases"
-    (reset! db/db {:file-envs {}})
-    (let [zloc (-> (z/of-string "(ns foo) set/subset?") z/rightmost)
-          [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
-      (is (some? range))
-      (is (= '(ns foo (:require [clojure.set :as set])) (z/sexpr loc))))))
+  (testing "aliases"
+    (testing "known namespaces in project"
+      (reset! db/db {:file-envs
+                     {"file://a.clj" (parser/find-usages "(ns a (:require [foo.s :as s]))" :clj {})}})
+      (let [zloc (-> (z/of-string "(ns foo) s/thing") z/rightmost)
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+        (is (some? range))
+        (is (= '(ns foo (:require [foo.s :as s])) (z/sexpr loc)))))
+    (testing "common ns aliases"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo) set/subset?") z/rightmost)
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.set :as set])) (z/sexpr loc))))))
+  (testing "common refers"
+    (testing "when require doesn't exists"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo) deftest") z/rightmost)
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.test :refer [deftest]])) (z/sexpr loc)))))
+    (testing "when already exists another require"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo (:require [clojure.set :refer [subset?]])) deftest") z/rightmost)
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.set :refer [subset?]]
+                                  [clojure.test :refer [deftest]])) (z/sexpr loc)))))
+    (testing "when already exists that ns with another refer"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [deftest]])) testing") z/rightmost)
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.test :refer [deftest testing]])) (z/sexpr loc)))))
+    (testing "we don't add existing refers"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [testing]])) testing") z/rightmost)]
+        (is (= nil (transform/add-missing-libspec zloc)))))))
 
 (deftest unwind-thread-test
   (let [zloc (z/of-string "(-> a b (c) d)")

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -310,45 +310,62 @@
       (reset! db/db {:file-envs
                      {"file://a.clj" (parser/find-usages "(ns a (:require [foo.s :as s]))" :clj {})}})
       (let [zloc (-> (z/of-string "(ns foo) s/thing") z/rightmost)
-            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc nil)]
         (is (some? range))
         (is (= '(ns foo (:require [foo.s :as s])) (z/sexpr loc)))))
     (testing "common ns aliases"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo) set/subset?") z/rightmost)
-            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc nil)]
         (is (some? range))
         (is (= '(ns foo (:require [clojure.set :as set])) (z/sexpr loc))))))
   (testing "common refers"
     (testing "when require doesn't exists"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo) deftest") z/rightmost)
-            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc nil)]
         (is (some? range))
         (is (= '(ns foo (:require [clojure.test :refer [deftest]])) (z/sexpr loc)))))
     (testing "when already exists another require"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo (:require [clojure.set :refer [subset?]])) deftest") z/rightmost)
-            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc nil)]
         (is (some? range))
         (is (= '(ns foo (:require [clojure.set :refer [subset?]]
                                   [clojure.test :refer [deftest]])) (z/sexpr loc)))))
     (testing "when already exists that ns with another refer"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [deftest]])) testing") z/rightmost)
-            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc nil)]
         (is (some? range))
         (is (= '(ns foo (:require [clojure.test :refer [deftest testing]])) (z/sexpr loc)))))
     (testing "we don't add existing refers"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [testing]])) testing") z/rightmost)]
-        (is (= nil (transform/add-missing-libspec zloc)))))
+        (is (= nil (transform/add-missing-libspec zloc nil)))))
     (testing "we can add multiple refers"
       (reset! db/db {:file-envs {}})
       (let [zloc (-> (z/of-string "(ns foo (:require [clojure.test :refer [deftest testing]])) is") z/rightmost)
-            [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
+            [{:keys [loc range]}] (transform/add-missing-libspec zloc nil)]
         (is (some? range))
-        (is (= '(ns foo (:require [clojure.test :refer [deftest testing is]])) (z/sexpr loc)))))))
+        (is (= '(ns foo (:require [clojure.test :refer [deftest testing is]])) (z/sexpr loc))))))
+  (testing "from code-action source"
+    (testing "aliases"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo) set/subset?") z/rightmost)
+            response (transform/add-missing-libspec zloc {:source :code-action})
+            [{:keys [loc range]}] (:result response)]
+        (is (= 'clojure.set (-> response :code-action-data :ns-name)))
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.set :as set])) (z/sexpr loc)))))
+    (testing "refers"
+      (reset! db/db {:file-envs {}})
+      (let [zloc (-> (z/of-string "(ns foo) deftest") z/rightmost)
+            response (transform/add-missing-libspec zloc {:source :code-action})
+            [{:keys [loc range]}] (:result response)]
+        (is (= 'clojure.test (-> response :code-action-data :ns-name)))
+        (is (some? range))
+        (is (= '(ns foo (:require [clojure.test :refer [deftest]])) (z/sexpr loc)))))))
 
 (deftest unwind-thread-test
   (let [zloc (z/of-string "(-> a b (c) d)")


### PR DESCRIPTION
This PR improves the add missing namespace code action:

- Add the namespace which will be required so `Add missing namespace` -> `Add 'clojure.test' missing namespace`
- It suggests known common alias namespaces like `set` -> `clojure.set`, `walk` -> `clojure.walk`, `string` -> `clojure.string` etc
- It suggests known common refers like `deftest`, `testing`, `is`, `are`, `fact`, `facts` etc.

![clojure-code-action-add-missing-ns](https://user-images.githubusercontent.com/7820865/103601103-b53cba80-4ee7-11eb-9f76-56e674b72fd8.gif)
