### PR TITLE
Support keywords analysis with clj-kondo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
         borkdude/dynaload {:mvn/version "0.2.2"}
         cljfmt/cljfmt {:mvn/version "0.7.0" :exclusions [rewrite-cljs/rewrite-cljs]}
         medley/medley {:mvn/version "1.3.0"}
-        clj-kondo/clj-kondo {:mvn/version "2021.01.21-20210126.140057-6"}}
+        clj-kondo/clj-kondo {:mvn/version "2021.01.21-20210203.204227-15"}}
  :paths ["resources" "src"]
  :aliases {:run {:main-opts ["-m" "clojure-lsp.main"]
                  :jvm-opts ["-Xmx2g" "-server"]}}}

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -83,7 +83,8 @@
       (update-in [:config] merge user-config)
 
       :always
-      (assoc-in [:config :output] {:analysis {:arglists true}
+      (assoc-in [:config :output] {:analysis {:arglists true
+                                              :keywords true}
                                    :canonical-paths true})
 
       locals
@@ -134,7 +135,7 @@
       (:alias element)
       (conj (set/rename-keys (assoc element :bucket :namespace-alias) {:alias-row :name-row :alias-col :name-col :alias-end-row :name-end-row :alias-end-col :name-end-col})))
 
-    (contains? #{:locals :local-usages} bucket)
+    (contains? #{:locals :local-usages :keywords} bucket)
     [(set/rename-keys element {:row :name-row :col :name-col :end-row :name-end-row :end-col :name-end-col})]
 
     :else

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -147,7 +147,7 @@
         element (entry->normalized-entries (assoc v :bucket bucket))
         :let [{:keys [name-row name-col name-end-row name-end-col] :as element} element
               valid? (and name-row name-col name-end-row name-end-col)
-              _ (when-not valid? (log/error "Cannot find position for:" (:name element) (pr-str element) (some-> (:name element) meta)))]
+              _ (when-not valid? (log/debug "Cannot find position for:" (:name element) (pr-str element) (some-> (:name element) meta)))]
         :when valid?]
     element))
 

--- a/src/clojure_lsp/feature/completion.clj
+++ b/src/clojure_lsp/feature/completion.clj
@@ -33,6 +33,9 @@
        :namespace-alias} bucket)
     :module
 
