### PR TITLE
Add code lens resolve support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,7 @@
         org.eclipse.xtend/org.eclipse.xtend.lib {:mvn/version "2.24.0" :exclusions [com.google.guava/guava]}
         com.google.guava/guava {:mvn/version "30.1-jre"}
         rewrite-clj/rewrite-clj {:local/root "lib/rewrite-clj-0.6.2-SNAPSHOT.jar"}
+        org.clojure/data.json {:mvn/version "1.0.0"}
         log4j/log4j {:mvn/version "1.2.17" :exclusions [javax.mail/mail
                                                         javax.jms/jms
                                                         com.sun.jdmk/jmxtools

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -47,6 +47,7 @@ Below are all the currently supported LSP capabilities and their implementation 
 | textDocument/documentHighlight         | √    |                                               |
 | textDocument/documentSymbol            | √    |                                               |
 | textDocument/codeAction                | √    |                                               |
+| codeAction/resolve                     | √    |                                               |
 | textDocument/codeLens                  | √    |                                               |
 | codeLens/resolve                       | √    |                                               |
 | textDocument/documentLink              |      |                                               |

--- a/src/clojure_lsp/feature/code_actions.clj
+++ b/src/clojure_lsp/feature/code_actions.clj
@@ -3,7 +3,6 @@
     [clojure-lsp.feature.definition :as f.definition]
     [clojure-lsp.feature.refactor :as f.refactor]
     [clojure-lsp.refactor.transform :as r.transform]
-    [clojure.tools.logging :as log]
     [rewrite-clj.zip :as z])
   (:import
    (org.eclipse.lsp4j
@@ -32,7 +31,8 @@
              "clean-ns"
              {:command {:title     "Clean namespace"
                         :command   "clean-ns"
-                        :arguments [uri line character]}}))
+                        :arguments [uri line character]}}
+             {}))
     (dissoc :data :diagnostics)))
 
 (defn all [zloc uri row col diagnostics client-capabilities]
@@ -105,4 +105,4 @@
                        :character character}})
 
       (not resolve-support?)
-      #(map resolve-code-action %))))
+      (->> (map resolve-code-action)))))

--- a/src/clojure_lsp/feature/code_actions.clj
+++ b/src/clojure_lsp/feature/code_actions.clj
@@ -3,66 +3,106 @@
     [clojure-lsp.feature.definition :as f.definition]
     [clojure-lsp.feature.refactor :as f.refactor]
     [clojure-lsp.refactor.transform :as r.transform]
-    [rewrite-clj.zip :as z]))
+    [clojure.tools.logging :as log]
+    [rewrite-clj.zip :as z])
+  (:import
+   (org.eclipse.lsp4j
+     CodeActionKind)))
+
+(defn resolve-code-action [{{:keys [id uri line character]} :data :as code-action}]
+  (->
+    (merge code-action
+           (case id
+
+             "refactor-inline-symbol"
+             {:command {:title     "Inline symbol"
+                        :command   "inline-symbol"
+                        :arguments [uri line character]}}
+
+             "refactor-cycle-privacy"
+             {:command {:title     "Cycle privacy"
+                        :command   "cycle-privacy"
+                        :arguments [uri line character]}}
+
+             "refactor-extract-function"
+             {:command {:title     "Extract function"
+                        :command   "extract-function"
+                        :arguments [uri line character "new-function"]}}
+
+             "clean-ns"
+             {:command {:title     "Clean namespace"
+                        :command   "clean-ns"
+                        :arguments [uri line character]}}))
+    (dissoc :data :diagnostics)))
 
 (defn all [zloc uri row col diagnostics client-capabilities]
   (let [workspace-edit-capability? (get-in client-capabilities [:workspace :workspace-edit])
-        inside-function? (r.transform/inside-function? zloc)
-        [_ {def-uri :uri
-            definition :usage}] (f.definition/definition-usage uri row col)
-        inline-symbol? (r.transform/inline-symbol? def-uri definition)
-        line (dec row)
-        character (dec col)
-        has-unknown-ns? (some #(= (compare "unresolved-namespace" (:code %)) 0) diagnostics)
-        unresolved-symbol (some #(= (compare "unresolved-symbol" (:code %)) 0) diagnostics)
-        known-refer? (when unresolved-symbol
-                       (get r.transform/common-refers->info (z/sexpr zloc)))
-        missing-require (when (or has-unknown-ns? known-refer?)
-                          (f.refactor/call-refactor {:loc zloc
-                                                     :refactoring :add-missing-libspec
-                                                     :uri uri
-                                                     :version 0
-                                                     :row row
-                                                     :col col
-                                                     :args {:source :code-action}}))
-        missing-import (when unresolved-symbol
-                         (r.transform/add-common-import-to-namespace zloc))]
+        resolve-support? (get-in client-capabilities [:text-document :code-action :resolve-support])
+        inside-function?           (r.transform/inside-function? zloc)
+        [_ {def-uri    :uri
+            definition :usage}]    (f.definition/definition-usage uri row col)
+        inline-symbol?             (r.transform/inline-symbol? def-uri definition)
+        line                       (dec row)
+        character                  (dec col)
+        has-unknown-ns?            (some #(= (compare "unresolved-namespace" (:code %)) 0) diagnostics)
+        unresolved-symbol          (some #(= (compare "unresolved-symbol" (:code %)) 0) diagnostics)
+        known-refer?               (when unresolved-symbol
+                                     (get r.transform/common-refers->info (z/sexpr zloc)))
+        missing-require            (when (or has-unknown-ns? known-refer?)
+                                     (f.refactor/call-refactor {:loc         zloc
+                                                                :refactoring :add-missing-libspec
+                                                                :uri         uri
+                                                                :version     0
+                                                                :row         row
+                                                                :col         col
+                                                                :args        {:source :code-action}}))
+        missing-import             (when unresolved-symbol
+                                     (r.transform/add-common-import-to-namespace zloc))]
     (cond-> []
 
       (:result missing-require)
       (conj {:title          (str "Add missing '" (-> missing-require :code-action-data :ns-name) "' require")
-             :kind           :quick-fix
+             :kind           CodeActionKind/QuickFix
              :preferred?     true
+             :data           {:id "add-missing-require"}
              :workspace-edit (f.refactor/refactor-client-seq-changes uri 0 (:result missing-require))})
 
       (:result missing-import)
       (conj {:title          (str "Add missing '" (-> missing-import :code-action-data :import-name) "' import")
-             :kind           :quick-fix
+             :kind           CodeActionKind/QuickFix
              :preferred?     true
+             :data           {:id "add-missing-import"}
              :workspace-edit (f.refactor/refactor-client-seq-changes uri 0 (:result missing-import))})
 
       inline-symbol?
       (conj {:title   "Inline symbol"
-             :kind    :refactor-inline
-             :command {:title     "Inline symbol"
-                       :command   "inline-symbol"
-                       :arguments [uri line character]}})
+             :kind    CodeActionKind/RefactorInline
+             :data    {:id "refactor-inline-symbol"
+                       :uri uri
+                       :line line
+                       :character character}})
 
       inside-function?
       (conj {:title   "Cycle privacy"
-             :kind    :refactor-rewrite
-             :command {:title     "Cycle privacy"
-                       :command   "cycle-privacy"
-                       :arguments [uri line character]}}
+             :kind    CodeActionKind/RefactorRewrite
+             :data    {:id "refactor-cycle-privacy"
+                       :uri uri
+                       :line line
+                       :character character}}
             {:title   "Extract function"
-             :kind    :refactor-extract
-             :command {:title     "Extract function"
-                       :command   "extract-function"
-                       :arguments [uri line character "new-function"]}})
+             :kind    CodeActionKind/RefactorExtract
+             :data    {:id "refactor-extract-function"
+                       :uri uri
+                       :line line
+                       :character character}})
 
       workspace-edit-capability?
       (conj {:title   "Clean namespace"
-             :kind    :source-organize-imports
-             :command {:title     "Clean namespace"
-                       :command   "clean-ns"
-                       :arguments [uri line character]}}))))
+             :kind    CodeActionKind/SourceOrganizeImports
+             :data    {:id "clean-ns"
+                       :uri uri
+                       :line line
+                       :character character}})
+
+      (not resolve-support?)
+      #(map resolve-code-action %))))

