### PR TITLE
Improve did-change performance

### DIFF
--- a/src/clojure_lsp/feature/file_management.clj
+++ b/src/clojure_lsp/feature/file_management.clj
@@ -75,22 +75,21 @@
 
 (defn did-change [uri text version]
   ;; Ensure we are only accepting newer changes
-  (async/go
-    (let [notify-references? (get-in @db/db [:settings :notify-references-on-file-change] false)]
-      (loop [state-db @db/db]
-        (when (> version (get-in state-db [:documents uri :v] -1))
-          (when-let [new-analysis (crawler/run-kondo-on-text! text uri)]
-            (let [filename (shared/uri->filename uri)
-                  old-analysis (get-in @db/db [:analysis filename])]
-              (if (compare-and-set! db/db state-db (-> state-db
-                                                       (assoc-in [:documents uri] {:v version :text text})
-                                                       (crawler/update-analysis uri (:analysis new-analysis))
-                                                       (crawler/update-findings uri (:findings new-analysis))))
-                (do
-                  (f.diagnostic/notify uri new-analysis)
-                  (when notify-references?
-                    (notify-references old-analysis (get-in @db/db [:analysis filename]))))
-                (recur @db/db)))))))))
+  (let [notify-references? (get-in @db/db [:settings :notify-references-on-file-change] false)]
+    (loop [state-db @db/db]
+      (when (> version (get-in state-db [:documents uri :v] -1))
+        (when-let [new-analysis (crawler/run-kondo-on-text! text uri)]
+          (let [filename (shared/uri->filename uri)
+                old-analysis (get-in @db/db [:analysis filename])]
+            (if (compare-and-set! db/db state-db (-> state-db
+                                                     (assoc-in [:documents uri] {:v version :text text})
+                                                     (crawler/update-analysis uri (:analysis new-analysis))
+                                                     (crawler/update-findings uri (:findings new-analysis))))
+              (do
+                (f.diagnostic/notify uri new-analysis)
+                (when notify-references?
+                  (notify-references old-analysis (get-in @db/db [:analysis filename]))))
+              (recur @db/db))))))))
 
 (defn force-get-document-text
   "Get document text from db, if document not found, tries to open the document"

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -45,7 +45,6 @@
       InitializeParams
       InitializeResult
       InitializedParams
-      ParameterInformation
       ReferenceParams
       Registration
       RegistrationParams
@@ -56,10 +55,8 @@
       SemanticTokensRangeParams
       SemanticTokensWithRegistrationOptions
       ServerCapabilities
-      SignatureHelp
       SignatureHelpOptions
       SignatureHelpParams
-      SignatureInformation
       TextDocumentContentChangeEvent
       TextDocumentSyncKind
       TextDocumentSyncOptions
@@ -115,13 +112,14 @@
 
   (^void didChange [_ ^DidChangeTextDocumentParams params]
     (go :didChange
-        (end
-         (let [textDocument (.getTextDocument params)
-               version (.getVersion textDocument)
-               changes (.getContentChanges params)
-               text (.getText ^TextDocumentContentChangeEvent (.get changes 0))
-               uri (interop/document->decoded-uri textDocument)]
-           (#'handlers/did-change uri text version)))))
+        (future
+          (let [textDocument (.getTextDocument params)
+                version (.getVersion textDocument)
+                changes (.getContentChanges params)
+                text (.getText ^TextDocumentContentChangeEvent (.get changes 0))
+                uri (interop/document->decoded-uri textDocument)]
+            (handlers/did-change uri text version)))
+        (CompletableFuture/completedFuture 0)))
 
   (^void didSave [_ ^DidSaveTextDocumentParams params]
     (go :didSave


### PR DESCRIPTION
- Add flag to disable/enable notify-references
- Disable notify-references by default for now, needs hammock time
- Make did-change completely async as we publish diagnostics later after scan