### PR TITLE
fix more windows path issue

### DIFF
--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -17,7 +17,7 @@
 (defn ^:private get-sqlite-db-file-path [project-root]
   (let [configured (some-> (get-in @db [:settings :sqlite-db-path])
                            io/file)
-        default (io/file (str project-root) ".lsp" "sqlite.db")
+        default (io/file ".lsp" "sqlite.db")
         file (or configured default)]
     (if (.isAbsolute file)
       (.getAbsolutePath file)

--- a/test/clojure_lsp/db_test.clj
+++ b/test/clojure_lsp/db_test.clj
@@ -4,7 +4,8 @@
    [clojure-lsp.test-helper :as h]
    [clojure.string :as s]
    [clojure.test :refer [deftest testing is]]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure-lsp.shared :as shared]))
 
 (h/reset-db-after-test)
 
@@ -22,7 +23,9 @@
       (is (= (-> expected io/file .getAbsolutePath)
              (#'db/get-sqlite-db-file-path project-path)))))
   (testing "when set to absolute path"
-    (let [settings-path "/db-dir/sqlite.db"]
+    (let [settings-path (if shared/windows-os?
+                          "D:/db-dir/sqlite.db"
+                          "/db-dir/sqlite.db")]
       (reset! db/db {:settings {:sqlite-db-path settings-path}})
       (is (= (-> settings-path io/file .getAbsolutePath)
              (#'db/get-sqlite-db-file-path project-path))))))


### PR DESCRIPTION
Windows consider path start with D: or C: as absolute path. 
This PR fix the tests.