--- a/src/clojure_lsp/feature/code_actions.clj
+++ b/src/clojure_lsp/feature/code_actions.clj
@@ -13,8 +13,8 @@
         inline-symbol? (r.transform/inline-symbol? def-uri definition)
         line (dec row)
         character (dec col)
-        has-unknown-ns? (some #(= (compare "unresolved-namespace" (some-> % .getCode .get)) 0) diagnostics)
-        unresolved-symbol (some #(= (compare "unresolved-symbol" (some-> % .getCode .get)) 0) diagnostics)
+        has-unknown-ns? (some #(= (compare "unresolved-namespace" (:code %)) 0) diagnostics)
+        unresolved-symbol (some #(= (compare "unresolved-symbol" (:code %)) 0) diagnostics)
         known-refer? (when unresolved-symbol
                        (get r.transform/common-refers->info (z/sexpr zloc)))
         missing-require (when (or has-unknown-ns? known-refer?)
@@ -26,7 +26,7 @@
                                                      :col col
                                                      :args {:source :code-action}}))
         missing-import (when unresolved-symbol
-                          (r.transform/add-common-import-to-namespace zloc))]
+                         (r.transform/add-common-import-to-namespace zloc))]
     (cond-> []
 
       (:result missing-require)

--- a/src/clojure_lsp/feature/code_actions.clj
+++ b/src/clojure_lsp/feature/code_actions.clj
@@ -4,8 +4,8 @@
     [clojure-lsp.feature.refactor :as f.refactor]
     [clojure-lsp.refactor.transform :as r.transform])
   (:import
-   (org.eclipse.lsp4j
-     CodeActionKind)))
+    (org.eclipse.lsp4j
+      CodeActionKind)))
 
 (defn resolve-code-action
   [{{:keys [id uri line character]} :data :as code-action}
@@ -23,6 +23,10 @@
                                                               :col         (inc character)
                                                               :args        {:source :code-action}})]
                {:workspace-edit (f.refactor/refactor-client-seq-changes uri 0 (:result missing-require))})
