### PR TITLE
Fix hover range

### DIFF
--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -272,7 +272,7 @@
         definition (when element (q/find-definition analysis element))]
     (cond
       definition
-      {:range (shared/->range definition)
+      {:range (shared/->range element)
        :contents (f.hover/hover-documentation definition)}
 
       element


### PR DESCRIPTION
We should use the element at point range instead of the definition.

Fixes #273 

![image](https://user-images.githubusercontent.com/7820865/105773684-0c600900-5f43-11eb-8bce-2e3f53d1f0a1.png)