+    (#{:keywords} bucket)
+    :keyword
+
     (and (#{:var-definitions} bucket)
          fixed-arities)
     :function

--- a/src/clojure_lsp/feature/completion.clj
+++ b/src/clojure_lsp/feature/completion.clj
@@ -14,10 +14,25 @@
 (defn ^:private remove-keys [pred m]
   (apply dissoc m (filter pred (keys m))))
 
+(defn ^:private keyword-element->keyword-str [{:keys [name alias ns]}]
+  (let [kw (cond
+             alias
+             (keyword (str alias) (str name))
+
+             ns
+             (keyword (str ns) (str name))
+
+             :else
+             (keyword name))]
+    (if alias
+      (str ":" kw)
+      (str kw))))
+
 (defn ^:private matches-cursor? [cursor-value s]
   (when (and s
              cursor-value
-             (string/starts-with? s (name cursor-value)))
+             (or (string/starts-with? s (name cursor-value))
+                 (string/starts-with? s (str cursor-value))))
     s))
 
 (defn ^:private supports-cljs? [uri]
@@ -54,8 +69,10 @@
         detail (or (when arglist-strs (string/join " " arglist-strs))
                    (some-> ns name))
         definition? (#{:namespace-definitions :var-definitions} bucket)]
-    (-> {:label  (or (some-> alias name)
-                     (-> element :name name))}
+    (-> {:label  (if (= bucket :keywords)
+                   (keyword-element->keyword-str element)
+                   (or (some-> alias name)
+                       (-> element :name name)))}
         (cond-> detail (assoc :detail detail)
                 deprecated (assoc :tags [1])
                 kind (assoc :kind kind)
@@ -66,8 +83,8 @@
 (defn valid-element-completion-item?
   [matches-fn
    cursor-uri
-   {cursor-from :from cursor-bucket :bucket :as _cursor-element}
-   {:keys [bucket to ns filename lang name alias] :as _element}]
+   {cursor-from :from cursor-bucket :bucket :as cursor-element}
+   {:keys [bucket to ns filename lang name alias] :as element}]
   (let [supported-file-types #{:cljc (shared/uri->file-type cursor-uri)}]
     (cond
       (#{:var-usages :local-usages :namespace-usages} bucket)
@@ -88,6 +105,19 @@
       (and lang
            (not (supported-file-types lang)))
       false
+
+      (and (= bucket :keywords)
+           (= filename (:filename cursor-element))
+           (parser/same-range? cursor-element element)) ;; is the same keyword
+      false
+
+      (and (= bucket :keywords)
+           (or (matches-fn (keyword-element->keyword-str element))
+               (and ns
+                    (matches-fn (str ns)))
+               (and alias
+                    (matches-fn (str alias)))))
+      true
 
       (or (and name (matches-fn name))
           (and alias (matches-fn alias)))

--- a/src/clojure_lsp/feature/rename.clj
+++ b/src/clojure_lsp/feature/rename.clj
@@ -1,0 +1,137 @@
+(ns clojure-lsp.feature.rename
+  (:require
+    [clojure-lsp.shared :as shared]
+    [clojure-lsp.db :as db]
+    [clojure.string :as string]
+    [clojure-lsp.parser :as parser]
+    [clojure-lsp.queries :as q]
+    [clojure-lsp.feature.refactor :as f.refactor]
+    [clojure.set :as set]))
+
+(defn ^:private namespace->uri [namespace source-paths filename]
+  (let [file-type (shared/uri->file-type filename)]
+    (shared/filename->uri
+      (str (first (filter #(string/starts-with? filename %) source-paths))
+           "/"
+           (-> namespace
+               (string/replace "." "/")
+               (string/replace "-" "_"))
+           "."
+           (name file-type)))))
+
+(defn ^:private rename-keyword [replacement {:keys [ns alias filename] :as reference}]
+  (let [ref-doc-uri (shared/filename->uri filename)
+        version (get-in @db/db [:documents ref-doc-uri :v] 0)
+        text (cond
+
+               (and alias
+                    (string/starts-with? replacement "::"))
+               (str "::" alias "/" (subs replacement 2))
+
+               alias
+               (str "::" alias "/" replacement)
+
+               (and ns
+                    (string/includes? (str ns) ".")
+                    (string/starts-with? replacement "::"))
+               replacement
+
+               (and ns
+                    (string/includes? (str ns) "."))
+               (str "::" replacement)
+
+               ns
+               (str ":" ns "/" replacement)
+
+               :else
+               replacement)]
+
+    {:range (shared/->range reference)
+     :new-text text
+     :text-document {:version version :uri ref-doc-uri}}))
+
+(defn ^:private rename-alias [replacement reference]
+  (let [alias? (= :namespace-alias (:bucket reference))
+        keyword? (= :keywords (:bucket reference))
+        ref-doc-uri (shared/filename->uri (:filename reference))
+        [u-prefix _ u-name] (when-not alias?
+                              (parser/ident-split (:name reference)))
+        version (get-in @db/db [:documents ref-doc-uri :v] 0)]
+    (if keyword?
+      {:range (shared/->range reference)
+       :new-text (str "::" replacement "/" (:name reference))
+       :text-document {:version version :uri ref-doc-uri}}
+      {:range (shared/->range reference)
+       :new-text (if alias? replacement (str u-prefix replacement "/" u-name))
+       :text-document {:version version :uri ref-doc-uri}})))
+
+(defn ^:private rename-local
+  [replacement reference]
+  (let [name-start (- (:name-end-col reference) (count (name (:name reference))))
+        ref-doc-id (shared/filename->uri (:filename reference))
+        version (get-in @db/db [:documents ref-doc-id :v] 0)]
+    (if (string/starts-with? replacement ":")
+      {:range (shared/->range (assoc reference
+                                     :name-col name-start))
+       :new-text (subs replacement 1)
+       :text-document {:version version :uri ref-doc-id}}
+      {:range (shared/->range (assoc reference :name-col name-start))
+       :new-text replacement
+       :text-document {:version version :uri ref-doc-id}})))
+
+(defn ^:private rename-other
+  [replacement reference]
+  (let [name-start (- (:name-end-col reference) (count (name (:name reference))))
+        ref-doc-id (shared/filename->uri (:filename reference))
+        version (get-in @db/db [:documents ref-doc-id :v] 0)]
+    {:range (shared/->range (assoc reference :name-col name-start))
+     :new-text replacement
+     :text-document {:version version :uri ref-doc-id}}))
+
+(defn ^:private rename-changes
+  [definition references replacement]
+  (condp = (:bucket definition)
+
+    :namespace-alias
+    (mapv (partial rename-alias replacement) references)
+
+    :keywords
+    (mapv (partial rename-keyword replacement) references)
+
+    :locals
+    (mapv (partial rename-local replacement) references)
+
+    (mapv (partial rename-other replacement) references)))
+
+(defn ^:private can-rename?
+  [definition references source-paths]
+  (and (seq references)
+       (or (not (seq source-paths))
+         (some #(string/starts-with? (:filename definition) %) source-paths))))
+
+(defn rename
+  [uri new-name row col]
+  (let [filename (shared/uri->filename uri)
+        references (q/find-references-from-cursor (:analysis @db/db) filename row col true)
+        definition (first (filter (comp #{:locals :var-definitions :namespace-definitions :namespace-alias :keywords} :bucket) references))
+        source-paths (get-in @db/db [:settings :source-paths])]
+    (when (can-rename? definition references source-paths)
+      (let [replacement (string/replace new-name #".*/([^/]*)$" "$1")
+            changes (rename-changes definition references replacement)
+            doc-changes (->> changes
+                             (group-by :text-document)
+                             (remove (comp empty? val))
+                             (map (fn [[text-document edits]]
+                                    {:text-document text-document
+                                     :edits (mapv #(dissoc % :text-document) edits)})))]
+        (if (and (= (:bucket definition) :namespace-definitions)
+                 (get-in @db/db [:client-capabilities :workspace :workspace-edit :document-changes]))
+          (let [new-uri (namespace->uri replacement source-paths (:filename definition))]
+            (swap! db/db (fn [db] (-> db
+                                      (update :documents #(set/rename-keys % {filename (shared/uri->filename new-uri)}))
+                                      (update :analysis #(set/rename-keys % {filename (shared/uri->filename new-uri)})))))
+            (f.refactor/client-changes (concat doc-changes
+                                               [{:kind "rename"
+                                                 :old-uri uri
+                                                 :new-uri new-uri}])))
+          (f.refactor/client-changes doc-changes))))))

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -10,19 +10,19 @@
     [clojure-lsp.feature.document-symbol :as f.document-symbol]
     [clojure-lsp.feature.hover :as f.hover]
     [clojure-lsp.feature.refactor :as f.refactor]
+    [clojure-lsp.feature.rename :as f.rename]
     [clojure-lsp.feature.semantic-tokens :as f.semantic-tokens]
     [clojure-lsp.interop :as interop]
     [clojure-lsp.parser :as parser]
     [clojure-lsp.producer :as producer]
     [clojure-lsp.queries :as q]
-    [taoensso.timbre :as log]
     [clojure-lsp.shared :as shared]
     [clojure.core.async :as async]
     [clojure.pprint :as pprint]
-    [clojure.set :as set]
     [clojure.string :as string]
     [rewrite-clj.node :as n]
-    [rewrite-clj.zip :as z])
+    [rewrite-clj.zip :as z]
+    [taoensso.timbre :as log])
   (:import
    [java.net URL
              URLDecoder
@@ -46,17 +46,6 @@
                              (subs (inc (count source-path)))
                              (string/replace #"/" ".")
                              (string/replace #"_" "-")))))))))
-
-(defn ^:private namespace->uri [namespace source-paths filename]
-  (let [file-type (shared/uri->file-type filename)]
-    (shared/filename->uri
-      (str (first (filter #(string/starts-with? filename %) source-paths))
-           "/"
-           (-> namespace
-               (string/replace "." "/")
-               (string/replace "-" "_"))
-           "."
-           (name file-type)))))
 
 (defn did-open [{:keys [textDocument] :as params}]
   (let [uri (-> textDocument :uri URLDecoder/decode)
@@ -119,118 +108,9 @@
              :range (shared/->range reference)})
           (q/find-references-from-cursor (:analysis @db/db) (shared/uri->filename textDocument) row col (:includeDeclaration context)))))
 
-(defn ^:private rename-keyword [replacement {:keys [ns alias filename] :as reference}]
-  (let [ref-doc-uri (shared/filename->uri filename)
-        version (get-in @db/db [:documents ref-doc-uri :v] 0)
-        text (cond
-
-               (and alias
-                    (string/starts-with? replacement "::"))
-               (str "::" alias "/" (subs replacement 2))
-
-               alias
-               (str "::" alias "/" replacement)
-
-               (and ns
-                    (string/includes? (str ns) ".")
-                    (string/starts-with? replacement "::"))
-               replacement
-
-               (and ns
-                    (string/includes? (str ns) "."))
-               (str "::" replacement)
-
-               ns
-               (str ":" ns "/" replacement)
-
-               :else
-               replacement)]
-
-    {:range (shared/->range reference)
-     :new-text text
-     :text-document {:version version :uri ref-doc-uri}}))
-
-(defn ^:private rename-alias [replacement reference]
-  (let [alias? (= :namespace-alias (:bucket reference))
-        keyword? (= :keywords (:bucket reference))
-        ref-doc-uri (shared/filename->uri (:filename reference))
-        [u-prefix _ u-name] (when-not alias?
-                              (parser/ident-split (:name reference)))
-        version (get-in @db/db [:documents ref-doc-uri :v] 0)]
-    (if keyword?
-      {:range (shared/->range reference)
-       :new-text (str "::" replacement "/" (:name reference))
-       :text-document {:version version :uri ref-doc-uri}}
-      {:range (shared/->range reference)
-       :new-text (if alias? replacement (str u-prefix replacement "/" u-name))
-       :text-document {:version version :uri ref-doc-uri}})))
-
-(defn ^:private rename-local
-  [replacement reference]
-  (let [name-start (- (:name-end-col reference) (count (name (:name reference))))
-        ref-doc-id (shared/filename->uri (:filename reference))
-        version (get-in @db/db [:documents ref-doc-id :v] 0)]
-    (if (string/starts-with? replacement ":")
-      {:range (shared/->range (assoc reference
-                                     :name-col name-start))
-       :new-text (subs replacement 1)
-       :text-document {:version version :uri ref-doc-id}}
-      {:range (shared/->range (assoc reference :name-col name-start))
-       :new-text replacement
-       :text-document {:version version :uri ref-doc-id}})))
-
-(defn ^:private rename-other
-  [replacement reference]
-  (let [name-start (- (:name-end-col reference) (count (name (:name reference))))
-        ref-doc-id (shared/filename->uri (:filename reference))
-        version (get-in @db/db [:documents ref-doc-id :v] 0)]
-    {:range (shared/->range (assoc reference :name-col name-start))
-     :new-text replacement
-     :text-document {:version version :uri ref-doc-id}}))
-
-(defn ^:private rename-changes
-  [definition references replacement]
-  (condp = (:bucket definition)
-
-    :namespace-alias
-    (mapv (partial rename-alias replacement) references)
-
-    :keywords
-    (mapv (partial rename-keyword replacement) references)
-
-    :locals
-    (mapv (partial rename-local replacement) references)
-
-    (mapv (partial rename-other replacement) references)))
-
 (defn rename [{:keys [textDocument position newName]}]
-  (let [[row col] (shared/position->line-column position)
-        filename (shared/uri->filename textDocument)
-        references (q/find-references-from-cursor (:analysis @db/db) filename row col true)
-        definition (first (filter (comp #{:locals :var-definitions :namespace-definitions :namespace-alias :keywords} :bucket) references))
-        source-paths (get-in @db/db [:settings :source-paths])
-        can-rename? (or (not (seq source-paths))
-                        (some #(string/starts-with? (:filename definition) %) source-paths))]
-    (when (and (seq references) can-rename?)
-      (let [replacement (string/replace newName #".*/([^/]*)$" "$1")
-            changes (rename-changes definition references replacement)
-            doc-changes (->> changes
-                             (group-by :text-document)
-                             (remove (comp empty? val))
-                             (map (fn [[text-document edits]]
-                                    {:text-document text-document
-                                     :edits (mapv #(dissoc % :text-document) edits)})))]
-        (if (and (= (:bucket definition) :namespace-definitions)
-                 (get-in @db/db [:client-capabilities :workspace :workspace-edit :document-changes]))
-          (let [new-uri (namespace->uri replacement source-paths (:filename definition))]
-            (swap! db/db (fn [db] (-> db
-                                      (update :documents #(set/rename-keys % {filename (shared/uri->filename new-uri)}))
-                                      (update :analysis #(set/rename-keys % {filename (shared/uri->filename new-uri)})))))
-            (f.refactor/client-changes (concat doc-changes
-                                               [{:kind "rename"
-                                                 :old-uri textDocument
-                                                 :new-uri new-uri}])))
-          (f.refactor/client-changes doc-changes))))))
+  (let [[row col] (shared/position->line-column position)]
+    (f.rename/rename textDocument newName row col)))
 
 (defn definition [{:keys [textDocument position]}]
   (let [[line column] (shared/position->line-column position)]

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -33,6 +33,13 @@
            (if (= r row) (>= c col) true)
            (if (= er end-row) (< ec end-col) true))))
 
+(defn same-range? [{:keys [name-row name-col name-end-row name-end-col] :as a-pos}
+                   {r :name-row c :name-col er :name-end-row ec :name-end-col :as b-pos}]
+  (and (= r name-row)
+       (= er name-end-row)
+       (= c name-col)
+       (= ec name-end-col)))
+
 ;; From rewrite-cljs
 (defn find-forms
   "Find last node (if more than one node) that is in range of pos and


### PR DESCRIPTION
Fixes #288 
Probably should close https://github.com/clj-kondo/clj-kondo/issues/1129

* Add support for finding definition of namespaced keywords (searching for `s/def ::my-keyword 123` or via alias `::foo/bar` if foo is required)
* Add support for finding references of keywords
* Add support for cursor hover keywords showing references
* Add support for renaming keywords:
  * simple keywords on the ns: `:foo`
  * namespaced keywords on the ns: `:foo/bar`
  * current ns aliased namespaced keywords on the ns: `::foo`
  * aliased namespaced keywords: `::foo/bar` if `foo` is a valid alias required
  * when renaming a namespace alias, we now rename aliased namespaced keywords too
* Completion