### PR TITLE
Fix for invalid analysis when cljs macros expanded

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -124,7 +124,7 @@
            (= 'let name)
            (= 'if name)
            (= 'new name))
-       (= 'clojure.core to)))
+       (#{'clojure.core 'cljs.core} to)))
 
 (defn ^:private valid-element? [{:keys [name-row name-col name-end-row name-end-col] :as _element}]
   (and name-row

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -395,7 +395,9 @@
         (producer/publish-diagnostic (<! debounced-diags))
         (recur))
       (go-loop []
-        (f.file-management/analyze-changes (<! debounced-changes))
+        (try
+          (f.file-management/analyze-changes (<! debounced-changes))
+          (catch Exception e (log/error e "in analyze go-loop")))
         (recur)))
     (.startListening launcher)))
 

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -397,7 +397,8 @@
       (go-loop []
         (try
           (f.file-management/analyze-changes (<! debounced-changes))
-          (catch Exception e (log/error e "in analyze go-loop")))
+          (catch Exception e
+            (log/error e "Error during analyzing buffer file changes")))
         (recur)))
     (.startListening launcher)))
 


### PR DESCRIPTION
It was causing all sorts of weird behaviour, including broken linting