### PR TITLE
Fix typo in Linux shasum computation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,7 @@ jobs:
           VERSION: ${{ steps.latest-tag.outputs.tag }}
         run: |
           macsha256=$(shasum -a 256 clojure-lsp-native-macos-amd64.zip/clojure-lsp-native-macos-amd64.zip | awk '{print $1}')
-          linuxsha256=$(shasum -a 256 clojure-lsp-mative-linux-amd64.zip/clojure-lsp-native-linux-amd64.zip | awk '{print $1}')
+          linuxsha256=$(shasum -a 256 clojure-lsp-native-linux-amd64.zip/clojure-lsp-native-linux-amd64.zip | awk '{print $1}')
           echo "::set-output name=macsha256::$macsha256"
           echo "::set-output name=linuxsha256::$linuxsha256"
 


### PR DESCRIPTION
The typo caused the Linux shasum to be empty in the generated Homebrew spec.

I've made https://github.com/clojure-lsp/homebrew-brew/pull/3 to fix the Homebrew spec for this release.
This PR should ensure everything works in the next one.

For context, here's the log where it failed

![Screenshot from 2021-04-28 10-48-07](https://user-images.githubusercontent.com/6305221/116375205-580aa300-a80f-11eb-94e7-4aa9193ba5a5.png)
