### PR TITLE
Workspace symbols fuzzy matching to be more intuitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve resolve-macro-as command to check and log if couldn't resolve the macro.
+- Improve workspace symbol filtering/searching. Now, the sole candidates shown are guaranteed to include all the characters contained in the filter/search string.
 
 ## 2021.04.13-12.47.33
 

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
         borkdude/dynaload {:mvn/version "0.2.2"}
         cljfmt/cljfmt {:mvn/version "0.7.0" :exclusions [rewrite-cljs/rewrite-cljs]}
         medley/medley {:mvn/version "1.3.0"}
-        clj-fuzzy/clj-fuzzy {:mvn/version "0.4.1"}
+        anonimitoraf/clj-flx {:mvn/version "1.1.0"}
         clj-kondo/clj-kondo {:mvn/version "2021.04.01-20210402.215253-6"}}
  :paths ["resources" "src"]
  :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.829"}}

--- a/src/clojure_lsp/feature/workspace_symbols.clj
+++ b/src/clojure_lsp/feature/workspace_symbols.clj
@@ -23,6 +23,27 @@
     elements
     (fuzzy-search query elements :name)))
 
+(defn ^:private group-by-ord
+  "Similar to `group-by` but returns a vector of the groups
+  without the keys.
+  Use this fn if the order of the groups needs to be preserved.
+  The order of groups depends on the order of their respective
+  first members."
+  [f coll]
+  (->> coll
+       (reduce (fn [groups curr]
+                 (let [group-key (f curr)
+                       group-idx (->> groups
+                                      (map-indexed (fn [idx g] {:idx idx :group g}))
+                                      (filter #(= group-key (-> % :group :key)))
+                                      first
+                                      :idx)]
+                   (if (nil? group-idx)
+                     (conj groups {:key group-key :members [curr]})
+                     (update-in groups [group-idx :members] conj curr))))
+               [])
+       (map :members)))
+
 (defn workspace-symbols [query]
   (->> (:analysis @db/db)
        q/filter-project-analysis
@@ -34,4 +55,7 @@
                {:name (-> element :name name)
                 :kind (f.document-symbol/element->symbol-kind element)
                 :location {:uri (shared/filename->uri (:filename element))
-                           :range (shared/->scope-range element)}}))))
+                           :range (shared/->scope-range element)}}))
+       (group-by-ord (comp :uri :location))
+       flatten
+       (into [])))

--- a/src/clojure_lsp/feature/workspace_symbols.clj
+++ b/src/clojure_lsp/feature/workspace_symbols.clj
@@ -1,19 +1,19 @@
 (ns clojure-lsp.feature.workspace-symbols
   (:require
-   [clj-fuzzy.metrics :as fuzzy]
-   [clojure-lsp.db :as db]
-   [clojure-lsp.feature.document-symbol :as f.document-symbol]
-   [clojure-lsp.queries :as q]
-   [clojure-lsp.shared :as shared]
-   [clojure.string :as string]
-   [taoensso.timbre :as log]))
+    [anonimitoraf.clj-flx :as flx]
+    [clojure-lsp.db :as db]
+    [clojure-lsp.feature.document-symbol :as f.document-symbol]
+    [clojure-lsp.queries :as q]
+    [clojure-lsp.shared :as shared]
+    [clojure.string :as string]
+    [taoensso.timbre :as log]))
 
 (defn ^:private fuzzy-search [^String query col get-against]
   (let [query (string/lower-case query)]
     (->> (for [doc col]
            {:data doc
-            :score (fuzzy/dice query (string/lower-case (name (get-against doc))))})
-         (filter #(< 0 (:score %)))
+            :score (flx/score query (string/lower-case (name (get-against doc))))})
+         (filter #(not (nil? (:score %))))
          (sort-by :score (comp - compare))
          (map :data))))
 

--- a/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -11,6 +11,9 @@
                                 "(defonce my-alpapapaca (atom {}))"
                                 "(def alpac 1)"
                                 "(defn alpacas [a b] alpac)"))