+
+             "add-missing-import"
+             (let [missing-import (r.transform/add-common-import-to-namespace zloc)]
+               {:workspace-edit (f.refactor/refactor-client-seq-changes uri 0 (:result missing-import))})
 
              "refactor-inline-symbol"
              {:command {:title     "Inline symbol"
@@ -48,7 +52,7 @@
 
 (defn all [zloc uri row col diagnostics client-capabilities]
   (let [workspace-edit-capability? (get-in client-capabilities [:workspace :workspace-edit])
-        resolve-support? (get-in client-capabilities [:text-document :code-action :resolve-support])
+        resolve-support?           (get-in client-capabilities [:text-document :code-action :resolve-support])
         inside-function?           (r.transform/inside-function? zloc)
         [_ {def-uri    :uri
             definition :usage}]    (f.definition/definition-usage uri row col)
@@ -60,54 +64,56 @@
         missing-require            (when (or has-unknown-ns? unresolved-symbol)
                                      (r.transform/find-missing-require zloc))
         missing-import             (when unresolved-symbol
-                                     (r.transform/add-common-import-to-namespace zloc))]
+                                     (r.transform/find-missing-import zloc))]
     (cond-> []
 
       missing-require
-      (conj {:title          (str "Add missing '" missing-require "' require")
-             :kind           CodeActionKind/QuickFix
-             :preferred?     true
-             :data           {:id "add-missing-require"
-                              :uri uri
-                              :line line
-                              :character character}})
+      (conj {:title      (str "Add missing '" missing-require "' require")
+             :kind       CodeActionKind/QuickFix
+             :preferred? true
+             :data       {:id        "add-missing-require"
+                          :uri       uri
+                          :line      line
+                          :character character}})
 
-      (:result missing-import)
-      (conj {:title          (str "Add missing '" (-> missing-import :code-action-data :import-name) "' import")
-             :kind           CodeActionKind/QuickFix
-             :preferred?     true
-             :data           {:id "add-missing-import"}
-             :workspace-edit (f.refactor/refactor-client-seq-changes uri 0 (:result missing-import))})
+      missing-import
+      (conj {:title      (str "Add missing '" missing-import "' import")
+             :kind       CodeActionKind/QuickFix
+             :preferred? true
+             :data       {:id        "add-missing-import"
+                          :uri       uri
+                          :line      line
+                          :character character}})
 
       inline-symbol?
-      (conj {:title   "Inline symbol"
-             :kind    CodeActionKind/RefactorInline
-             :data    {:id "refactor-inline-symbol"
-                       :uri uri
-                       :line line
-                       :character character}})
+      (conj {:title "Inline symbol"
+             :kind  CodeActionKind/RefactorInline
+             :data  {:id        "refactor-inline-symbol"
+                     :uri       uri
+                     :line      line
+                     :character character}})
 
       inside-function?
-      (conj {:title   "Cycle privacy"
-             :kind    CodeActionKind/RefactorRewrite
-             :data    {:id "refactor-cycle-privacy"
-                       :uri uri
-                       :line line
-                       :character character}}
-            {:title   "Extract function"
-             :kind    CodeActionKind/RefactorExtract
-             :data    {:id "refactor-extract-function"
-                       :uri uri
-                       :line line
-                       :character character}})
+      (conj {:title "Cycle privacy"
+             :kind  CodeActionKind/RefactorRewrite
+             :data  {:id        "refactor-cycle-privacy"
+                     :uri       uri
+                     :line      line
+                     :character character}}
+            {:title "Extract function"
+             :kind  CodeActionKind/RefactorExtract
+             :data  {:id        "refactor-extract-function"
+                     :uri       uri
+                     :line      line
+                     :character character}})
 
       workspace-edit-capability?
-      (conj {:title   "Clean namespace"
-             :kind    CodeActionKind/SourceOrganizeImports
-             :data    {:id "clean-ns"
-                       :uri uri
-                       :line line
-                       :character character}})
+      (conj {:title "Clean namespace"
+             :kind  CodeActionKind/SourceOrganizeImports
+             :data  {:id        "clean-ns"
+                     :uri       uri
+                     :line      line
+                     :character character}})
 
       (not resolve-support?)
       (->> (map #(resolve-code-action % zloc))))))

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -24,7 +24,8 @@
     [rewrite-clj.zip :as z]
     [trptcolin.versioneer.core :as version])
   (:import
-    [java.net URL JarURLConnection]))
+    [java.net URL
+              JarURLConnection]))
 
 (defn ^:private uri->namespace [uri]
   (let [project-root (:project-root @db/db)
@@ -339,16 +340,19 @@
                        (update :file-envs #(apply dissoc % uris)))))))
 
 (defn code-actions
-  [doc-id diagnostics line character]
+  [{:keys [range context textDocument]}]
   (let [db @db/db
-        row (inc (int line))
-        col (inc (int character))
+        diagnostics (-> context :diagnostics)
+        row (-> range :start :line inc)
+        col (-> range :start :character inc)
         zloc (-> db
-                 (get-in [:documents doc-id])
+                 (get-in [:documents textDocument])
                  :text
                  (parser/loc-at-pos row col))
         client-capabilities (get db :client-capabilities)]
-    (f.code-actions/all zloc doc-id row col diagnostics client-capabilities)))
+    (f.code-actions/all zloc textDocument row col diagnostics client-capabilities)))
+
+
 
 (defn code-lens
   [doc-id]

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -352,7 +352,9 @@
         client-capabilities (get db :client-capabilities)]
     (f.code-actions/all zloc textDocument row col diagnostics client-capabilities)))
 
-
+(defn resolve-code-action [action]
+  (log/info "->>" action)
+  (f.code-actions/resolve-code-action action))
 
 (defn code-lens
   [doc-id]

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -352,9 +352,12 @@
         client-capabilities (get db :client-capabilities)]
     (f.code-actions/all zloc textDocument row col diagnostics client-capabilities)))
 
-(defn resolve-code-action [action]
-  (log/info "->>" action)
-  (f.code-actions/resolve-code-action action))
+(defn resolve-code-action [{{:keys [uri line character]} :data :as action}]
+  (let [zloc (-> @db/db
+                 (get-in [:documents uri])
+                 :text
+                 (parser/loc-at-pos (inc line) (inc character)))]
+    (f.code-actions/resolve-code-action action zloc)))
 
 (defn code-lens
   [doc-id]

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -260,6 +260,17 @@
                      handlers/code-actions
                      (interop/conform-or-log ::interop/code-actions))))))))
 
