### PR TITLE
Fix uri->filename not fully decoding URI

### DIFF
--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -77,7 +77,7 @@
          jar-file
          ":"
          nested-file)
-    (str (string/replace uri #"^[a-z]+://" ""))))
+    (.getPath (URI. uri))))
 
 (defn filename->uri [^String filename]
   (let [jar-scheme? (= "jar" (get-in @db/db [:settings :dependency-scheme]))]

--- a/test/clojure_lsp/features/code_actions_test.clj
+++ b/test/clojure_lsp/features/code_actions_test.clj
@@ -42,23 +42,23 @@
                                     :range {:start {:line 2 :character 3}}}] {}))))
   (testing "already used alias, we add one more suggestion"
     (let [result (f.code-actions/all (zloc-at "file:///a.clj" 4 4)
-                                       "file:///a.clj"
-                                       4
-                                       4
-                                       [{:code "unresolved-namespace"
-                                         :range {:start {:line 3 :character 3}}}] {})]
+                                     "file:///a.clj"
+                                     4
+                                     4
+                                     [{:code "unresolved-namespace"
+                                       :range {:start {:line 3 :character 3}}}] {})]
       (is (some #(= (:title %) "Add require 'clojure.data.json' as 'json'") result))
       (is (some #(= (:title %) "Add require 'clojure.data.json' as 'data.json'") result)))))
 
 (deftest add-missing-namespace-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file://a.clj")
+                        "file:///a.clj")
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file://b.clj")
+                        "file:///b.clj")
   (h/load-code-and-locs (str "(ns another-ns)\n"
                              "(def bar ons/bar)\n"
                              "(def foo sns/foo)\n"
@@ -66,42 +66,42 @@
                              "MyClass.\n"
                              "Date.\n"
                              "Date/parse")
-                        "file://c.clj")
+                        "file:///c.clj")
   (testing "when it has not unresolved-namespace diagnostic"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file://c.clj" 2 10)
-                                      "file://c.clj"
+                  (f.code-actions/all (zloc-at "file:///c.clj" 2 10)
+                                      "file:///c.clj"
                                       2
                                       10
                                       [] {}))))
   (testing "when it has unresolved-namespace and can find namespace"
     (is (some #(= (:title %) "Add missing 'some-ns' require")
-              (f.code-actions/all (zloc-at "file://c.clj" 3 11)
-                                  "file://c.clj"
+              (f.code-actions/all (zloc-at "file:///c.clj" 3 11)
+                                  "file:///c.clj"
                                   3
                                   11
                                   [{:code "unresolved-namespace"
                                     :range {:start {:line 2 :character 10}}}] {}))))
   (testing "when it has unresolved-namespace but cannot find namespace"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file://c.clj" 2 11)
-                                      "file://c.clj"
+                  (f.code-actions/all (zloc-at "file:///c.clj" 2 11)
+                                      "file:///c.clj"
                                       2
                                       11
                                       [{:code "unresolved-namespace"
                                         :range {:start {:line 1 :character 10}}}] {}))))
   (testing "when it has unresolved-symbol and it's a known refer"
     (is (some #(= (:title %) "Add missing 'clojure.test' require")
-              (f.code-actions/all (zloc-at "file://c.clj" 4 2)
-                                  "file://c.clj"
+              (f.code-actions/all (zloc-at "file:///c.clj" 4 2)
+                                  "file:///c.clj"
                                   4
                                   2
                                   [{:code "unresolved-namespace"
                                     :range {:start {:line 3 :character 1}}}] {}))))
   (testing "when it has unresolved-symbol but it's not a known refer"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file://c.clj" 4 11)
-                                      "file://c.clj"
+                  (f.code-actions/all (zloc-at "file:///c.clj" 4 11)
+                                      "file:///c.clj"
                                       4
                                       11
                                       [{:code "unresolved-symbol"
@@ -116,19 +116,19 @@
                              "MyClass.\n"
                              "Date.\n"
                              "Date/parse")
-                        "file://c.clj")
+                        "file:///c.clj")
   (testing "when it has no unresolved-symbol diagnostic"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file://c.clj" 5 2)
-                                      "file://c.clj"
+                  (f.code-actions/all (zloc-at "file:///c.clj" 5 2)
+                                      "file:///c.clj"
                                       5
                                       2
                                       [] {}))))
 
   (testing "when it has unresolved-symbol but it's not a common import"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file://c.clj" 5 2)
-                                      "file://c.clj"
+                  (f.code-actions/all (zloc-at "file:///c.clj" 5 2)
+                                      "file:///c.clj"
                                       5
                                       2
                                       [{:code "unresolved-symbol"
@@ -136,8 +136,8 @@
                                         :range {:start {:line 4 :character 2}}}] {}))))
   (testing "when it has unresolved-symbol and it's a common import"
     (is (some #(= (:title %) "Add missing 'java.util.Date' import")
-              (f.code-actions/all (zloc-at "file://c.clj" 6 2)
-                                  "file://c.clj"
+              (f.code-actions/all (zloc-at "file:///c.clj" 6 2)
+                                  "file:///c.clj"
                                   6
                                   2
                                   [{:code "unresolved-symbol"
@@ -145,8 +145,8 @@
                                     :range {:start {:line 5 :character 2}}}] {}))))
   (testing "when it has unresolved-namespace and it's a common import via method"
     (is (some #(= (:title %) "Add missing 'java.util.Date' import")
-              (f.code-actions/all (zloc-at "file://c.clj" 7 2)
-                                  "file://c.clj"
+              (f.code-actions/all (zloc-at "file:///c.clj" 7 2)
+                                  "file:///c.clj"
                                   7
                                   2
                                   [{:code "unresolved-namespace"
@@ -182,7 +182,7 @@
                         "file:///b.clj")
   (testing "when in not a coll"
     (is (not-any? #(= (:title %) "Change coll to")
-                  (f.code-actions/all (zloc-at "file://b.clj" 1 1)
+                  (f.code-actions/all (zloc-at "file:///b.clj" 1 1)
                                       "file:///b.clj"
                                       1
                                       1
@@ -224,18 +224,18 @@
 (deftest cycle-privacy-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file://a.clj")
+                        "file:///a.clj")
   (testing "when non function location"
     (is (not-any? #(= (:title %) "Cycle privacy")
-                  (f.code-actions/all (zloc-at "file://a.clj" 1 5)
-                                      "file://a.clj"
+                  (f.code-actions/all (zloc-at "file:///a.clj" 1 5)
+                                      "file:///a.clj"
                                       1
                                       5
                                       [] {}))))
   (testing "when on function location"
     (is (some #(= (:title %) "Cycle privacy")
-              (f.code-actions/all (zloc-at "file://a.clj" 2 5)
-                                  "file://a.clj"
+              (f.code-actions/all (zloc-at "file:///a.clj" 2 5)
+                                  "file:///a.clj"
                                   2
                                   5
                                   [] {})))))
@@ -243,18 +243,18 @@
 (deftest extract-function-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file://a.clj")
+                        "file:///a.clj")
   (testing "when non function location"
     (is (not-any? #(= (:title %) "Extract function")
-                  (f.code-actions/all (zloc-at "file://a.clj" 1 5)
-                                      "file://a.clj"
+                  (f.code-actions/all (zloc-at "file:///a.clj" 1 5)
+                                      "file:///a.clj"
                                       1
                                       5
                                       [] {}))))
   (testing "when on function location"
     (is (some #(= (:title %) "Extract function")
-              (f.code-actions/all (zloc-at "file://a.clj" 2 5)
-                                  "file://a.clj"
+              (f.code-actions/all (zloc-at "file:///a.clj" 2 5)
+                                  "file:///a.clj"
                                   2
                                   5
                                   [] {})))))
@@ -313,12 +313,12 @@
 (deftest clean-ns-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file://a.clj")
+                        "file:///a.clj")
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file://b.clj")
+                        "file:///b.clj")
   (h/load-code-and-locs (str "(ns another-ns)\n"
                              "(def bar ons/bar)\n"
                              "(def foo sns/foo)\n"
@@ -326,11 +326,11 @@
                              "MyClass.\n"
                              "Date.\n"
                              "Date/parse")
-                        "file://c.clj")
+                        "file:///c.clj")
   (testing "without workspace edit client capability"
     (is (not-any? #(= (:title %) "Clean namespace")
-                  (f.code-actions/all (zloc-at "file://b.clj" 2 2)
-                                      "file://b.clj"
+                  (f.code-actions/all (zloc-at "file:///b.clj" 2 2)
+                                      "file:///b.clj"
                                       2
                                       2
                                       [] {}))))
@@ -338,8 +338,8 @@
   (testing "with workspace edit client capability"
     (swap! db/db assoc-in [:client-capabilities :workspace :workspace-edit] true)
     (is (some #(= (:title %) "Clean namespace")
-              (f.code-actions/all (zloc-at "file://b.clj" 2 2)
-                                  "file://b.clj"
+              (f.code-actions/all (zloc-at "file:///b.clj" 2 2)
+                                  "file:///b.clj"
                                   2
                                   2
                                   [] {:workspace {:workspace-edit true}})))))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -301,43 +301,43 @@
             (map :message usages))))))
 
 (deftest test-formatting
-  (reset! db/db {:documents {"file://a.clj" {:text "(a  )\n(b c d)"}}})
+  (reset! db/db {:documents {"file:///a.clj" {:text "(a  )\n(b c d)"}}})
   (is (= "(a)\n(b c d)"
-         (:new-text (first (handlers/formatting {:textDocument "file://a.clj"}))))))
+         (:new-text (first (handlers/formatting {:textDocument "file:///a.clj"}))))))
 
 (deftest test-formatting-noop
-  (reset! db/db {:documents {"file://a.clj" {:text "(a)\n(b c d)"}}})
-  (let [r (handlers/formatting {:textDocument "file://a.clj"})]
+  (reset! db/db {:documents {"file:///a.clj" {:text "(a)\n(b c d)"}}})
+  (let [r (handlers/formatting {:textDocument "file:///a.clj"})]
     (is (empty? r))
     (is (vector? r))))
 
 (deftest test-range-formatting
-  (reset! db/db {:documents {"file://a.clj" {:text "(a  )\n(b c d)"}}})
+  (reset! db/db {:documents {"file:///a.clj" {:text "(a  )\n(b c d)"}}})
   (is (= [{:range {:start {:line 0 :character 0}
                    :end {:line 0 :character 5}}
            :new-text "(a)"}]
-         (handlers/range-formatting "file://a.clj" {:row 1 :col 1 :end-row 1 :end-col 4}))))
+         (handlers/range-formatting "file:///a.clj" {:row 1 :col 1 :end-row 1 :end-col 4}))))
 
 (deftest test-code-actions-handle
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file://a.clj")
+                        "file:///a.clj")
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file://b.clj")
+                        "file:///b.clj")
   (h/load-code-and-locs (str "(ns another-ns)\n"
                              "(def bar ons/bar)\n"
                              "(def foo sns/foo)\n"
                              "(deftest some-test)\n"
                              "MyClass.\n"
                              "Date.")
-                        "file://c.clj")
+                        "file:///c.clj")
   (testing "when it has unresolved-namespace and can find namespace"
     (is (some #(= (:title %) "Add missing 'some-ns' require")
               (handlers/code-actions
-                {:textDocument "file://c.clj"
+                {:textDocument "file:///c.clj"
                  :context {:diagnostics [{:code "unresolved-namespace"
                                           :range {:start {:line 2 :character 10}}}]}
                  :range {:start {:line 2 :character 10}}}))))
@@ -345,14 +345,14 @@
     (swap! db/db merge {:client-capabilities {:workspace {:workspace-edit false}}})
     (is (not-any? #(= (:title %) "Clean namespace")
                   (handlers/code-actions
-                    {:textDocument "file://b.clj"
+                    {:textDocument "file:///b.clj"
                      :context {:diagnostics []}
                      :range {:start {:line 1 :character 1}}}))))
   (testing "with workspace edit client capability"
     (swap! db/db merge {:client-capabilities {:workspace {:workspace-edit true}}})
     (is (some #(= (:title %) "Clean namespace")
               (handlers/code-actions
-                {:textDocument "file://b.clj"
+                {:textDocument "file:///b.clj"
                  :context {:diagnostics []}
                  :range {:start {:line 1 :character 1}}})))))
 

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -27,7 +27,7 @@
 
 (deftest add-missing-libspec
   (testing "aliases"
-     (testing "known namespaces in project"
+    (testing "known namespaces in project"
       (h/load-code-and-locs "(ns a (:require [foo.s :as s]))")
       (let [zloc (-> (z/of-string "(ns foo) s/thing") z/rightmost)
             [{:keys [loc range]}] (transform/add-missing-libspec zloc)]
@@ -278,7 +278,7 @@
                          ""
                          "(defn func []"
                          "  (f/some))")]
-      (test-clean-ns {:documents {"file://a.clj" {:text to-clean}}}
+      (test-clean-ns {:documents {"file:///a.clj" {:text to-clean}}}
                      to-clean
                      (code "(ns foo.bar"
                            " (:require"
@@ -320,46 +320,46 @@
                          "  b/some"
                          "  (some))")))
   (testing "unused refer from multiple refers"
-      (test-clean-ns {}
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [bar :refer [some other] ]))"
-                           "(some)")
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [bar :refer [some] ]))"
-                           "(some)")))
+    (test-clean-ns {}
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [bar :refer [some other] ]))"
+                         "(some)")
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [bar :refer [some] ]))"
+                         "(some)")))
   (testing "unused middle refer from multiple refers"
-      (test-clean-ns {}
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [bar :refer [some other baz another] ]))"
-                           "(some)"
-                           "(another)"
-                           "(baz)")
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [bar :refer [another baz some] ]))"
-                           "(some)"
-                           "(another)"
-                           "(baz)")))
+    (test-clean-ns {}
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [bar :refer [some other baz another] ]))"
+                         "(some)"
+                         "(another)"
+                         "(baz)")
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [bar :refer [another baz some] ]))"
+                         "(some)"
+                         "(another)"
+                         "(baz)")))
   (testing "unused refer and alias"
-      (test-clean-ns {}
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [bar :refer [some] ]"
-                           "   [baz :as b]))")
-                     (code "(ns foo.bar)")))
+    (test-clean-ns {}
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [bar :refer [some] ]"
+                         "   [baz :as b]))")
+                   (code "(ns foo.bar)")))
   (testing "unsorted used refer"
-      (test-clean-ns {}
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [some :refer [foo bar baz]]))"
-                           "   foo bar baz")
-                     (code "(ns foo.bar"
-                           " (:require"
-                           "   [some :refer [bar baz foo]]))"
-                           "   foo bar baz")))
+    (test-clean-ns {}
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [some :refer [foo bar baz]]))"
+                         "   foo bar baz")
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "   [some :refer [bar baz foo]]))"
+                         "   foo bar baz")))
   (testing "single unused full package import"
     (test-clean-ns {}
                    (code "(ns foo.bar"

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -26,6 +26,11 @@
     (is (= "jar:file:////home/some/.m2/some-jar.jar!/clojure/core.clj"
            (shared/filename->uri "/home/some/.m2/some-jar.jar:clojure/core.clj")))))
 
+(deftest uri->filename
+  (testing "should decode special characters in file URI"
+    (is (= "/path+/encoded characters!"
+           (shared/uri->filename "file:///path%2B/encoded%20characters%21")))))
+
 (deftest ->range-test
   (testing "should subtract 1 from row and col values"
     (is (= {:start {:line      1

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -6,7 +6,7 @@
 
 (deftest uri->project-related-path
   (is (= "/src/my-project/some/ns.clj"
-        (shared/uri->project-related-path "file://home/foo/bar/my-project/src/my-project/some/ns.clj" "file://home/foo/bar/my-project"))))
+         (shared/uri->project-related-path "file:///home/foo/bar/my-project/src/my-project/some/ns.clj" "file:///home/foo/bar/my-project"))))
 
 (deftest filename->uri
   (testing "when it is not a jar and contains slash"


### PR DESCRIPTION
I found that clojure-lsp was not loading my project's .lsp/config.edn file. This was because the project's root path contained whitespace, and so the `%20` in the URI was not correctly being decoded into the correct path by the `uri->filename` function.