+  (h/load-code-and-locs (h/code "(ns foo.goat.ns (:require [foo.alpaca.ns :as a]))"
+                                "(defn goats-from-alpacas [alpacas] (map inc alpacas))")
+                        "file:///b.clj")
   (testing "querying all symbols"
     (is (= [{:name "foo.alpaca.ns"
              :kind :namespace
@@ -31,7 +34,15 @@
              :kind :function
              :location
              {:uri "file:///a.clj"
-              :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}]
+              :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}
+            {:kind :namespace,
+             :location {:range {:end {:character 15, :line 0}, :start {:character 0, :line 0}},
+                        :uri "file:///b.clj"},
+             :name "foo.goat.ns"}
+            {:kind :function,
+             :location {:range {:end {:character 53, :line 1}, :start {:character 0, :line 1}},
+                        :uri "file:///b.clj"},
+             :name "goats-from-alpacas"}]
            (f.workspace-symbols/workspace-symbols ""))))
   (testing "querying a specific function using fuzzy search"
     (is (= [{:name "foo.alpaca.ns"
@@ -48,5 +59,9 @@
              :kind :variable
              :location
              {:uri "file:///a.clj"
-              :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}]
+              :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}
+            {:kind :function,
+             :location {:range {:end {:character 53, :line 1}, :start {:character 0, :line 1}},
+                        :uri "file:///b.clj"},
+             :name "goats-from-alpacas"}]
            (f.workspace-symbols/workspace-symbols "alpaca")))))

--- a/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -1,54 +1,52 @@
 (ns clojure-lsp.features.workspace-symbols-test
   (:require
-   [clojure.test :refer [deftest testing]]
-   [clojure-lsp.test-helper :as h]
-   [clojure-lsp.feature.workspace-symbols :as f.workspace-symbols]))
+    [clojure.test :refer [deftest testing is]]
+    [clojure-lsp.test-helper :as h]
+    [clojure-lsp.feature.workspace-symbols :as f.workspace-symbols]))
 
 (h/reset-db-after-test)
 
 (deftest workspace-symbols
-  (h/load-code-and-locs (h/code "(ns foo.bar.ns (:require [clojure.string :as string]))"
-                                "(defonce my-atom (atom {}))"
-                                "(def bar 1)"
-                                "(defn baz [a b] bar)"))
+  (h/load-code-and-locs (h/code "(ns foo.alpaca.ns (:require [clojure.string :as string]))"
+                                "(defonce my-alpapapaca (atom {}))"
+                                "(def alpac 1)"
+                                "(defn alpacas [a b] alpac)"))
   (testing "querying all symbols"
-    (h/assert-submaps
-     [{:name "foo.bar.ns"
-       :kind :namespace
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 0 :character 0} :end {:line 0 :character 14}}}}
-      {:name "my-atom"
-       :kind :variable
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 1 :character 0} :end {:line 1 :character 27}}}}
-      {:name "bar"
-       :kind :variable
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 2 :character 0} :end {:line 2 :character 11}}}}
-      {:name "baz"
-       :kind :function
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 3 :character 0} :end {:line 3 :character 20}}}}]
-     (f.workspace-symbols/workspace-symbols "")))
+    (is (= [{:name "foo.alpaca.ns"
+             :kind :namespace
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 0 :character 0} :end {:line 0 :character 17}}}}
+            {:name "my-alpapapaca"
+             :kind :variable
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}
+            {:name "alpac"
+             :kind :variable
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 2 :character 0} :end {:line 2 :character 13}}}}
+            {:name "alpacas"
+             :kind :function
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}]
+           (f.workspace-symbols/workspace-symbols ""))))
   (testing "querying a specific function using fuzzy search"
-    (h/assert-submaps
-     [{:name "bar"
-       :kind :variable
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 2 :character 0} :end {:line 2 :character 11}}}}
-      {:name "baz"
-       :kind :function
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 3 :character 0} :end {:line 3 :character 20}}}}
-      {:name "foo.bar.ns"
-       :kind :namespace
-       :location
-       {:uri "file:///a.clj"
-        :range {:start {:line 0 :character 0} :end {:line 0 :character 14}}}}]
-     (f.workspace-symbols/workspace-symbols "ba"))))
+    (is (= [{:name "foo.alpaca.ns"
+             :kind :namespace
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 0 :character 0} :end {:line 0 :character 17}}}}
+            {:name "alpacas"
+             :kind :function
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}
+            {:name "my-alpapapaca"
+             :kind :variable
+             :location
+             {:uri "file:///a.clj"
+              :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}]
+           (f.workspace-symbols/workspace-symbols "alpaca")))))


### PR DESCRIPTION
* Replace clj-fuzzy's dice algorithm with clj-flx's for fuzzy-matching
workspace symbols
* Improve the workspace symbol's fuzzy matching unit tests to be
stricter and a bit more complex

---
Now, workspace symbol fuzzy-matching works similar to VSCode's intellisense, Emacs' ivy's fuzzy (I think there are a couple), Sublime text (apparently).

P.S Sorry about the indentation changes to the require statements.