### PR TITLE
Avoid diagnostic thread crash when some token has no row/col information

### DIFF
--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -87,12 +87,16 @@
   (string/replace uri project-root ""))
 
 (defn ->range [{:keys [name-row name-end-row name-col name-end-col row end-row col end-col] :as element}]
-  (when element
-    {:start {:line (max 0 (dec (or name-row row))) :character (max 0 (dec (or name-col col)))}
-     :end {:line (max 0 (dec (or name-end-row end-row))) :character (max 0 (dec (or name-end-col end-col)))}}))
+  (try
+    (when (and element (or name-row row))
+      {:start {:line (max 0 (dec (or name-row row))) :character (max 0 (dec (or name-col col)))}
+       :end {:line (max 0 (dec (or name-end-row end-row))) :character (max 0 (dec (or name-end-col end-col)))}})
+    (catch Exception e
+      (log/warn "error in ->range, element = " (pr-str element))
+      (throw e))))
 
 (defn ->scope-range [{:keys [name-row name-end-row name-col name-end-col row end-row col end-col] :as element}]
-  (when element
+  (when (and element (or row name-row))
     {:start {:line (max 0 (dec (or row name-row))) :character (max 0 (dec (or col name-col)))}
      :end {:line (max 0 (dec (or end-row name-end-row))) :character (max 0 (dec (or end-col name-end-col)))}}))
 


### PR DESCRIPTION
I have a macro that creates new bindings, and I'm writing a custom hook for it so clj-kondo could lint it correctly. Because the macro creates new bindings out of nowhere, the generated token nodes has no row/col information, which made the clojure-lsp diagnostic thread crash in the [`shared/->range`](https://github.com/clojure-lsp/clojure-lsp/blob/master/src/clojure_lsp/shared.clj#L89) function:

```
2021-03-03T07:13:38.979Z dev.local WARN [clojure-lsp.shared:95] - error in ->range, element =  {:end-row nil, :end-col nil, :type :unused-binding, :filename "foo.clj", :message "unused binding request", :row nil, :col nil, :level :warning}atch-8
                                              java.lang.Thread.run              Thread.java:  832
                                                               ...
clojure.core.async.impl.concurrent/counted-thread-factory/reify/fn           concurrent.clj:   29
                java.util.concurrent.ThreadPoolExecutor$Worker.run  ThreadPoolExecutor.java:  630
                 java.util.concurrent.ThreadPoolExecutor.runWorker  ThreadPoolExecutor.java: 1130
                                                               ...
             clojure.core.async.impl.channels.ManyToManyChannel/fn             channels.clj:  135
                       clojure.core.async.impl.ioc-macros/take!/fn           ioc_macros.clj:  991
      clojure.core.async.impl.ioc-macros/run-state-machine-wrapped           ioc_macros.clj:  982
              clojure.core.async.impl.ioc-macros/run-state-machine           ioc_macros.clj:  978
                     clojure-lsp.main/run/fn/state-machine--auto--                 main.clj:  396
                  clojure-lsp.main/run/fn/state-machine--auto--/fn                 main.clj:  396
               clojure-lsp.feature.file-management/analyze-changes      file_management.clj:  114
                            clojure-lsp.feature.diagnostics/notify          diagnostics.clj:   26
                                                 clojure.core/mapv                 core.clj: 6908
                                               clojure.core/reduce                 core.clj: 6833
                                       clojure.core.protocols/fn/G            protocols.clj:   13
                                         clojure.core.protocols/fn            protocols.clj:   75
                                 clojure.core.protocols/seq-reduce            protocols.clj:   31
                                       clojure.core.protocols/fn/G            protocols.clj:   19
                                         clojure.core.protocols/fn            protocols.clj:  136
                                                               ...
                                              clojure.core/mapv/fn                 core.clj: 6917
         clojure-lsp.feature.diagnostics/kondo-finding->diagnostic          diagnostics.clj:   12
                                        clojure-lsp.shared/->range               shared.clj:   92
                                                               ...
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "x" is null
```
