### PR TITLE
Process most of async client request after processing changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Include non full qualified vars on unused-public-var exclude filter.
 - Improve hover documentation: use correct markdown for docstrings; remove unnecessary new lines; add link to filename location.
+- Rollback full text changes on last release and change approach for a temporary fix. #424
 
 ## 2021.05.06-19.44.00
 

--- a/src/clojure_lsp/feature/semantic_tokens.clj
+++ b/src/clojure_lsp/feature/semantic_tokens.clj
@@ -1,7 +1,8 @@
 (ns clojure-lsp.feature.semantic-tokens
   (:require
    [clojure-lsp.db :as db]
-   [clojure-lsp.shared :as shared])
+   [clojure-lsp.shared :as shared]
+   [taoensso.timbre :as log])
   (:import
    [clojure.lang PersistentVector]))
 


### PR DESCRIPTION
didChange LSP method is a critical piece of the server, it should process the changes of the client buffer along with process new diagnostics/analysis for other requests use updated analysis.

There was a issue introduced with async didChange processing some time ago where since we started to handling didChange completely async, some client requests done while the didChange was not totally complete were using outdated analysis of code, like semantic tokens, code lenses, document highlight.

So I introduced on 857bdc186e5585771c3b50b2c444065fb2b2e018 the sync didChange and fixed the out of sync for those features, but that made the didChange request wait for clj-kondo analysis which may take a while for large buffers (~28s on clojure.core buffer, ~7000 lines).

This PR rollback to handle async the code processing but adds a new `:processing-changes` to the db, and make features that highly rely on updated analysis like semantic-tokens, code lenses, document highlight to await the changes processing to then process those features.

This was the best approach I found and it worked very well even on clojure.core buffers, making didChange async/quickly and safely processing features with updated content (async as they were already).