### PR TITLE
Update installer version parsing

### DIFF
--- a/install-latest-clojure-lsp.sh
+++ b/install-latest-clojure-lsp.sh
@@ -39,7 +39,7 @@ CURL_CMD="curl -Ls"
 
 # Get version of an executable
 get_exec_version() {
-    $1 --version | awk '{print $NF}'
+    $1 --version | head -n 1 | awk '{ print $NF }'
 }
 
 # Get the latest Github release tag


### PR DESCRIPTION
A line was added to the ```--version``` output in https://github.com/clojure-lsp/clojure-lsp/commit/68ea1eb0f790502a74b80711d8e6280856defa5e which broke the installer script. 

This is a simple change to resolve the issue.