+  (^CompletableFuture resolveCodeAction [_ ^CodeAction unresolved]
+    (go :resolveCodeAction
+        (CompletableFuture/supplyAsync
+          (reify Supplier
+            (get [_this]
+              (end
+                (->> unresolved
+                     j/from-java
+                     handlers/resolve-code-action
+                     (interop/conform-or-log ::interop/code-action))))))))
+
   (^CompletableFuture codeLens [_ ^CodeLensParams params]
     (go :codeLens
         (CompletableFuture/supplyAsync
@@ -458,7 +469,8 @@
                   (InitializeResult. (doto (ServerCapabilities.)
                                        (.setHoverProvider true)
                                        (.setCallHierarchyProvider true)
-                                       (.setCodeActionProvider true)
+                                       (.setCodeActionProvider (doto (CodeActionOptions. interop/code-action-kind)
+                                                                 (.setResolveProvider true)))
                                        (.setCodeLensProvider (CodeLensOptions. true))
                                        (.setReferencesProvider true)
                                        (.setRenameProvider true)

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -1,70 +1,73 @@
 (ns clojure-lsp.main
   (:require
-   [clojure-lsp.db :as db]
-   [clojure-lsp.feature.refactor :as f.refactor]
-   [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
-   [clojure-lsp.handlers :as handlers]
-   [clojure-lsp.interop :as interop]
-   [clojure-lsp.shared :as shared]
-   [clojure-lsp.window :as window]
-   [clojure.core.async :as async]
-   [clojure.tools.logging :as log]
-   [nrepl.server :as nrepl.server]
-   [trptcolin.versioneer.core :as version])
+    [clojure-lsp.db :as db]
+    [clojure-lsp.feature.refactor :as f.refactor]
+    [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
+    [clojure-lsp.handlers :as handlers]
+    [clojure-lsp.interop :as interop]
+    [clojure-lsp.shared :as shared]
+    [clojure-lsp.window :as window]
+    [clojure.core.async :as async]
+    [clojure.tools.logging :as log]
+    [nrepl.server :as nrepl.server]
+    [trptcolin.versioneer.core :as version]
+    [clojure.java.data :as j])
   (:import
-   (clojure_lsp ClojureExtensions)
-   (org.eclipse.lsp4j.services LanguageServer TextDocumentService WorkspaceService LanguageClient)
-   (org.eclipse.lsp4j
-     ApplyWorkspaceEditParams
-     CallHierarchyIncomingCallsParams
-     CallHierarchyPrepareParams
-     CodeActionParams
-     CodeLens
-     CodeLensParams
-     CodeLensOptions
-     CompletionItem
-     CompletionOptions
-     CompletionParams
-     DefinitionParams
-     DidChangeConfigurationParams
-     DidChangeTextDocumentParams
-     DidChangeWatchedFilesParams
-     DidChangeWatchedFilesRegistrationOptions
-     DidCloseTextDocumentParams
-     DidOpenTextDocumentParams
-     DidSaveTextDocumentParams
-     DocumentFormattingParams
-     DocumentHighlightParams
-     DocumentRangeFormattingParams
-     DocumentSymbolParams
-     ExecuteCommandOptions
-     ExecuteCommandParams
-     FileSystemWatcher
-     HoverParams
-     InitializeParams
-     InitializeResult
-     InitializedParams
-     ParameterInformation
-     ReferenceParams
-     Registration
-     RegistrationParams
-     RenameParams
-     SaveOptions
-     SemanticTokensLegend
-     SemanticTokensParams
-     SemanticTokensRangeParams
-     SemanticTokensWithRegistrationOptions
-     ServerCapabilities
-     SignatureHelp
-     SignatureHelpParams
-     SignatureInformation
-     TextDocumentContentChangeEvent
-     TextDocumentSyncKind
-     TextDocumentSyncOptions
-     WorkspaceSymbolParams)
-   (org.eclipse.lsp4j.launch LSPLauncher)
-   (java.util.concurrent CompletableFuture)
-   (java.util.function Supplier))
+    (clojure_lsp ClojureExtensions)
+    (org.eclipse.lsp4j.services LanguageServer TextDocumentService WorkspaceService LanguageClient)
+    (org.eclipse.lsp4j
+      ApplyWorkspaceEditParams
+      CallHierarchyIncomingCallsParams
+      CallHierarchyPrepareParams
+      CodeActionParams
+      CodeAction
+      CodeActionOptions
+      CodeLens
+      CodeLensParams
+      CodeLensOptions
+      CompletionItem
+      CompletionOptions
+      CompletionParams
+      DefinitionParams
+      DidChangeConfigurationParams
+      DidChangeTextDocumentParams
+      DidChangeWatchedFilesParams
+      DidChangeWatchedFilesRegistrationOptions
+      DidCloseTextDocumentParams
+      DidOpenTextDocumentParams
+      DidSaveTextDocumentParams
+      DocumentFormattingParams
+      DocumentHighlightParams
+      DocumentRangeFormattingParams
+      DocumentSymbolParams
+      ExecuteCommandOptions
+      ExecuteCommandParams
+      FileSystemWatcher
+      HoverParams
+      InitializeParams
+      InitializeResult
+      InitializedParams
+      ParameterInformation
+      ReferenceParams
+      Registration
+      RegistrationParams
+      RenameParams
+      SaveOptions
+      SemanticTokensLegend
+      SemanticTokensParams
+      SemanticTokensRangeParams
+      SemanticTokensWithRegistrationOptions
+      ServerCapabilities
+      SignatureHelp
+      SignatureHelpParams
+      SignatureInformation
+      TextDocumentContentChangeEvent
+      TextDocumentSyncKind
+      TextDocumentSyncOptions
+      WorkspaceSymbolParams)
+    (org.eclipse.lsp4j.launch LSPLauncher)
+    (java.util.concurrent CompletableFuture)
+    (java.util.function Supplier))
   (:gen-class))
 
 (defonce formatting (atom false))
@@ -234,11 +237,11 @@
                                  start (.getStart range)
                                  end (.getEnd range)]
                              (interop/conform-or-log ::interop/edits (#'handlers/range-formatting
-                                                                       doc-id
-                                                                       {:row (inc (.getLine start))
-                                                                        :col (inc (.getCharacter start))
-                                                                        :end-row (inc (.getLine end))
-                                                                        :end-col (inc (.getCharacter end))})))
+                                                                      doc-id
+                                                                      {:row (inc (.getLine start))
+                                                                       :col (inc (.getCharacter start))
+                                                                       :end-row (inc (.getLine end))
+                                                                       :end-col (inc (.getCharacter end))})))
                            (catch Exception e
                              (log/error e))
                            (finally
@@ -247,40 +250,35 @@
               result)))))
 
   (^CompletableFuture codeAction [_ ^CodeActionParams params]
-   (go :codeAction
-       (CompletableFuture/supplyAsync
-         (reify Supplier
-           (get [_this]
-             (end
-               (try
-                 (let [doc-id          (interop/document->decoded-uri (.getTextDocument params))
-                       diagnostics     (.getDiagnostics (.getContext params))
-                       start           (.getStart (.getRange params))
-                       start-line      (.getLine start)
-                       start-character (.getCharacter start)]
-                   (interop/conform-or-log ::interop/code-actions (#'handlers/code-actions doc-id diagnostics start-line start-character)))
-                 (catch Exception e
-                   (log/error e)))))))))
+    (go :codeAction
+        (CompletableFuture/supplyAsync
+          (reify Supplier
+            (get [_this]
+              (end
+                (->> params
+                     j/from-java
+                     handlers/code-actions
+                     (interop/conform-or-log ::interop/code-actions))))))))
 
   (^CompletableFuture codeLens [_ ^CodeLensParams params]
-   (go :codeLens
-       (CompletableFuture/supplyAsync
-         (reify Supplier
-           (get [_this]
-             (end
-               (let [doc-id (interop/document->decoded-uri (.getTextDocument params))]
-                 (interop/conform-or-log ::interop/code-lenses (#'handlers/code-lens doc-id)))))))))
+    (go :codeLens
+        (CompletableFuture/supplyAsync
+          (reify Supplier
+            (get [_this]
+              (end
+                (let [doc-id (interop/document->decoded-uri (.getTextDocument params))]
+                  (interop/conform-or-log ::interop/code-lenses (#'handlers/code-lens doc-id)))))))))
 
   (^CompletableFuture resolveCodeLens [_ ^CodeLens params]
-   (go :resolveCodeLens
-       (CompletableFuture/supplyAsync
-         (reify Supplier
-           (get [_this]
-             (end
-               (->> (.getData params)
-                    interop/json->clj
-                    (handlers/code-lens-resolve (-> params .getRange shared/range->clj))
-                    (interop/conform-or-log ::interop/code-lens))))))))
+    (go :resolveCodeLens
+        (CompletableFuture/supplyAsync
+          (reify Supplier
+            (get [_this]
+              (end
+                (->> (.getData params)
+                     interop/json->clj
+                     (handlers/code-lens-resolve (-> params .getRange shared/range->clj))
+                     (interop/conform-or-log ::interop/code-lens))))))))
 
   (^CompletableFuture definition [this ^DefinitionParams params]
     (go :definition

--- a/test/clojure_lsp/features/code_actions_test.clj
+++ b/test/clojure_lsp/features/code_actions_test.clj
@@ -1,0 +1,157 @@
+(ns clojure-lsp.features.code-actions-test
+  (:require
+    [clojure-lsp.db :as db]
+    [clojure-lsp.feature.code-actions :as f.code-actions]
+    [clojure-lsp.parser :as parser]
+    [clojure.string :as string]
+    [clojure.test :refer [deftest testing is]]))
+
+(defn zloc-at [file row col]
+  (-> @db/db
+      (get-in [:documents file])
+      :text
+      (parser/loc-at-pos row col)))
+
+(deftest test-code-actions-without-resolve-support
+  (let [references-code   (str "(ns some-ns)\n"
+                               "(def foo)")
+        b-code   (str "(ns other-ns (:require [some-ns :as sns]))\n"
+                      "(def bar 1)\n"
+                      "(defn baz []\n"
+                      "  bar)")
+        c-code   (str "(ns another-ns)\n"
+                      "(def bar ons/bar)\n"
+                      "(def foo sns/foo)\n"
+                      "(deftest some-test)\n"
+                      "MyClass.\n"
+                      "Date.")
+        db-state {:documents {"file://a.clj" {:text references-code}
+                              "file://b.clj" {:text b-code}
+                              "file://c.clj" {:text c-code}}
+                  :file-envs {"file://a.clj" (parser/find-usages references-code :clj {})
+                              "file://b.clj" (parser/find-usages b-code :clj {})
+                              "file://c.clj" (parser/find-usages c-code :clj {})}}]
+    (reset! db/db db-state)
+    (testing "Add missing namespace"
+      (testing "when it has not unresolved-namespace diagnostic"
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                      (f.code-actions/all (zloc-at "file://c.clj" 2 10)
+                                          "file://c.clj"
+                                          2
+                                          10
+                                          [] {}))))
+
+      (testing "when it has unresolved-namespace but cannot find namespace"
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                      (f.code-actions/all (zloc-at "file://c.clj" 2 11)
+                                          "file://c.clj"
+                                          2
+                                          11
+                                          [{:code "unresolved-namespace"}] {}))))
+
+      (testing "when it has unresolved-namespace and can find namespace"
+        (is (some #(= (:title %) "Add missing 'some-ns' require")
+                  (f.code-actions/all (zloc-at "file://c.clj" 3 11)
+                                      "file://c.clj"
+                                      3
+                                      11
+                                      [{:code "unresolved-namespace"}] {}))))
+      (testing "when it has unresolved-symbol and it's a known refer"
+        (is (some #(= (:title %) "Add missing 'clojure.test' require")
+                  (f.code-actions/all (zloc-at "file://c.clj" 4 2)
+                                      "file://c.clj"
+                                      4
+                                      2
+                                      [{:code "unresolved-namespace"}] {}))))
+      (testing "when it has unresolved-symbol but it's not a known refer"
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                      (f.code-actions/all (zloc-at "file://c.clj" 4 11)
+                                          "file://c.clj"
+                                          4
+                                          11
+                                          [{:code "unresolved-symbol"}] {})))))
+    (testing "Add common missing import"
+      (testing "when it has no unknown-symbol diagnostic"
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                      (f.code-actions/all (zloc-at "file://c.clj" 5 2)
+                                          "file://c.clj"
+                                          5
+                                          2
+                                          [] {}))))
+
+      (testing "when it has unknown-symbol but it's not a common import"
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                      (f.code-actions/all (zloc-at "file://c.clj" 5 2)
+                                          "file://c.clj"
+                                          5
+                                          2
+                                          [{:code "unresolved-symbol"}] {}))))
+      (testing "when it has unknown-symbol but it's not a common import"
+        (is (some #(= (:title %) "Add missing 'java.util.Date' import")
+                  (f.code-actions/all (zloc-at "file://c.clj" 6 2)
+                                      "file://c.clj"
+                                      6
+                                      2
+                                      [{:code "unresolved-symbol"}] {})))))
+    (testing "Inline symbol"
+      (testing "when in not a let/def symbol"
+        (is (not-any? #(= (:title %) "Inline symbol")
+                      (f.code-actions/all (zloc-at "file://b.clj" 4 8)
+                                          "file://b.clj"
+                                          4
+                                          8
+                                          [] {}))))
+      (testing "when in let/def symbol"
+        (is (some #(= (:title %) "Inline symbol")
+                  (f.code-actions/all (zloc-at "file://b.clj" 4 5)
+                                      "file://b.clj"
+                                      4
+                                      5
+                                      [] {})))))
+    (testing "Cycle privacy"
+      (testing "when non function location"
+        (is (not-any? #(= (:title %) "Cycle privacy")
+                      (f.code-actions/all (zloc-at "file://a.clj" 1 5)
+                                          "file://a.clj"
+                                          1
+                                          5
+                                          [] {}))))
+      (testing "when on function location"
+        (is (some #(= (:title %) "Cycle privacy")
+                  (f.code-actions/all (zloc-at "file://a.clj" 2 5)
+                                      "file://a.clj"
+                                      2
+                                      5
+                                      [] {})))))
+    (testing "Extract function"
+      (testing "when non function location"
+        (is (not-any? #(= (:title %) "Extract function")
+                      (f.code-actions/all (zloc-at "file://a.clj" 1 5)
+                                          "file://a.clj"
+                                          1
+                                          5
+                                          [] {}))))
+      (testing "when on function location"
+        (is (some #(= (:title %) "Extract function")
+                  (f.code-actions/all (zloc-at "file://a.clj" 2 5)
+                                      "file://a.clj"
+                                      2
+                                      5
+                                      [] {})))))
+    (testing "clean namespace"
+      (testing "without workspace edit client capability"
+        (is (not-any? #(= (:title %) "Clean namespace")
+                      (f.code-actions/all (zloc-at "file://b.clj" 2 2)
+                                          "file://b.clj"
+                                          2
+                                          2
+                                          [] {}))))
+
+      (testing "with workspace edit client capability"
+        (reset! db/db (assoc-in db-state [:client-capabilities :workspace :workspace-edit] true))
+        (is (some #(= (:title %) "Clean namespace")
+                  (f.code-actions/all (zloc-at "file://b.clj" 2 2)
+                                      "file://b.clj"
+                                      2
+                                      2
+                                      [] {:workspace {:workspace-edit true}})))))))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -446,82 +446,124 @@
       (testing "when it has not unresolved-namespace diagnostic"
         (reset! db/db db-state)
         (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                      (handlers/code-actions "file://c.clj" [] 1 9))))
+                      (handlers/code-actions
+                        {:textDocument "file://c.clj"
+                         :context {:diagnostics []}
+                         :range {:start {:line 1 :character 9}}}))))
 
       (testing "when it has unresolved-namespace but cannot find namespace"
         (reset! db/db db-state)
-        (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 1 10) (Position. 1 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unresolved-namespace")]
-          (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                        (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 1 10)))))
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                        (handlers/code-actions
+                          {:textDocument "file://c.clj"
+                           :context {:diagnostics [{:code "unresolved-namespace"}]}
+                           :range {:start {:line 1 :character 10}}}))))
 
       (testing "when it has unresolved-namespace and can find namespace"
         (reset! db/db db-state)
-        (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 2 10) (Position. 2 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unresolved-namespace")]
-          (is (some #(= (:title %) "Add missing 'some-ns' require")
-                    (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 2 10)))))
+        (is (some #(= (:title %) "Add missing 'some-ns' require")
+                    (handlers/code-actions
+                      {:textDocument "file://c.clj"
+                       :context {:diagnostics [{:code "unresolved-namespace"}]}
+                       :range {:start {:line 2 :character 10}}}))))
       (testing "when it has unresolved-symbol and it's a known refer"
         (reset! db/db db-state)
-        (let [unknown-symbol-diagnostic (Diagnostic. (Range. (Position. 3 1) (Position. 3 8)) "Unresolved symbol deftest" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
-          (is (some #(= (:title %) "Add missing 'clojure.test' require")
-                    (handlers/code-actions "file://c.clj" [unknown-symbol-diagnostic] 3 1)))))
+        (is (some #(= (:title %) "Add missing 'clojure.test' require")
+                  (handlers/code-actions
+                    {:textDocument "file://c.clj"
+                     :context {:diagnostics [{:code "unresolved-symbol"}]}
+                     :range {:start {:line 3 :character 1}}}))))
       (testing "when it has unresolved-symbol but it's not a known refer"
         (reset! db/db db-state)
-        (let [unknown-symbol-diagnostic (Diagnostic. (Range. (Position. 3 10) (Position. 3 18)) "Unresolved symbol some-test" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
-          (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                        (handlers/code-actions "file://c.clj" [unknown-symbol-diagnostic] 3 10))))))
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                        (handlers/code-actions
+                          {:textDocument "file://c.clj"
+                           :context {:diagnostics [{:code "unresolved-symbol"}]}
+                           :range {:start {:line 3 :character 10}}})))))
     (testing "Add common missing import"
       (testing "when it has no unknown-symbol diagnostic"
         (reset! db/db db-state)
         (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                      (handlers/code-actions "file://c.clj" [] 4 1))))
