### PR TITLE
Bump clj-flx with VERY significant performance improvements for workspace symbol filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Significantly improve the performance of workspace symbol filtering/searching. [See relevant commit](https://github.com/anonimitoraf/clj-flx/commit/61b2081b65b7d3be14851bac03ea508147c90054).
+
 ## 2021.04.23-15.49.47
 
 - Improve resolve-macro-as command to check and log if couldn't resolve the macro.

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
         borkdude/dynaload {:mvn/version "0.2.2"}
         cljfmt/cljfmt {:mvn/version "0.7.0" :exclusions [rewrite-cljs/rewrite-cljs]}
         medley/medley {:mvn/version "1.3.0"}
-        anonimitoraf/clj-flx {:mvn/version "1.1.0"}
+        anonimitoraf/clj-flx {:mvn/version "1.2.0"}
         clj-kondo/clj-kondo {:mvn/version "2021.04.23"}}
  :paths ["resources" "src"]
  :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.829"}}


### PR DESCRIPTION
I'm sorry I procrastinated benchmarking.
I found out that my initial implementation was very slow.

For example, calculating the score of candidate `quite a very long candidate string` against search string `quite a long string` would take 2000ms.

I've now fixed this. Now the same calculation takes only 3ms. (Almost 1000x faster). [Relevant commit](https://github.com/anonimitoraf/clj-flx/commit/61b2081b65b7d3be14851bac03ea508147c90054)

More info in https://github.com/anonimitoraf/clj-flx#benchmarks.

I've not changed any tests and they all still pass :D (both in clojure-lsp and clj-flx)