### PR TITLE
clj-kondo batch analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix document-symbol after #261 - Fixes #276
+- Reduce memory usage on startup batch analyzing classpath via clj-kondo. - Fixes #268
 
 ## 2021.01.25-22.56.05
 

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -87,7 +87,7 @@
       locals
       (assoc-in [:config :output :analysis :locals] true))))
 
-(def clj-kondo-analysis-batch-size 100)
+(def clj-kondo-analysis-batch-size 50)
 
 (defn ^:private run-kondo-on-paths! [paths]
   (kondo/run! (kondo-args {:parallel true
@@ -148,7 +148,7 @@
 (defn ^:private analyze-paths [paths public-only?]
   (let [start-time (System/nanoTime)
         result (run-kondo-on-paths-batch! paths)
-        end-time (float (/ (- (System/nanoTime) start-time) 1000000))
+        end-time (float (/ (- (System/nanoTime) start-time) 1000000000))
         _ (log/info "Paths analyzed, took" end-time "secs. Caching for next startups...")
         kondo-analysis (cond-> (:analysis result)
                            public-only? (dissoc :namespace-usages :var-usages)

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -414,9 +414,10 @@
   (or (dot-nrepl-port-file)
       (embedded-nrepl-server)))
 
-(defn- inject-pid-for-log4j []
+(defn- inject-pid-for-log4j
   "Inject a PID context value so we can include it in log4j
   logs."
+  []
   (let [pid (-> (ManagementFactory/getRuntimeMXBean)
                 (.getName)
                 (string/split #"@")


### PR DESCRIPTION
Related to #268 and #229 

The idea is to partition clj-kondo calls to decrease memory consumption, this will increase server startup a little though (tested and the startup  time is increased by ~1%-3%).
We may think in a good default batch size (ATM 50), or make it optional via some flag.

Log output:
```
INFO  clojure-lsp.crawler: Analyzing 157 paths with clj-kondo with batch size of 4 ...
INFO  clojure-lsp.crawler: Analyzing 1/4 batch paths with clj-kondo...
INFO  clojure-lsp.crawler: Analyzing 2/4 batch paths with clj-kondo...
INFO  clojure-lsp.crawler: Analyzing 3/4 batch paths with clj-kondo...
INFO  clojure-lsp.crawler: Analyzing 4/4 batch paths with clj-kondo...
INFO  clojure-lsp.crawler: Paths analyzed, took 59.44 secs. Caching for next startups...
```

More details of the improvement here: https://github.com/clojure-lsp/clojure-lsp/issues/268#issuecomment-767518212