### PR TITLE
Prevent orphaned server processes

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -124,7 +124,7 @@
 
 (defn ^:private classpath-cmd->windows-safe-classpath-cmd
   [classpath]
-  (if (shared/windows-os?)
+  (if shared/windows-os?
     (into ["powershell.exe"] classpath)
     classpath))
 

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -431,19 +431,14 @@
         (end
           (apply #'handlers/extension method args)))))
 
-(defn ^:private process-alive?
-  [pid]
-  (let [{:keys [exit]} (shell/sh "kill" "-0" (str pid))]
-    (= exit 0)))
-
 (defn ^:private start-parent-process-liveness-probe!
   [ppid server]
   (future (run!
            (fn [_]
              (Thread/sleep 5000)
-             (log/info "Checking parent process" ppid "liveness")
-             (if (process-alive? ppid)
-               (log/info "Parent process" ppid "is running")
+             (log/debug "Checking parent process" ppid "liveness")
+             (if (shared/process-alive? ppid)
+               (log/debug "Parent process" ppid "is running")
                (do
                  (log/info "Parent process" ppid "is not running - exiting server")
                  (.exit server))))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -431,7 +431,7 @@
         (end
           (apply #'handlers/extension method args)))))
 
-(defn process-alive?
+(defn ^:private process-alive?
   [pid]
   (let [{:keys [exit]} (shell/sh "kill" "-0" (str pid))]
     (= exit 0)))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -433,16 +433,16 @@
 
 (defn ^:private start-parent-process-liveness-probe!
   [ppid server]
-  (future (run!
-           (fn [_]
-             (Thread/sleep 5000)
-             (log/debug "Checking parent process" ppid "liveness")
-             (if (shared/process-alive? ppid)
-               (log/debug "Parent process" ppid "is running")
-               (do
-                 (log/info "Parent process" ppid "is not running - exiting server")
-                 (.exit server))))
-           (range))))
+  (async/go-loop []
+    (async/<! (async/timeout 5000))
+    (log/debug "Checking parent process" ppid "liveness")
+    (if (shared/process-alive? ppid)
+      (do 
+        (log/debug "Parent process" ppid "is running")
+        (recur))
+      (do
+        (log/info "Parent process" ppid "is not running - exiting server")
+        (.exit server)))))
 
 (def server
   (proxy [ClojureExtensions LanguageServer] []

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -8,6 +8,7 @@
    [clojure-lsp.shared :as shared]
    [clojure-lsp.window :as window]
    [clojure.core.async :as async]
+   [clojure.java.shell :as shell]
    [clojure.tools.logging :as log]
    [nrepl.server :as nrepl.server]
    [trptcolin.versioneer.core :as version])
@@ -430,6 +431,24 @@
         (end
           (apply #'handlers/extension method args)))))
 
+(defn process-alive?
+  [pid]
+  (let [{:keys [exit]} (shell/sh "kill" "-0" (str pid))]
+    (= exit 0)))
+
+(defn start-parent-process-liveness-probe!
+  [ppid server]
+  (future (run!
+           (fn [_]
+             (Thread/sleep 5000)
+             (log/info "Checking parent process" ppid "liveness")
+             (if (process-alive? ppid)
+               (log/info "Parent process" ppid "is running")
+               (do
+                 (log/info "Parent process" ppid "is not running - exiting server")
+                 (.exit server))))
+           (range))))
+
 (def server
   (proxy [ClojureExtensions LanguageServer] []
     (^CompletableFuture initialize [^InitializeParams params]
@@ -440,6 +459,8 @@
               (#'handlers/initialize (.getRootUri params)
                                      (client-capabilities params)
                                      (client-settings params))
+              (when-let [parent-process-id (.getProcessId params)]
+                (start-parent-process-liveness-probe! parent-process-id this))
               (let [settings (:settings @db/db)]
                 (CompletableFuture/completedFuture
                   (InitializeResult. (doto (ServerCapabilities.)
@@ -484,7 +505,7 @@
       (log/info "Shutting down")
       (reset! db/db {:documents {}}) ;; TODO confirm this is correct
       (CompletableFuture/completedFuture
-        {:result nil}))
+       {:result nil}))
     (exit []
       (log/info "Exit")
       (shutdown-agents)

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -436,7 +436,7 @@
   (let [{:keys [exit]} (shell/sh "kill" "-0" (str pid))]
     (= exit 0)))
 
-(defn start-parent-process-liveness-probe!
+(defn ^:private start-parent-process-liveness-probe!
   [ppid server]
   (future (run!
            (fn [_]


### PR DESCRIPTION
Add parent process probe if `processId` is sent in initialize request. Exit server gracefully if parent process is not alive.

The process liveness check has been tested on Linux and Windows.