+                      (handlers/code-actions
+                        {:textDocument "file://c.clj"
+                         :context {:diagnostics []}
+                         :range {:start {:line 4 :character 1}}}))))
 
       (testing "when it has unknown-symbol but it's not a common import"
         (reset! db/db db-state)
-        (let [unresolved-symbol-diagnostic (Diagnostic. (Range. (Position. 4 1) (Position. 4 5)) "Unresolved symbol" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
-          (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                        (handlers/code-actions "file://c.clj" [unresolved-symbol-diagnostic] 4 1)))))
+        (is (not-any? #(string/starts-with? (:title %) "Add missing")
+                        (handlers/code-actions
+                          {:textDocument "file://c.clj"
+                           :context {:diagnostics [{:code "unresolved-symbol"}]}
+                           :range {:start {:line 4 :character 1}}}))))
       (testing "when it has unknown-symbol but it's not a common import"
         (reset! db/db db-state)
-        (let [unresolved-symbol-diagnostic (Diagnostic. (Range. (Position. 5 1) (Position. 5 5)) "Unresolved symbol" DiagnosticSeverity/Error "some source" "unresolved-symbol")]
-          (is (some #(= (:title %) "Add missing 'java.util.Date' import")
-                    (handlers/code-actions "file://c.clj" [unresolved-symbol-diagnostic] 5 1))))))
+        (is (some #(= (:title %) "Add missing 'java.util.Date' import")
+                    (handlers/code-actions
+                      {:textDocument "file://c.clj"
+                       :context {:diagnostics [{:code "unresolved-symbol"}]}
+                       :range {:start {:line 5 :character 1}}})))))
     (testing "Inline symbol"
       (testing "when in not a let/def symbol"
         (reset! db/db db-state)
         (is (not-any? #(= (:title %) "Inline symbol")
-                      (handlers/code-actions "file://b.clj" [] 3 7))))
+                      (handlers/code-actions
+                        {:textDocument "file://b.clj"
+                         :context {:diagnostics []}
+                         :range {:start {:line 3 :character 7}}}))))
       (testing "when in let/def symbol"
         (reset! db/db db-state)
         (is (some #(= (:title %) "Inline symbol")
-                  (handlers/code-actions "file://b.clj" [] 3 4)))))
+                  (handlers/code-actions
+                    {:textDocument "file://b.clj"
+                     :context {:diagnostics []}
+                     :range {:start {:line 3 :character 4}}})))))
     (testing "Cycle privacy"
       (testing "when non function location"
         (reset! db/db db-state)
         (is (not-any? #(= (:title %) "Cycle privacy")
-                      (handlers/code-actions "file://a.clj" [] 0 4))))
+                      (handlers/code-actions
+                        {:textDocument "file://a.clj"
+                         :context {:diagnostics []}
+                         :range {:start {:line 0 :character 4}}}))))
       (testing "when on function location"
         (reset! db/db db-state)
         (is (some #(= (:title %) "Cycle privacy")
-                  (handlers/code-actions "file://a.clj" [] 1 4)))))
+                  (handlers/code-actions
+                    {:textDocument "file://a.clj"
+                     :context {:diagnostics []}
+                     :range {:start {:line 1 :character 4}}})))))
     (testing "Extract function"
       (testing "when non function location"
         (reset! db/db db-state)
         (is (not-any? #(= (:title %) "Extract function")
-                      (handlers/code-actions "file://a.clj" [] 0 4))))
+                      (handlers/code-actions
+                        {:textDocument "file://a.clj"
+                         :context {:diagnostics []}
+                         :range {:start {:line 0 :character 4}}}))))
       (testing "when on function location"
         (reset! db/db db-state)
         (is (some #(= (:title %) "Extract function")
-                  (handlers/code-actions "file://a.clj" [] 1 4)))))
+                  (handlers/code-actions
+                    {:textDocument "file://a.clj"
+                     :context {:diagnostics []}
+                     :range {:start {:line 1 :character 4}}})))))
     (testing "clean namespace"
       (testing "without workspace edit client capability"
         (reset! db/db db-state)
         (is (not-any? #(= (:title %) "Clean namespace")
-                      (handlers/code-actions "file://b.clj" [] 1 1))))
+                      (handlers/code-actions
+                        {:textDocument "file://b.clj"
+                         :context {:diagnostics []}
+                         :range {:start {:line 1 :character 1}}}))))
 
       (testing "with workspace edit client capability"
         (reset! db/db (assoc-in db-state [:client-capabilities :workspace :workspace-edit] true))
         (is (some #(= (:title %) "Clean namespace")
-    (handlers/code-actions "file://b.clj" [] 1 1)))))))
+    (handlers/code-actions
+      {:textDocument "file://b.clj"
+       :context {:diagnostics []}
+       :range {:start {:line 1 :character 1}}})))))))
 
 (deftest test-code-lens
   (let [references-code (str "(ns some-ns)\n"

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -423,9 +423,9 @@
            :new-text "(a)"}]
          (handlers/range-formatting "file://a.clj" {:row 1 :col 1 :end-row 1 :end-col 4}))))
 
