### PR TITLE
Remove ns from document-symbol, showing only functions/vars

### DIFF
--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -192,22 +192,14 @@
 
 (defn document-symbol [{:keys [textDocument]}]
   (let [filename (shared/uri->filename textDocument)
-        local-analysis (get-in @db/db [:analysis filename])
-        namespace-definition (q/find-first (comp #{:namespace-definitions} :bucket) local-analysis)]
-    [{:name (or (some-> namespace-definition :name name)
-                filename)
-      :kind (f.document-symbol/element->symbol-kind namespace-definition)
-      :range full-file-range
-      :selection-range (if namespace-definition
-                         (shared/->scope-range namespace-definition)
-                         full-file-range)
-      :children (->> local-analysis
-                     (filter (comp #{:var-definitions} :bucket))
-                     (mapv (fn [e]
-                             {:name            (-> e :name name)
-                              :kind            (f.document-symbol/element->symbol-kind e)
-                              :range           (shared/->scope-range e)
-                              :selection-range (shared/->range e)})))}]))
+        local-analysis (get-in @db/db [:analysis filename])]
+    (->> local-analysis
+         (filter (comp #{:var-definitions} :bucket))
+         (mapv (fn [e]
+                 {:name            (-> e :name name)
+                  :kind            (f.document-symbol/element->symbol-kind e)
+                  :range           (shared/->scope-range e)
+                  :selection-range (shared/->range e)})))))
 
 (defn document-highlight [{:keys [textDocument position]}]
   (let [line (-> position :line inc)

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -121,18 +121,14 @@
 (deftest document-symbol
   (h/load-code-and-locs "(ns a) (def bar ::bar) (def ^:m baz 1)")
   (h/assert-submaps
-    [{:name "a"
-      :kind :namespace
-      :range {:start {:line 0 :character 0} :end {:line 999999 :character 999999}}
-      :selection-range {:start {:line 0 :character 0} :end {:line 0 :character 5}}
-      :children [{:name "bar"
-                  :kind :variable
-                  :range {:start {:line 0 :character 7} :end {:line 0 :character 22}}
-                  :selection-range {:start {:line 0 :character 12} :end {:line 0 :character 15}}}
-                 {:name "baz"
-                  :kind :variable
-                  :range {:start {:line 0 :character 23} :end {:line 0 :character 38}}
-                  :selection-range {:start {:line 0 :character 32} :end {:line 0 :character 35}}}]}]
+    [{:name "bar"
+      :kind :variable
+      :range {:start {:line 0 :character 7} :end {:line 0 :character 22}}
+      :selection-range {:start {:line 0 :character 12} :end {:line 0 :character 15}}}
+     {:name "baz"
+      :kind :variable
+      :range {:start {:line 0 :character 23} :end {:line 0 :character 38}}
+      :selection-range {:start {:line 0 :character 32} :end {:line 0 :character 35}}}]
     (handlers/document-symbol {:textDocument "file:///a.clj"})))
 
 (deftest document-highlight


### PR DESCRIPTION
Showing the ns looks redundant and for some clients like Emacs, it's too much info, so this PR show only the functions/vars from that ns.