### PR TITLE
update datalevin version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,7 @@
         borkdude/dynaload {:mvn/version "0.2.2"}
         cljfmt/cljfmt {:mvn/version "0.7.0" :exclusions [rewrite-cljs/rewrite-cljs]}
         medley/medley {:mvn/version "1.3.0"}
-        datalevin/datalevin {:mvn/version "0.3.17"}
+        datalevin/datalevin {:mvn/version "0.4.0"}
         clj-kondo/clj-kondo {:mvn/version "2021.02.14-20210218.170309-6"}}
  :paths ["resources" "src" "target/classes"]
  :aliases {:test {:extra-paths ["test"]}

--- a/graalvm/native-unix-compile.sh
+++ b/graalvm/native-unix-compile.sh
@@ -13,6 +13,11 @@ then
     CLOJURE_LSP_JAR=$(ls target/clojure-lsp-*-standalone.jar)
 fi
 
+cd graalvm/c/
+gcc -Wall -g -c dtlv.c -o dtlv.o
+ar rcs libdtlv.a dtlv.o
+cd ../../
+
 CLOJURE_LSP_XMX=${CLOJURE_LSP_XMX:-"-J-Xmx4g"}
 
 args=("-jar" "$CLOJURE_LSP_JAR"

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -23,18 +23,18 @@
       (.getAbsolutePath (io/file (str project-root) file)))))
 
 (defn make-db [project-root]
-  (l/open-lmdb (get-db-file-path project-root)))
+  (l/open-kv (get-db-file-path project-root)))
 
 (defn save-deps [project-root project-hash classpath analysis]
   (let [db (make-db project-root)]
     (l/open-dbi db table)
-    (l/transact db [[:del table :project-analysis]])
-    (l/transact db [[:put table :project-analysis {:version version
-                                                   :project-root (str project-root)
-                                                   :project-hash project-hash
-                                                   :classpath classpath
-                                                   :analysis analysis}]])
-    (l/close db)))
+    (l/transact-kv db [[:del table :project-analysis]])
+    (l/transact-kv db [[:put table :project-analysis {:version      version
+                                                      :project-root (str project-root)
+                                                      :project-hash project-hash
+                                                      :classpath    classpath
+                                                      :analysis     analysis}]])
+    (l/close-kv db)))
 
 (defn read-deps [project-root]
   (let [db (make-db project-root)]


### PR DESCRIPTION
Datalevin 0.4.x has some slight changes in function names. Updated. I have tested, with this version of Datalevin, clojure-lsp compiles to native just fine.  

For now, we are including the C code manually and compile it to libdtlv.a.  I will figure out how to include it in the jar instead in the future. 