-(deftest test-code-actions
+(deftest test-code-actions-handle
   (let [references-code   (str "(ns some-ns)\n"
-                      "(def foo)")
+                               "(def foo)")
         b-code   (str "(ns other-ns (:require [some-ns :as sns]))\n"
                       "(def bar 1)\n"
                       "(defn baz []\n"
@@ -442,128 +442,28 @@
                   :file-envs {"file://a.clj" (parser/find-usages references-code :clj {})
                               "file://b.clj" (parser/find-usages b-code :clj {})
                               "file://c.clj" (parser/find-usages c-code :clj {})}}]
-    (testing "Add missing namespace"
-      (testing "when it has not unresolved-namespace diagnostic"
-        (reset! db/db db-state)
-        (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                      (handlers/code-actions
-                        {:textDocument "file://c.clj"
-                         :context {:diagnostics []}
-                         :range {:start {:line 1 :character 9}}}))))
-
-      (testing "when it has unresolved-namespace but cannot find namespace"
-        (reset! db/db db-state)
-        (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                        (handlers/code-actions
-                          {:textDocument "file://c.clj"
-                           :context {:diagnostics [{:code "unresolved-namespace"}]}
-                           :range {:start {:line 1 :character 10}}}))))
-
-      (testing "when it has unresolved-namespace and can find namespace"
-        (reset! db/db db-state)
-        (is (some #(= (:title %) "Add missing 'some-ns' require")
+    (testing "when it has unresolved-namespace and can find namespace"
+      (reset! db/db db-state)
+      (is (some #(= (:title %) "Add missing 'some-ns' require")
+                (handlers/code-actions
+                  {:textDocument "file://c.clj"
+                   :context {:diagnostics [{:code "unresolved-namespace"}]}
+                   :range {:start {:line 2 :character 10}}}))))
+    (testing "without workspace edit client capability"
+      (reset! db/db db-state)
+      (is (not-any? #(= (:title %) "Clean namespace")
                     (handlers/code-actions
-                      {:textDocument "file://c.clj"
-                       :context {:diagnostics [{:code "unresolved-namespace"}]}
-                       :range {:start {:line 2 :character 10}}}))))
-      (testing "when it has unresolved-symbol and it's a known refer"
-        (reset! db/db db-state)
-        (is (some #(= (:title %) "Add missing 'clojure.test' require")
-                  (handlers/code-actions
-                    {:textDocument "file://c.clj"
-                     :context {:diagnostics [{:code "unresolved-symbol"}]}
-                     :range {:start {:line 3 :character 1}}}))))
-      (testing "when it has unresolved-symbol but it's not a known refer"
-        (reset! db/db db-state)
-        (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                        (handlers/code-actions
-                          {:textDocument "file://c.clj"
-                           :context {:diagnostics [{:code "unresolved-symbol"}]}
-                           :range {:start {:line 3 :character 10}}})))))
-    (testing "Add common missing import"
-      (testing "when it has no unknown-symbol diagnostic"
-        (reset! db/db db-state)
-        (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                      (handlers/code-actions
-                        {:textDocument "file://c.clj"
-                         :context {:diagnostics []}
-                         :range {:start {:line 4 :character 1}}}))))
+                      {:textDocument "file://b.clj"
+                       :context {:diagnostics []}
+                       :range {:start {:line 1 :character 1}}}))))
 
