### PR TITLE
include timestamp and PID in lsp logs

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -4,4 +4,4 @@ log4j.appender.FILE=org.apache.log4j.FileAppender
 # Set the name of the file
 log4j.appender.FILE.File=/tmp/clojure-lsp.out
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.FILE.layout.ConversionPattern=%-5p %c: %m%n
+log4j.appender.FILE.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss} %X{PID} %-5p %c %m%n


### PR DESCRIPTION
Since multiple clojure-lsp instance logs into the same `/tmp/clojure-lsp.out` file, it'll be helpful to distinguish what each lsp instance is doing by including the timestamp and PID in each log message.

Before:
```
DEBUG clojure-lsp.main: :codeAction 40 ([:codeAction #{18908224820185}])
```

After:
```
2021/01/26 11:19:30 88291 DEBUG clojure-lsp.main :codeAction 109 ()
```