### PR TITLE
Render brew class with template. Add Linux support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,13 +419,19 @@ jobs:
         env:
           VERSION: ${{ steps.latest-tag.outputs.tag }}
         run: |
-          sha256=$(shasum -a 256 clojure-lsp-native-macos-amd64.zip/clojure-lsp-native-macos-amd64.zip | awk '{print $1}')
-          echo "::set-output name=sha256::$sha256"
+          macsha256=$(shasum -a 256 clojure-lsp-native-macos-amd64.zip/clojure-lsp-native-macos-amd64.zip | awk '{print $1}')
+          linuxsha256=$(shasum -a 256 clojure-lsp-mative-linux-amd64.zip/clojure-lsp-native-linux-amd64.zip | awk '{print $1}')
+          echo "::set-output name=macsha256::$macsha256"
+          echo "::set-output name=linuxsha256::$linuxsha256"
+
+      - name: Install Babashka
+        run: curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install | sudo bash
 
       - name: Bump Homebrew formula
         env:
           VERSION: ${{ steps.latest-tag.outputs.tag }}
-          SHA256: ${{ steps.sha256.outputs.sha256 }}
+          MAC_SHA256: ${{ steps.sha256.outputs.macsha256 }}
+          LINUX_SHA256: ${{ steps.sha256.outputs.linuxsha256 }}
         run: |
           git config --global user.name "Clojure LSP Bot"
           git config --global user.email "ercdll1337+clojure-lsp@gmail.com"
@@ -433,9 +439,7 @@ jobs:
           echo "${{ secrets.CLOJURE_LSP_BOT_BREW_COMMIT_TOKEN }}" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
           git clone git@github.com:clojure-lsp/homebrew-brew.git
           cd homebrew-brew
-          sed -i .rb 's/sha256 ".*"/sha256 "${{ env.SHA256 }}"/g' clojure-lsp-native.rb
-          sed -i .rb 's/[0-9]\{4\}.[0-9]\{2\}.[0-9]\{2\}-[0-9]\{2\}.[0-9]\{2\}.[0-9]\{2\}/${{ env.VERSION }}/g' clojure-lsp-native.rb
-          rm -f clojure-lsp-native.rb.rb
+          bb -o render.clj --version "${{ env.VERSION }}" --mac-sha "${{ env.MAC_SHA256 }}" --linux-sha "${{ env.LINUX_SHA256 }}" > clojure-lsp-native.rb
           cat clojure-lsp-native.rb
           git add .
           git commit -m "Bump to version: ${{ env.VERSION }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Significantly improve the performance of workspace symbol filtering/searching. [See relevant commit](https://github.com/anonimitoraf/clj-flx/commit/61b2081b65b7d3be14851bac03ea508147c90054).
 - Always sort refers when clean-ns.
+- Add support for installing with homebrew on Linux.
 - Bump clj-kondo to 2021.04.24-20210426.144134-2 adding support for finding re-frame by keyword. Fixes #411
 
 ## 2021.04.23-15.49.47

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ In Github releases you will find a `clojure-lsp` file that runs a embedded jar. 
 - Grab the latest `clojure-lsp` from github [LATEST](https://github.com/snoe/clojure-lsp/releases/latest)
 - Place it in your $PATH with a chmod 755
 
-## MacOS
+## Homebrew (MacOS and Linux)
 
 We have a custom tap using the native compiled binaries for users that use homebrew:
 


### PR DESCRIPTION
The main goal of this PR is to add Linux support to the homebrew tap.

The current sed implemenation doesn't allow you to template 2 different SHA files.

<strike>The action has been updated to run a small go program that renders the ruby class as a template, which is much more robust.
The mac-latest virtual environment includes a go runtime by default: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#language-and-runtime</strike>

The corresponding changes to the brew repo are done in this PR (which should be merged first): https://github.com/clojure-lsp/homebrew-brew/pull/2

edit: I rewrote the go script as a babashka script.