-      (testing "when it has unknown-symbol but it's not a common import"
-        (reset! db/db db-state)
-        (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                        (handlers/code-actions
-                          {:textDocument "file://c.clj"
-                           :context {:diagnostics [{:code "unresolved-symbol"}]}
-                           :range {:start {:line 4 :character 1}}}))))
-      (testing "when it has unknown-symbol but it's not a common import"
-        (reset! db/db db-state)
-        (is (some #(= (:title %) "Add missing 'java.util.Date' import")
-                    (handlers/code-actions
-                      {:textDocument "file://c.clj"
-                       :context {:diagnostics [{:code "unresolved-symbol"}]}
-                       :range {:start {:line 5 :character 1}}})))))
-    (testing "Inline symbol"
-      (testing "when in not a let/def symbol"
-        (reset! db/db db-state)
-        (is (not-any? #(= (:title %) "Inline symbol")
-                      (handlers/code-actions
-                        {:textDocument "file://b.clj"
-                         :context {:diagnostics []}
-                         :range {:start {:line 3 :character 7}}}))))
-      (testing "when in let/def symbol"
-        (reset! db/db db-state)
-        (is (some #(= (:title %) "Inline symbol")
-                  (handlers/code-actions
-                    {:textDocument "file://b.clj"
-                     :context {:diagnostics []}
-                     :range {:start {:line 3 :character 4}}})))))
-    (testing "Cycle privacy"
-      (testing "when non function location"
-        (reset! db/db db-state)
-        (is (not-any? #(= (:title %) "Cycle privacy")
-                      (handlers/code-actions
-                        {:textDocument "file://a.clj"
-                         :context {:diagnostics []}
-                         :range {:start {:line 0 :character 4}}}))))
-      (testing "when on function location"
-        (reset! db/db db-state)
-        (is (some #(= (:title %) "Cycle privacy")
-                  (handlers/code-actions
-                    {:textDocument "file://a.clj"
-                     :context {:diagnostics []}
-                     :range {:start {:line 1 :character 4}}})))))
-    (testing "Extract function"
-      (testing "when non function location"
-        (reset! db/db db-state)
-        (is (not-any? #(= (:title %) "Extract function")
-                      (handlers/code-actions
-                        {:textDocument "file://a.clj"
-                         :context {:diagnostics []}
-                         :range {:start {:line 0 :character 4}}}))))
-      (testing "when on function location"
-        (reset! db/db db-state)
-        (is (some #(= (:title %) "Extract function")
-                  (handlers/code-actions
-                    {:textDocument "file://a.clj"
-                     :context {:diagnostics []}
-                     :range {:start {:line 1 :character 4}}})))))
-    (testing "clean namespace"
-      (testing "without workspace edit client capability"
-        (reset! db/db db-state)
-        (is (not-any? #(= (:title %) "Clean namespace")
-                      (handlers/code-actions
-                        {:textDocument "file://b.clj"
-                         :context {:diagnostics []}
-                         :range {:start {:line 1 :character 1}}}))))
-
-      (testing "with workspace edit client capability"
-        (reset! db/db (assoc-in db-state [:client-capabilities :workspace :workspace-edit] true))
-        (is (some #(= (:title %) "Clean namespace")
-    (handlers/code-actions
-      {:textDocument "file://b.clj"
-       :context {:diagnostics []}
-       :range {:start {:line 1 :character 1}}})))))))
+    (testing "with workspace edit client capability"
+      (reset! db/db (assoc-in db-state [:client-capabilities :workspace :workspace-edit] true))
+      (is (some #(= (:title %) "Clean namespace")
+                (handlers/code-actions
+                  {:textDocument "file://b.clj"
+                   :context {:diagnostics []}
+                   :range {:start {:line 1 :character 1}}}))))))
 
 (deftest test-code-lens
   (let [references-code (str "(ns some-ns)\n"


### PR DESCRIPTION
- WIth LSP 3.16 released, servers can add support for codeActions/resolve, which should improve server performance since we will only calculate the workspace-edits if client chooses to execute the code action. If client does not support resolve code action yet, we just resolve them on `textDocument/codeActions` as before.
-  Refactor code actions code
- Add support to j/from-java where we can now unwrap a java class -> clojure easily and more realiable