### PR TITLE
Fix inconsistent URI encoding and path representation

### DIFF
--- a/integration-test/integration/helper.clj
+++ b/integration-test/integration/helper.clj
@@ -20,10 +20,7 @@
        io/file))
 
 (defn file->uri [file]
-  (let [path (.getAbsolutePath file)]
-    (if (str/starts-with? path "/")
-      (str "file://" path)
-      (str "file:///" path))))
+  (-> file .toPath .toUri .toString))
 
 (defn source-path->uri [source-path]
   (-> source-path

--- a/src/clojure_lsp/config.clj
+++ b/src/clojure_lsp/config.clj
@@ -70,8 +70,8 @@
   (when (file-exists? home-dir-file)
     (read-edn-file home-dir-file)))
 
-(defn ^:private resolve-project-configs [project-root ^java.io.File home-dir-file]
-  (loop [dir (io/file (shared/uri->filename project-root))
+(defn ^:private resolve-project-configs [project-root-uri ^java.io.File home-dir-file]
+  (loop [dir (io/file (shared/uri->filename project-root-uri))
          configs []]
     (let [file (io/file dir ".lsp" "config.edn")
           parent (.getParentFile dir)]
@@ -82,9 +82,9 @@
                         (conj (read-edn-file file))))
         configs))))
 
-(defn resolve-config [project-root]
+(defn resolve-config [project-root-uri]
   (let [home-dir-file (get-home-config-file)]
     (reduce shared/deep-merge
             (merge {}
                    (resolve-home-config home-dir-file))
-            (resolve-project-configs project-root home-dir-file))))
+            (resolve-project-configs project-root-uri home-dir-file))))

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -217,10 +217,10 @@
     (log/info "Analyzing source paths for project root" root-path)
     (analyze-paths! source-paths false)))
 
-(defn initialize-project [project-root-uri client-capabilities client-settings]
+(defn initialize-project [project-root-uri client-capabilities]
   (let [project-settings (config/resolve-config project-root-uri)
         root-path (shared/uri->path project-root-uri)
-        settings (-> (merge client-settings project-settings)
+        settings (-> (merge (:settings @db/db) project-settings)
                      (update :source-paths (fn [source-paths] (mapv #(str (.getAbsolutePath (to-file root-path %))) source-paths)))
                      (update :cljfmt cljfmt.main/merge-default-options))]
     (when-let [log-path (:log-path settings)]
@@ -228,7 +228,6 @@
     (swap! db/db assoc
            :project-root-uri project-root-uri
            :project-settings project-settings
-           :client-settings client-settings
            :settings settings
            :client-capabilities client-capabilities)
     (analyze-project! project-root-uri)))

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -209,26 +209,26 @@
           (log/info "Manual GC after classpath scan took" (float (/ (- (System/nanoTime) start-time) 1000000000)) "seconds")
           (db/save-deps root-path project-hash classpath analysis))))))
 
-(defn ^:private analyze-project! [project-root]
-  (let [root-path (shared/uri->path project-root)
+(defn ^:private analyze-project! [project-root-uri]
+  (let [root-path (shared/uri->path project-root-uri)
         settings (:settings @db/db)
         source-paths (get settings :source-paths)]
     (analyze-classpath! root-path source-paths settings)
     (log/info "Analyzing source paths for project root" root-path)
     (analyze-paths! source-paths false)))
 
-(defn initialize-project [project-root client-capabilities client-settings]
-  (let [project-settings (config/resolve-config project-root)
-        root-path (shared/uri->path project-root)
+(defn initialize-project [project-root-uri client-capabilities client-settings]
+  (let [project-settings (config/resolve-config project-root-uri)
+        root-path (shared/uri->path project-root-uri)
         settings (-> (merge client-settings project-settings)
                      (update :source-paths (fn [source-paths] (mapv #(str (.getAbsolutePath (to-file root-path %))) source-paths)))
                      (update :cljfmt cljfmt.main/merge-default-options))]
     (when-let [log-path (:log-path settings)]
       (logging/update-log-path log-path))
     (swap! db/db assoc
-           :project-root project-root
+           :project-root-uri project-root-uri
            :project-settings project-settings
            :client-settings client-settings
            :settings settings
            :client-capabilities client-capabilities)
-    (analyze-project! project-root)))
+    (analyze-project! project-root-uri)))

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -14,37 +14,37 @@
 
 (def version 1)
 
-(defn ^:private get-sqlite-db-file-path [project-root]
+(defn ^:private get-sqlite-db-file-path [project-root-path]
   (let [configured (some-> (get-in @db [:settings :sqlite-db-path])
                            io/file)
-        default (io/file (str project-root) ".lsp" "sqlite.db")
+        default (io/file (str project-root-path) ".lsp" "sqlite.db")
         file (or configured default)]
     (if (.isAbsolute file)
       (.getAbsolutePath file)
-      (.getAbsolutePath (io/file (str project-root) file)))))
+      (.getAbsolutePath (io/file (str project-root-path) file)))))
 
-(defn ^:private make-spec [project-root]
-  (let [lsp-db-path (get-sqlite-db-file-path project-root)]
+(defn ^:private make-spec [project-root-path]
+  (let [lsp-db-path (get-sqlite-db-file-path project-root-path)]
     {:dbtype "sqlite"
      :dbname lsp-db-path}))
 
-(defn save-deps [project-root project-hash classpath analysis]
-  (let [db-spec (make-spec project-root)]
+(defn save-deps [project-root-path project-hash classpath analysis]
+  (let [db-spec (make-spec project-root-path)]
     (io/make-parents (:dbname db-spec))
     (with-open [conn (jdbc/get-connection db-spec)]
       (jdbc/execute! conn ["drop table if exists project;"])
       (jdbc/execute! conn ["create table project (version text, root text unique, hash text, classpath text, analysis text);"])
       (jdbc/execute! conn ["insert or replace into project
                             (version, root, hash, classpath, analysis)
-                            values (?,?,?,?,?);" (str version) (str project-root) project-hash (pr-str classpath) (pr-str analysis)]))))
+                            values (?,?,?,?,?);" (str version) (str project-root-path) project-hash (pr-str classpath) (pr-str analysis)]))))
 
-(defn read-deps [project-root]
+(defn read-deps [project-root-path]
   (try
-    (with-open [conn (jdbc/get-connection (make-spec project-root))]
+    (with-open [conn (jdbc/get-connection (make-spec project-root-path))]
       (let [project-row
             (-> (jdbc/execute! conn
                                 ["select root, hash, classpath, analysis from project where root = ? and version = ?"
-                                 (str project-root)
+                                 (str project-root-path)
                                  (str version)]
                                 {:builder-fn rs/as-unqualified-lower-maps})
                  (nth 0))]

--- a/src/clojure_lsp/feature/call_hierarchy.clj
+++ b/src/clojure_lsp/feature/call_hierarchy.clj
@@ -13,14 +13,14 @@
 
 (defn ^:private element-by-uri->call-hierarchy-item
   [{uri :uri {:keys [name-row name-col arglist-strs deprecated] value :name :as element} :element}
-   project-root]
+   project-root-uri]
   (let [range (shared/->range element)
         project-file? (string/starts-with? uri "file://")
         detail (if project-file?
                  (-> (f.file-management/force-get-document-text uri)
                      (parser/loc-at-pos name-row name-col)
                      edit/find-namespace-name)
-                 (shared/uri->relative-filepath uri project-root))]
+                 (shared/uri->relative-filepath uri project-root-uri))]
     {:name (if arglist-strs
              (str (name value) " " (some->> arglist-strs (remove nil?) (string/join " ")))
              (name value))
@@ -31,9 +31,9 @@
      :range range
      :selection-range range}))
 
-(defn prepare [uri row col project-root]
+(defn prepare [uri row col project-root-uri]
   (let [cursor-element (q/find-element-under-cursor (:analysis @db/db) (shared/uri->filename uri) row col)]
-    [(element-by-uri->call-hierarchy-item {:uri uri :element cursor-element} project-root)]))
+    [(element-by-uri->call-hierarchy-item {:uri uri :element cursor-element} project-root-uri)]))
 
 (defn ^:private element->incoming-usage-by-uri
   [{:keys [name-row name-col filename]}]
@@ -56,15 +56,15 @@
       {:uri definition-uri
        :element definition})))
 
-(defn incoming [uri row col project-root]
+(defn incoming [uri row col project-root-uri]
   (->> (q/find-references-from-cursor (:analysis @db/db) (shared/uri->filename uri) row col false)
        (map element->incoming-usage-by-uri)
        (remove nil?)
        (mapv (fn [element-by-uri]
                {:from-ranges []
-                :from (element-by-uri->call-hierarchy-item element-by-uri project-root)}))))
+                :from (element-by-uri->call-hierarchy-item element-by-uri project-root-uri)}))))
 
-(defn outgoing [uri row col project-root]
+(defn outgoing [uri row col project-root-uri]
   (let [analysis (:analysis @db/db)
         filename (shared/uri->filename uri)
         zloc (-> (f.file-management/force-get-document-text uri)
@@ -84,4 +84,4 @@
              (remove nil?)
              (mapv (fn [element-by-uri]
                      {:from-ranges []
-                      :to (element-by-uri->call-hierarchy-item element-by-uri project-root)})))))))
+                      :to (element-by-uri->call-hierarchy-item element-by-uri project-root-uri)})))))))

--- a/src/clojure_lsp/feature/call_hierarchy.clj
+++ b/src/clojure_lsp/feature/call_hierarchy.clj
@@ -20,7 +20,7 @@
                  (-> (f.file-management/force-get-document-text uri)
                      (parser/loc-at-pos name-row name-col)
                      edit/find-namespace-name)
-                 (shared/uri->project-related-path uri project-root))]
+                 (shared/uri->relative-filepath uri project-root))]
     {:name (if arglist-strs
              (str (name value) " " (some->> arglist-strs (remove nil?) (string/join " ")))
              (name value))

--- a/src/clojure_lsp/feature/completion.clj
+++ b/src/clojure_lsp/feature/completion.clj
@@ -263,6 +263,9 @@
                       :kind :snippet
                       :insert-text-format :snippet)))))
 
+(defn- sort-completion-results [results]
+  (sort-by (juxt :label :detail) results))
+
 (defn completion [uri row col]
   (let [filename (shared/uri->filename uri)
         {:keys [text]} (get-in @db/db [:documents uri])
@@ -306,13 +309,13 @@
       inside-refer?
       (->> (with-refer-elements matches-fn cursor-loc (concat other-ns-elements external-ns-elements))
            (into #{})
-           (sort-by :label)
+           sort-completion-results
            not-empty)
 
       inside-require?
       (->> (with-ns-definition-elements matches-fn (concat other-ns-elements external-ns-elements))
            (into #{})
-           (sort-by :label)
+           sort-completion-results
            not-empty)
 
       :else
@@ -339,8 +342,8 @@
         (into (with-snippets cursor-loc text row col))
 
         :always
-        (->> (sort-by :label)
-             not-empty)))))
+        (-> sort-completion-results
+            not-empty)))))
 
 (defn ^:private resolve-item-by-ns
   [{{:keys [name ns filename]} :data :as item}]

--- a/src/clojure_lsp/feature/file_management.clj
+++ b/src/clojure_lsp/feature/file_management.clj
@@ -21,11 +21,10 @@
       (->> source-paths
            (some (fn [source-path]
                    (when (string/starts-with? filename source-path)
-                     (some-> filename
-                             (subs (inc (count source-path))
-                                   (- (count filename)
-                                      (inc (count (name file-type)))))
-                             (string/replace #"/" ".")
+                     (some-> (shared/relativize-filepath filename source-path)
+                             (->> (re-find #"^(.+)\.\S+$"))
+                             (nth 1)
+                             (string/replace (System/getProperty "file.separator") ".")
                              (string/replace #"_" "-")))))))))
 
 (defn did-open [uri text]

--- a/src/clojure_lsp/feature/file_management.clj
+++ b/src/clojure_lsp/feature/file_management.clj
@@ -11,10 +11,10 @@
    [taoensso.timbre :as log]))
 
 (defn ^:private uri->namespace [uri]
-  (let [project-root (:project-root @db/db)
+  (let [project-root-uri (:project-root-uri @db/db)
         source-paths (get-in @db/db [:settings :source-paths])
-        in-project? (when project-root
-                      (string/starts-with? uri project-root))
+        in-project? (when project-root-uri
+                      (string/starts-with? uri project-root-uri))
         file-type (shared/uri->file-type uri)
         filename (shared/uri->filename uri)]
     (when (and in-project? (not= :unknown file-type))

--- a/src/clojure_lsp/feature/rename.clj
+++ b/src/clojure_lsp/feature/rename.clj
@@ -12,13 +12,11 @@
 (defn ^:private namespace->uri [namespace source-paths filename]
   (let [file-type (shared/uri->file-type filename)]
     (shared/filename->uri
-      (str (first (filter #(string/starts-with? filename %) source-paths))
-           "/"
-           (-> namespace
-               (string/replace "." "/")
-               (string/replace "-" "_"))
-           "."
-           (name file-type)))))
+      (shared/join-filepaths (first (filter #(string/starts-with? filename %) source-paths))
+                             (-> namespace
+                                 (string/replace "." (System/getProperty "file.separator"))
+                                 (string/replace "-" "_")
+                                 (str "." (name file-type)))))))
 
 (defn ^:private rename-keyword [replacement {:keys [ns alias name filename
                                                     name-col name-end-col

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -31,7 +31,6 @@
   (:import
     [java.net
      URL
-     URI
      JarURLConnection]))
 
 (def ^:private full-file-range
@@ -48,16 +47,7 @@
 
 (defn initialize [project-root-uri client-capabilities client-settings]
   (when project-root-uri
-    (swap! db/db assoc
-           :client-settings client-settings
-           :settings (cond-> client-settings
-                       (not (map? (:uri-format client-settings)))
-                       (assoc :uri-format
-                              {:upper-case-drive-letter? (->> project-root-uri URI. .getPath
-                                                              (re-find #"^/[A-Z]:/")
-                                                              boolean)
-                               :encode-colons-in-path? (string/includes? project-root-uri "%3A")})))
-    (crawler/initialize-project project-root-uri client-capabilities)))
+    (crawler/initialize-project project-root-uri client-capabilities client-settings)))
 
 (defn did-open [{:keys [textDocument]}]
   (let [uri (:uri textDocument)

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -23,7 +23,6 @@
     [clojure-lsp.queries :as q]
     [clojure-lsp.shared :as shared]
     [clojure.pprint :as pprint]
-    [clojure.string :as string]
     [medley.core :as medley]
     [rewrite-clj.node :as n]
     [rewrite-clj.zip :as z]

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -30,7 +30,6 @@
   (:import
     [java.net
      URL
-     URLDecoder
      JarURLConnection]))
 
 (def ^:private full-file-range
@@ -50,7 +49,7 @@
     (crawler/initialize-project project-root client-capabilities client-settings)))
 
 (defn did-open [{:keys [textDocument]}]
-  (let [uri (-> textDocument :uri URLDecoder/decode)
+  (let [uri (:uri textDocument)
         text (:text textDocument)]
     (f.file-management/did-open uri text))
   nil)

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -44,9 +44,9 @@
            (recur)
            ~@body)))))
 
-(defn initialize [project-root client-capabilities client-settings]
-  (when project-root
-    (crawler/initialize-project project-root client-capabilities client-settings)))
+(defn initialize [project-root-uri client-capabilities client-settings]
+  (when project-root-uri
+    (crawler/initialize-project project-root-uri client-capabilities client-settings)))
 
 (defn did-open [{:keys [textDocument]}]
   (let [uri (:uri textDocument)
@@ -135,7 +135,7 @@
 (defn ^:private server-info []
   (let [db @db/db]
     {:type :info
-     :message (with-out-str (pprint/pprint {:project-root (:project-root db)
+     :message (with-out-str (pprint/pprint {:project-root-uri (:project-root-uri db)
                                             :project-settings (:project-settings db)
                                             :client-settings (:client-settings db)
                                             :port (or (:port db)
@@ -266,24 +266,24 @@
 
 (defn prepare-call-hierarchy
   [{:keys [textDocument position]}]
-  (let [project-root (:project-root @db/db)]
+  (let [project-root-uri (:project-root-uri @db/db)]
     (f.call-hierarchy/prepare textDocument
                               (inc (:line position))
                               (inc (:character position))
-                              project-root)))
+                              project-root-uri)))
 
 (defn call-hierarchy-incoming
   [{:keys [item]}]
   (let [uri (:uri item)
         row (inc (-> item :range :start :line))
         col (inc (-> item :range :start :character))
-        project-root (:project-root @db/db)]
-    (f.call-hierarchy/incoming uri row col project-root)))
+        project-root-uri (:project-root-uri @db/db)]
+    (f.call-hierarchy/incoming uri row col project-root-uri)))
 
 (defn call-hierarchy-outgoing
   [{:keys [item]}]
   (let [uri (:uri item)
         row (inc (-> item :range :start :line))
         col (inc (-> item :range :start :character))
-        project-root (:project-root @db/db)]
-    (f.call-hierarchy/outgoing uri row col project-root)))
+        project-root-uri (:project-root-uri @db/db)]
+    (f.call-hierarchy/outgoing uri row col project-root-uri)))

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.interop
   (:require
-    [clojure-lsp.shared :as shared]
     [clojure.data.json :as json]
     [clojure.java.data :as j]
     [clojure.spec.alpha :as s]

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -47,13 +47,10 @@
       VersionedTextDocumentIdentifier
       WatchKind
       WorkspaceEdit)
-    (org.eclipse.lsp4j.jsonrpc.messages Either)
-    (java.net URLDecoder)))
+    (org.eclipse.lsp4j.jsonrpc.messages Either)))
 
-(defn document->decoded-uri [^TextDocumentIdentifier document]
-  (-> document
-      .getUri
-      URLDecoder/decode))
+(defn document->uri [^TextDocumentIdentifier document]
+  (.getUri document))
 
 (defmethod j/from-java DiagnosticSeverity [^DiagnosticSeverity instance]
   (-> instance .name .toLowerCase keyword))
@@ -74,11 +71,11 @@
   (j/from-java (.get instance)))
 
 (defmethod j/from-java TextDocumentIdentifier [^TextDocumentIdentifier instance]
-  (document->decoded-uri instance))
+  (document->uri instance))
 
 (defmethod j/from-java VersionedTextDocumentIdentifier [^VersionedTextDocumentIdentifier instance]
   {:version (.getVersion instance)
-   :uri (document->decoded-uri instance)})
+   :uri (document->uri instance)})
 
 (defmethod j/from-java JsonElement [^JsonElement instance]
   (-> instance

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -1,12 +1,13 @@
 (ns clojure-lsp.interop
   (:require
+    [clojure-lsp.shared :as shared]
     [clojure.data.json :as json]
     [clojure.java.data :as j]
     [clojure.spec.alpha :as s]
     [clojure.string :as string]
-    [taoensso.timbre :as log]
     [clojure.walk :as walk]
-    [medley.core :as medley])
+    [medley.core :as medley]
+    [taoensso.timbre :as log])
   (:import
     (com.google.gson JsonElement)
     (org.eclipse.lsp4j

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -161,7 +161,7 @@
            (end
             (let [result (when (compare-and-set! formatting false true)
                            (try
-                             (let [doc-id (interop/document->decoded-uri (.getTextDocument params))
+                             (let [doc-id (interop/document->uri (.getTextDocument params))
                                    range (.getRange params)
                                    start (.getStart range)
                                    end (.getEnd range)]

--- a/test/clojure_lsp/config_test.clj
+++ b/test/clojure_lsp/config_test.clj
@@ -1,6 +1,7 @@
 (ns clojure-lsp.config-test
   (:require
    [clojure-lsp.config :as config]
+   [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest testing is]]))
 
 (deftest resolve-config
@@ -8,28 +9,28 @@
     (with-redefs [config/get-property (constantly nil)
                   config/file-exists? (constantly nil)
                   config/get-env (constantly nil)]
-      (is (= {} (config/resolve-config "/home/user/some/project/")))))
+      (is (= {} (config/resolve-config (h/file-uri "file:///home/user/some/project/"))))))
   (testing "when user doesn't have a home config but has a project config"
     (with-redefs [config/get-property (constantly nil)
                   config/get-env (constantly nil)
-                  config/file-exists? #(= "/home/user/some/project/.lsp/config.edn" (str %))
+                  config/file-exists? #(= (h/file-path "/home/user/some/project/.lsp/config.edn") (str %))
                   slurp (constantly "{:foo {:bar 1}}")]
-      (is (= {:foo {:bar 1}} (config/resolve-config "/home/user/some/project/")))))
+      (is (= {:foo {:bar 1}} (config/resolve-config (h/file-uri "file:///home/user/some/project/"))))))
   (testing "when user has a home config but doesn't have a project config"
-    (with-redefs [config/get-property (constantly "/home/user")
+    (with-redefs [config/get-property (constantly (h/file-path "/home/user"))
                   config/get-env (constantly nil)
-                  config/file-exists? #(= "/home/user/.lsp/config.edn" (str %))
+                  config/file-exists? #(= (h/file-path "/home/user/.lsp/config.edn") (str %))
                   slurp (constantly "{:foo {:bar 1}}")]
-      (is (= {:foo {:bar 1}} (config/resolve-config "/home/user/some/project/")))))
+      (is (= {:foo {:bar 1}} (config/resolve-config (h/file-uri "file:///home/user/some/project/"))))))
   (testing "when user has a home config and a project config we merge with project as priority"
-    (with-redefs [config/get-property (constantly "/home/user")
+    (with-redefs [config/get-property (constantly (h/file-path "/home/user"))
                   config/get-env (constantly nil)
-                  config/file-exists? #(or (= "/home/user/.lsp/config.edn" (str %))
-                                           (= "/home/user/some/project/.lsp/config.edn" (str %)))
+                  config/file-exists? #(or (= (h/file-path "/home/user/.lsp/config.edn") (str %))
+                                           (= (h/file-path "/home/user/some/project/.lsp/config.edn") (str %)))
                   slurp (fn [f]
-                          (if (= "/home/user/.lsp/config.edn" (str f))
+                          (if (= (h/file-path "/home/user/.lsp/config.edn") (str f))
                             "{:foo {:bar 1 :baz 1} :home :bla}"
                             "{:foo {:baz 2}}"))]
       (is (= {:foo {:bar 1
                     :baz 2}
-              :home :bla} (config/resolve-config "/home/user/some/project/"))))))
+              :home :bla} (config/resolve-config (h/file-uri "file:///home/user/some/project/")))))))

--- a/test/clojure_lsp/db_test.clj
+++ b/test/clojure_lsp/db_test.clj
@@ -8,21 +8,21 @@
 
 (h/reset-db-after-test)
 
-(def project-path "/user/project")
-(def default-db-path (s/join "/" [project-path ".lsp" "sqlite.db"]))
+(def project-path (h/file-path "/user/project"))
+(def default-db-path (str (io/file project-path ".lsp" "sqlite.db")))
 
 (deftest sqlite-db-file-setting
   (testing "when not set"
     (reset! db/db {})
-    (is (= (-> default-db-path io/file .getAbsolutePath) (#'db/get-sqlite-db-file-path project-path))))
+    (is (= default-db-path (#'db/get-sqlite-db-file-path project-path))))
   (testing "when set to relative path"
     (let [settings-path "subdir/sqlite.db"
-          expected (s/join "/" [project-path settings-path])]
+          expected (.getAbsolutePath (io/file project-path settings-path))]
       (reset! db/db {:settings {:sqlite-db-path settings-path}})
-      (is (= (-> expected io/file .getAbsolutePath)
+      (is (= expected
              (#'db/get-sqlite-db-file-path project-path)))))
   (testing "when set to absolute path"
-    (let [settings-path "/db-dir/sqlite.db"]
+    (let [settings-path (h/file-path "/db-dir/sqlite.db")]
       (reset! db/db {:settings {:sqlite-db-path settings-path}})
-      (is (= (-> settings-path io/file .getAbsolutePath)
+      (is (= settings-path
              (#'db/get-sqlite-db-file-path project-path))))))

--- a/test/clojure_lsp/features/call_hierarchy_test.clj
+++ b/test/clojure_lsp/features/call_hierarchy_test.clj
@@ -35,7 +35,7 @@
         "(defn d-func []"
         "  (println 1))"))
 
-(def project-root "file:/")
+(def project-root-uri "file:/")
 
 (deftest prepare
   (h/load-code-and-locs a-code (h/file-uri "file:///some/a.clj"))
@@ -43,7 +43,7 @@
   (h/load-code-and-locs c-code (h/file-uri "file:///some/c.clj"))
   (h/load-code-and-locs d-code (h/file-uri "file:///some/d.clj"))
   (testing "single element"
-    (let [items (f.call-hierarchy/prepare (h/file-uri "file:///some/d.clj") 2 7 project-root)]
+    (let [items (f.call-hierarchy/prepare (h/file-uri "file:///some/d.clj") 2 7 project-root-uri)]
       (is (= 1 (count items)))
       (is (= {:name            "d-func []"
               :kind            :function
@@ -69,7 +69,7 @@
                :uri (h/file-uri "file:///some/c.clj")
                :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
                :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}]
-      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 project-root)))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 project-root-uri)))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -97,7 +97,7 @@
                :uri (h/file-uri "file:///some/b.clj")
                :range {:start {:line 5 :character 6} :end {:line 5 :character 14}}
                :selection-range {:start {:line 5 :character 6} :end {:line 5 :character 14}}}}]
-      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 project-root))))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 project-root-uri))))
 
 (deftest outgoing
   (h/load-code-and-locs a-code (h/file-uri "file:///some/a.clj"))
@@ -115,7 +115,7 @@
              :uri (h/file-uri "file:///some/b.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 project-root)))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 project-root-uri)))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -135,4 +135,4 @@
              :uri (h/file-uri "file:///some/c.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 project-root))))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 project-root-uri))))

--- a/test/clojure_lsp/features/call_hierarchy_test.clj
+++ b/test/clojure_lsp/features/call_hierarchy_test.clj
@@ -38,27 +38,27 @@
 (def project-root "file:/")
 
 (deftest prepare
-  (h/load-code-and-locs a-code "file:///some/a.clj")
-  (h/load-code-and-locs b-code "file:///some/b.clj")
-  (h/load-code-and-locs c-code "file:///some/c.clj")
-  (h/load-code-and-locs d-code "file:///some/d.clj")
+  (h/load-code-and-locs a-code (h/file-uri "file:///some/a.clj"))
+  (h/load-code-and-locs b-code (h/file-uri "file:///some/b.clj"))
+  (h/load-code-and-locs c-code (h/file-uri "file:///some/c.clj"))
+  (h/load-code-and-locs d-code (h/file-uri "file:///some/d.clj"))
   (testing "single element"
-    (let [items (f.call-hierarchy/prepare "file:///some/d.clj" 2 7 project-root)]
+    (let [items (f.call-hierarchy/prepare (h/file-uri "file:///some/d.clj") 2 7 project-root)]
       (is (= 1 (count items)))
       (is (= {:name            "d-func []"
               :kind            :function
               :tags            []
               :detail          "some.d"
-              :uri             "file:///some/d.clj"
+              :uri             (h/file-uri "file:///some/d.clj")
               :range           {:start {:line 1 :character 6} :end {:line 1 :character 12}}
               :selection-range {:start {:line 1 :character 6} :end {:line 1 :character 12}}}
              (first items))))))
 
 (deftest incoming
-  (h/load-code-and-locs a-code "file:///some/a.clj")
-  (h/load-code-and-locs b-code "file:///some/b.clj")
-  (h/load-code-and-locs c-code "file:///some/c.clj")
-  (h/load-code-and-locs d-code "file:///some/d.clj")
+  (h/load-code-and-locs a-code (h/file-uri "file:///some/a.clj"))
+  (h/load-code-and-locs b-code (h/file-uri "file:///some/b.clj"))
+  (h/load-code-and-locs c-code (h/file-uri "file:///some/c.clj"))
+  (h/load-code-and-locs d-code (h/file-uri "file:///some/d.clj"))
   (testing "from first element"
     (h/assert-submaps
       [{:from-ranges []
@@ -66,10 +66,10 @@
                :kind :function
                :tags []
                :detail "some.c"
-               :uri "file:///some/c.clj"
+               :uri (h/file-uri "file:///some/c.clj")
                :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
                :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}]
-      (f.call-hierarchy/incoming "file:///some/d.clj" 2 7 project-root)))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 project-root)))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -78,7 +78,7 @@
                :kind :function
                :tags []
                :detail "some.b"
-               :uri "file:///some/b.clj"
+               :uri (h/file-uri "file:///some/b.clj")
                :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
                :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}
        {:from-ranges []
@@ -86,7 +86,7 @@
                :kind :function
                :tags []
                :detail "some.b"
-               :uri "file:///some/b.clj"
+               :uri (h/file-uri "file:///some/b.clj")
                :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
                :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}
        {:from-ranges []
@@ -94,16 +94,16 @@
                :kind :function
                :tags []
                :detail "some.b"
-               :uri "file:///some/b.clj"
+               :uri (h/file-uri "file:///some/b.clj")
                :range {:start {:line 5 :character 6} :end {:line 5 :character 14}}
                :selection-range {:start {:line 5 :character 6} :end {:line 5 :character 14}}}}]
-      (f.call-hierarchy/incoming "file:///some/c.clj" 3 7 project-root))))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 project-root))))
 
 (deftest outgoing
-  (h/load-code-and-locs a-code "file:///some/a.clj")
-  (h/load-code-and-locs b-code "file:///some/b.clj")
-  (h/load-code-and-locs c-code "file:///some/c.clj")
-  (h/load-code-and-locs d-code "file:///some/d.clj")
+  (h/load-code-and-locs a-code (h/file-uri "file:///some/a.clj"))
+  (h/load-code-and-locs b-code (h/file-uri "file:///some/b.clj"))
+  (h/load-code-and-locs c-code (h/file-uri "file:///some/c.clj"))
+  (h/load-code-and-locs d-code (h/file-uri "file:///some/d.clj"))
 
   (testing "from first element"
     (h/assert-submaps
@@ -112,10 +112,10 @@
              :kind :function
              :tags []
              :detail "some.b"
-             :uri "file:///some/b.clj"
+             :uri (h/file-uri "file:///some/b.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}]
-      (f.call-hierarchy/outgoing "file:///some/a.clj" 3 7 project-root)))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 project-root)))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -124,7 +124,7 @@
              :kind :function
              :tags []
              :detail "some.c"
-             :uri "file:///some/c.clj"
+             :uri (h/file-uri "file:///some/c.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}
        {:from-ranges []
@@ -132,7 +132,7 @@
              :kind :function
              :tags []
              :detail "some.c"
-             :uri "file:///some/c.clj"
+             :uri (h/file-uri "file:///some/c.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 2 :character 6} :end {:line 2 :character 12}}}}]
-      (f.call-hierarchy/outgoing "file:///some/b.clj" 3 7 project-root))))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 project-root))))

--- a/test/clojure_lsp/features/code_actions_test.clj
+++ b/test/clojure_lsp/features/code_actions_test.clj
@@ -16,33 +16,33 @@
       (parser/loc-at-pos row col)))
 
 (deftest add-alias-suggestion-code-actions
-  (h/load-code-and-locs "(ns clojure.set)" "file:///clojure.core.clj")
-  (h/load-code-and-locs "(ns medley.core)" "file:///medley.core.clj")
-  (h/load-code-and-locs "(ns clojure.data.json)" "file:///clojure.data.json.clj")
-  (h/load-code-and-locs "(ns some (:require [chesire :as json]))" "file:///some.clj")
+  (h/load-code-and-locs "(ns clojure.set)" (h/file-uri "file:///clojure.core.clj"))
+  (h/load-code-and-locs "(ns medley.core)" (h/file-uri "file:///medley.core.clj"))
+  (h/load-code-and-locs "(ns clojure.data.json)" (h/file-uri "file:///clojure.data.json.clj"))
+  (h/load-code-and-locs "(ns some (:require [chesire :as json]))" (h/file-uri "file:///some.clj"))
   (h/load-code-and-locs (h/code "(ns some)"
                                 "(clojure.set/union #{} #{})"
                                 "(medley.core/foo 1 2)"
                                 "(clojure.data.json/bar 1 2)"))
   (testing "simple ns"
     (is (some #(= (:title %) "Add require 'clojure.set' as 'set'")
-              (f.code-actions/all (zloc-at "file:///a.clj" 2 4)
-                                  "file:///a.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 4)
+                                  (h/file-uri "file:///a.clj")
                                   2
                                   4
                                   [{:code "unresolved-namespace"
                                     :range {:start {:line 1 :character 3}}}] {}))))
   (testing "core ns"
     (is (some #(= (:title %) "Add require 'medley.core' as 'medley'")
-              (f.code-actions/all (zloc-at "file:///a.clj" 3 4)
-                                  "file:///a.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 4)
+                                  (h/file-uri "file:///a.clj")
                                   3
                                   4
                                   [{:code "unresolved-namespace"
                                     :range {:start {:line 2 :character 3}}}] {}))))
   (testing "already used alias, we add one more suggestion"
-    (let [result (f.code-actions/all (zloc-at "file:///a.clj" 4 4)
-                                     "file:///a.clj"
+    (let [result (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4)
+                                     (h/file-uri "file:///a.clj")
                                      4
                                      4
                                      [{:code "unresolved-namespace"
@@ -53,12 +53,12 @@
 (deftest add-missing-namespace-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (h/load-code-and-locs (str "(ns another-ns)\n"
                              "(def bar ons/bar)\n"
                              "(def foo sns/foo)\n"
@@ -66,42 +66,42 @@
                              "MyClass.\n"
                              "Date.\n"
                              "Date/parse")
-                        "file:///c.clj")
+                        (h/file-uri "file:///c.clj"))
   (testing "when it has not unresolved-namespace diagnostic"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file:///c.clj" 2 10)
-                                      "file:///c.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 2 10)
+                                      (h/file-uri "file:///c.clj")
                                       2
                                       10
                                       [] {}))))
   (testing "when it has unresolved-namespace and can find namespace"
     (is (some #(= (:title %) "Add missing 'some-ns' require")
-              (f.code-actions/all (zloc-at "file:///c.clj" 3 11)
-                                  "file:///c.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 3 11)
+                                  (h/file-uri "file:///c.clj")
                                   3
                                   11
                                   [{:code "unresolved-namespace"
                                     :range {:start {:line 2 :character 10}}}] {}))))
   (testing "when it has unresolved-namespace but cannot find namespace"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file:///c.clj" 2 11)
-                                      "file:///c.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 2 11)
+                                      (h/file-uri "file:///c.clj")
                                       2
                                       11
                                       [{:code "unresolved-namespace"
                                         :range {:start {:line 1 :character 10}}}] {}))))
   (testing "when it has unresolved-symbol and it's a known refer"
     (is (some #(= (:title %) "Add missing 'clojure.test' require")
-              (f.code-actions/all (zloc-at "file:///c.clj" 4 2)
-                                  "file:///c.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 2)
+                                  (h/file-uri "file:///c.clj")
                                   4
                                   2
                                   [{:code "unresolved-namespace"
                                     :range {:start {:line 3 :character 1}}}] {}))))
   (testing "when it has unresolved-symbol but it's not a known refer"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file:///c.clj" 4 11)
-                                      "file:///c.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 11)
+                                      (h/file-uri "file:///c.clj")
                                       4
                                       11
                                       [{:code "unresolved-symbol"
@@ -116,19 +116,19 @@
                              "MyClass.\n"
                              "Date.\n"
                              "Date/parse")
-                        "file:///c.clj")
+                        (h/file-uri "file:///c.clj"))
   (testing "when it has no unresolved-symbol diagnostic"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file:///c.clj" 5 2)
-                                      "file:///c.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 5 2)
+                                      (h/file-uri "file:///c.clj")
                                       5
                                       2
                                       [] {}))))
 
   (testing "when it has unresolved-symbol but it's not a common import"
     (is (not-any? #(string/starts-with? (:title %) "Add missing")
-                  (f.code-actions/all (zloc-at "file:///c.clj" 5 2)
-                                      "file:///c.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 5 2)
+                                      (h/file-uri "file:///c.clj")
                                       5
                                       2
                                       [{:code "unresolved-symbol"
@@ -136,8 +136,8 @@
                                         :range {:start {:line 4 :character 2}}}] {}))))
   (testing "when it has unresolved-symbol and it's a common import"
     (is (some #(= (:title %) "Add missing 'java.util.Date' import")
-              (f.code-actions/all (zloc-at "file:///c.clj" 6 2)
-                                  "file:///c.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 6 2)
+                                  (h/file-uri "file:///c.clj")
                                   6
                                   2
                                   [{:code "unresolved-symbol"
@@ -145,8 +145,8 @@
                                     :range {:start {:line 5 :character 2}}}] {}))))
   (testing "when it has unresolved-namespace and it's a common import via method"
     (is (some #(= (:title %) "Add missing 'java.util.Date' import")
-              (f.code-actions/all (zloc-at "file:///c.clj" 7 2)
-                                  "file:///c.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 7 2)
+                                  (h/file-uri "file:///c.clj")
                                   7
                                   2
                                   [{:code "unresolved-namespace"
@@ -157,18 +157,18 @@
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (testing "when in not a let/def symbol"
     (is (not-any? #(= (:title %) "Inline symbol")
-                  (f.code-actions/all (zloc-at "file:///b.clj" 4 8)
-                                      "file:///b.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 8)
+                                      (h/file-uri "file:///b.clj")
                                       4
                                       8
                                       [] {}))))
   (testing "when in let/def symbol"
     (is (some #(= (:title %) "Inline symbol")
-              (f.code-actions/all (zloc-at "file:///b.clj" 4 5)
-                                  "file:///b.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 5)
+                                  (h/file-uri "file:///b.clj")
                                   4
                                   5
                                   [] {})))))
@@ -179,44 +179,44 @@
                                 "{:some :map}"
                                 "[:some :vector]"
                                 "#{:some :set}")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (testing "when in not a coll"
     (is (not-any? #(= (:title %) "Change coll to")
-                  (f.code-actions/all (zloc-at "file:///b.clj" 1 1)
-                                      "file:///b.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 1 1)
+                                      (h/file-uri "file:///b.clj")
                                       1
                                       1
                                       [] {}))))
   (testing "when in a list"
     (is (some #(= (:title %) "Change coll to map")
-              (f.code-actions/all (zloc-at "file:///b.clj" 2 1) "file:///b.clj" 2 1 [] {}))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 1) (h/file-uri "file:///b.clj") 2 1 [] {}))))
   (testing "when in a map"
     (is (some #(= (:title %) "Change coll to vector")
-              (f.code-actions/all (zloc-at "file:///b.clj" 3 1) "file:///b.clj" 3 1 [] {}))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 1) (h/file-uri "file:///b.clj") 3 1 [] {}))))
   (testing "when in a vector"
     (is (some #(= (:title %) "Change coll to set")
-              (f.code-actions/all (zloc-at "file:///b.clj" 4 1) "file:///b.clj" 4 1 [] {}))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1) (h/file-uri "file:///b.clj") 4 1 [] {}))))
   (testing "when in a set"
     (is (some #(= (:title %) "Change coll to list")
-              (f.code-actions/all (zloc-at "file:///b.clj" 5 1) "file:///b.clj" 5 1 [] {})))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 5 1) (h/file-uri "file:///b.clj") 5 1 [] {})))))
 
 (deftest move-to-let-code-action
   (h/load-code-and-locs (h/code "(let [a 1"
                                 "      b 2]"
                                 "  (+ 1 2))"
                                 "(+ 1 2)")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (testing "when not inside a let form"
     (is (not-any? #(= (:title %) "Move to let")
-                  (f.code-actions/all (zloc-at "file:///b.clj" 4 1)
-                                      "file:///b.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1)
+                                      (h/file-uri "file:///b.clj")
                                       4
                                       1
                                       [] {}))))
   (testing "when inside let form"
     (is (some #(= (:title %) "Move to let")
-              (f.code-actions/all (zloc-at "file:///b.clj" 3 3)
-                                  "file:///b.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 3)
+                                  (h/file-uri "file:///b.clj")
                                   3
                                   3
                                   [] {})))))
@@ -224,18 +224,18 @@
 (deftest cycle-privacy-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (testing "when non function location"
     (is (not-any? #(= (:title %) "Cycle privacy")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 1 5)
-                                      "file:///a.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 5)
+                                      (h/file-uri "file:///a.clj")
                                       1
                                       5
                                       [] {}))))
   (testing "when on function location"
     (is (some #(= (:title %) "Cycle privacy")
-              (f.code-actions/all (zloc-at "file:///a.clj" 2 5)
-                                  "file:///a.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+                                  (h/file-uri "file:///a.clj")
                                   2
                                   5
                                   [] {})))))
@@ -243,18 +243,18 @@
 (deftest extract-function-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (testing "when non function location"
     (is (not-any? #(= (:title %) "Extract function")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 1 5)
-                                      "file:///a.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 5)
+                                      (h/file-uri "file:///a.clj")
                                       1
                                       5
                                       [] {}))))
   (testing "when on function location"
     (is (some #(= (:title %) "Extract function")
-              (f.code-actions/all (zloc-at "file:///a.clj" 2 5)
-                                  "file:///a.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+                                  (h/file-uri "file:///a.clj")
                                   2
                                   5
                                   [] {})))))
@@ -265,15 +265,15 @@
                                 "(def bar (some-func 1 2))"))
   (testing "when not in a unresolved symbol"
     (is (not-any? #(= (:title %) "Create private function")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 1 10)
-                                      "file:///a.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 10)
+                                      (h/file-uri "file:///a.clj")
                                       1
                                       10
                                       [] {}))))
   (testing "when in a unresolved symbol"
     (is (some #(= (:title %) "Create private function 'some-func'")
-              (f.code-actions/all (zloc-at "file:///a.clj" 2 10)
-                                  "file:///a.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 10)
+                                  (h/file-uri "file:///a.clj")
                                   2
                                   10
                                   [{:code "unresolved-symbol"
@@ -284,41 +284,41 @@
   (h/load-code-and-locs (h/code "(ns some-ns)"
                                 "(def foo)"
                                 "(- (+ 1 1) 2)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (testing "when in a ns or :require"
     (is (not-any? #(= (:title %) "Thread first all")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 1 1) "file:///a.clj" 1 1 [] {}))))
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {}))))
   (testing "when in a def similar location"
     (is (not-any? #(= (:title %) "Thread first all")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 2 1) "file:///a.clj" 2 1 [] {}))))
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 1) (h/file-uri "file:///a.clj") 2 1 [] {}))))
   (testing "when on a valid function that can be threaded"
     (is (some #(= (:title %) "Thread first all")
-              (f.code-actions/all (zloc-at "file:///a.clj" 3 1) "file:///a.clj" 3 1 [] {})))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {})))))
 
 (deftest thread-last-all-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
                                 "(def foo)"
                                 "(- (+ 1 1) 2)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (testing "when in a ns or :require"
     (is (not-any? #(= (:title %) "Thread last all")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 1 1) "file:///a.clj" 1 1 [] {}))))
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {}))))
   (testing "when in a def similar location"
     (is (not-any? #(= (:title %) "Thread last all")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 2 1) "file:///a.clj" 2 1 [] {}))))
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 1) (h/file-uri "file:///a.clj") 2 1 [] {}))))
   (testing "when on a valid function that can be threaded"
     (is (some #(= (:title %) "Thread last all")
-              (f.code-actions/all (zloc-at "file:///a.clj" 3 1) "file:///a.clj" 3 1 [] {})))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {})))))
 
 (deftest clean-ns-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (h/load-code-and-locs (str "(ns another-ns)\n"
                              "(def bar ons/bar)\n"
                              "(def foo sns/foo)\n"
@@ -326,11 +326,11 @@
                              "MyClass.\n"
                              "Date.\n"
                              "Date/parse")
-                        "file:///c.clj")
+                        (h/file-uri "file:///c.clj"))
   (testing "without workspace edit client capability"
     (is (not-any? #(= (:title %) "Clean namespace")
-                  (f.code-actions/all (zloc-at "file:///b.clj" 2 2)
-                                      "file:///b.clj"
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
+                                      (h/file-uri "file:///b.clj")
                                       2
                                       2
                                       [] {}))))
@@ -338,8 +338,8 @@
   (testing "with workspace edit client capability"
     (swap! db/db assoc-in [:client-capabilities :workspace :workspace-edit] true)
     (is (some #(= (:title %) "Clean namespace")
-              (f.code-actions/all (zloc-at "file:///b.clj" 2 2)
-                                  "file:///b.clj"
+              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
+                                  (h/file-uri "file:///b.clj")
                                   2
                                   2
                                   [] {:workspace {:workspace-edit true}})))))
@@ -351,7 +351,7 @@
                                 "(+ 1 2)"))
   (testing "when inside a macro usage"
     (is (some #(= (:title %) "Resolve macro 'some-ns/foo' as...")
-              (f.code-actions/all (zloc-at "file:///a.clj" 3 7) "file:///a.clj" 3 7 [] {}))))
+              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7) (h/file-uri "file:///a.clj") 3 7 [] {}))))
   (testing "when not inside a macro usage"
     (is (not-any? #(= (:title %) "Resolve macro 'some-ns/foo' as...")
-                  (f.code-actions/all (zloc-at "file:///a.clj" 4 4) "file:///a.clj" 4 4 [] {})))))
+                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4) (h/file-uri "file:///a.clj") 4 4 [] {})))))

--- a/test/clojure_lsp/features/completion_test.clj
+++ b/test/clojure_lsp/features/completion_test.clj
@@ -43,8 +43,8 @@
   (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
   (testing "complete-a"
     (h/assert-submaps
-     [{:label "alpaca" :kind :property :detail "user"}
-      {:label "alpaca" :kind :property :detail "alpaca.ns"}
+     [{:label "alpaca" :kind :property :detail "alpaca.ns"}
+      {:label "alpaca" :kind :property :detail "user"}
       {:label "alpha" :kind :variable}
       {:label "ba" :detail "alpaca.ns"}]
      (f.completion/completion (h/file-uri "file:///b.clj") 3 3)))
@@ -58,8 +58,8 @@
      (f.completion/completion (h/file-uri "file:///b.clj") 4 3)))
   (testing "complete-alpaca"
     (h/assert-submaps
-     [{:label "alpaca" :kind :property :detail "user"}
-      {:label "alpaca" :kind :property :detail "alpaca.ns"}
+     [{:label "alpaca" :kind :property :detail "alpaca.ns"}
+      {:label "alpaca" :kind :property :detail "user"}
       {:label "alpha" :kind :variable}
       {:label "ba" :detail "alpaca.ns"}]
      (f.completion/completion (h/file-uri "file:///b.clj") 3 3)))

--- a/test/clojure_lsp/features/completion_test.clj
+++ b/test/clojure_lsp/features/completion_test.clj
@@ -14,31 +14,31 @@
   (h/load-code-and-locs (code "(ns alpaca.ns (:require [user :as alpaca]))"
                               "(alpaca/)"
                               "(def barr)"
-                              "(def bazz)") "file:///a.cljc")
+                              "(def bazz)") (h/file-uri "file:///a.cljc"))
   (h/load-code-and-locs (code "(ns user)"
                               "(def alpha)"
                               "alp"
-                              "ba") "file:///b.clj")
+                              "ba") (h/file-uri "file:///b.clj"))
   (h/load-code-and-locs (code "(ns alpaca.ns)"
-                              "(def baff)") "file:///c.cljs")
+                              "(def baff)") (h/file-uri "file:///c.cljs"))
   (h/load-code-and-locs (code "(ns d (:require [alpaca.ns :as alpaca])) frequen"
                               "(def bar \"some good docs\"123)"
                               "(defn barbaz [a b] 123)"
                               "(def some 123)")
-                        "file:///d.clj")
+                        (h/file-uri "file:///d.clj"))
   (h/load-code-and-locs (code "(ns e (:require [alpaca.ns :refer [ba]]"
                               "                [d :as d-alias]))"
                               "Syste"
                               "d-alias/b"
                               "123")
-                        "file:///e.clj")
+                        (h/file-uri "file:///e.clj"))
   (h/load-code-and-locs (code "(ns f (:require [alpaca.ns :refer [ba]]"
                               "                 alp))")
-                        "file:///f.clj")
+                        (h/file-uri "file:///f.clj"))
   (h/load-code-and-locs (code "(ns g (:require [alpaca.ns :as ba :refer [baq]]))"
                               "(defn bar [baz] ba)"
                               "")
-                        "file:///g.clj")
+                        (h/file-uri "file:///g.clj"))
 
   (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
   (testing "complete-a"
@@ -47,7 +47,7 @@
       {:label "alpaca" :kind :property :detail "alpaca.ns"}
       {:label "alpha" :kind :variable}
       {:label "ba" :detail "alpaca.ns"}]
-     (f.completion/completion "file:///b.clj" 3 3)))
+     (f.completion/completion (h/file-uri "file:///b.clj") 3 3)))
   (testing "complete-ba"
     (h/assert-submaps
      [{:label "ba" :kind :property}
@@ -55,45 +55,45 @@
       {:label "ba/barr"}
       {:label "ba/bazz"}
       {:label "bases" :detail "clojure.core/bases"}]
-     (f.completion/completion "file:///b.clj" 4 3)))
+     (f.completion/completion (h/file-uri "file:///b.clj") 4 3)))
   (testing "complete-alpaca"
     (h/assert-submaps
      [{:label "alpaca" :kind :property :detail "user"}
       {:label "alpaca" :kind :property :detail "alpaca.ns"}
       {:label "alpha" :kind :variable}
       {:label "ba" :detail "alpaca.ns"}]
-     (f.completion/completion "file:///b.clj" 3 3)))
+     (f.completion/completion (h/file-uri "file:///b.clj") 3 3)))
   (testing "complete-core-stuff"
     (h/assert-submaps
      [{:label "frequencies", :detail "clojure.core/frequencies"}]
-     (f.completion/completion "file:///d.clj" 1 49))
+     (f.completion/completion (h/file-uri "file:///d.clj") 1 49))
     (testing "complete symbols from alias"
       (h/assert-submaps
        [{:label "d-alias/bar"
          :kind :variable}
         {:label "d-alias/barbaz", :kind :function}]
-       (f.completion/completion "file:///e.clj" 4 10))))
+       (f.completion/completion (h/file-uri "file:///e.clj") 4 10))))
   (testing "complete cljc files"
     (h/assert-submaps
      [{:label "alpaca/alpha" :kind :variable}
       {:label "alpaca/baff" :kind :variable}
       {:label "alpaca/barr" :kind :variable}
       {:label "alpaca/bazz" :kind :variable}]
-     (f.completion/completion "file:///a.cljc" 2 8)))
+     (f.completion/completion (h/file-uri "file:///a.cljc") 2 8)))
   (testing "complete-core-stuff"
     (h/assert-submaps
      [{:label "frequencies", :detail "clojure.core/frequencies"}]
-     (f.completion/completion "file:///d.clj" 1 49))
+     (f.completion/completion (h/file-uri "file:///d.clj") 1 49))
     (h/assert-submaps
      [{:label "System", :detail "java.lang.System"}]
-     (f.completion/completion "file:///e.clj" 3 6)))
+     (f.completion/completion (h/file-uri "file:///e.clj") 3 6)))
   (testing "complete non symbols doesn't blow up"
-    (is (= nil (f.completion/completion "file:///e.clj" 5 3))))
+    (is (= nil (f.completion/completion (h/file-uri "file:///e.clj") 5 3))))
   (testing "complete all available namespace definitions when inside require"
     (h/assert-submaps
      [{:label "alpaca.ns" :kind :module}
       {:label "alpaca.ns" :kind :module}]
-     (f.completion/completion "file:///f.clj" 2 21)))
+     (f.completion/completion (h/file-uri "file:///f.clj") 2 21)))
   (testing "complete locals"
     (h/assert-submaps
      [{:label "ba" :kind :property}
@@ -105,9 +105,9 @@
       {:label "baz"}
        ;; TODO should complete local refer
       #_{:label "baq"}]
-     (f.completion/completion "file:///g.clj" 2 18)))
+     (f.completion/completion (h/file-uri "file:///g.clj") 2 18)))
   (testing "complete without prefix return all available completions"
-    (is (< 100 (count (f.completion/completion "file:///g.clj" 3 1))))))
+    (is (< 100 (count (f.completion/completion (h/file-uri "file:///g.clj") 3 1))))))
 
 (deftest completing-full-ns
   (h/load-code-and-locs
@@ -115,11 +115,11 @@
            "(def foo 1)"))
   (let [[[full-ns-r full-ns-c]] (h/load-code-and-locs
                                  (h/code "(ns foo)"
-                                         "(alpaca.ns/f|)") "file:///b.clj")]
+                                         "(alpaca.ns/f|)") (h/file-uri "file:///b.clj"))]
     (testing "completing a project full ns"
       (h/assert-submaps
        [{:label "alpaca.ns/foo" :kind :variable}]
-       (f.completion/completion "file:///b.clj" full-ns-r full-ns-c)))))
+       (f.completion/completion (h/file-uri "file:///b.clj") full-ns-r full-ns-c)))))
 
 (deftest completing-with-reader-macros
   (let [[[before-reader-r before-reader-c]
@@ -130,17 +130,17 @@
                                                    "1"
                                                    "#?(:clj \"clojure\" :cljs \"clojurescript\")"
                                                    "1"
-                                                   "some-fun|") "file:///a.cljc")]
+                                                   "some-fun|") (h/file-uri "file:///a.cljc"))]
     (testing "before reader macro"
       (h/assert-submaps
        [{:label         "some-function"
          :kind          :variable}]
-       (f.completion/completion "file:///a.cljc" before-reader-r before-reader-c)))
+       (f.completion/completion (h/file-uri "file:///a.cljc") before-reader-r before-reader-c)))
     (testing "after reader macro"
       (h/assert-submaps
        [{:label         "some-function"
          :kind          :variable}]
-       (f.completion/completion "file:///a.cljc" after-reader-r after-reader-c)))))
+       (f.completion/completion (h/file-uri "file:///a.cljc") after-reader-r after-reader-c)))))
 
 (deftest resolve-item-test
   (h/load-code-and-locs "(ns a) (def foo \"Some docs\" 1)")
@@ -148,19 +148,19 @@
     (is (= {:label "Some" :kind :module}
            (f.completion/resolve-item {:label "Some" :kind :module}))))
   (testing "When element contains data of a element/knows the element"
-    (is (= {:label "foo" :documentation ["a/foo\n\n----\nSome docs\n----\n/a.clj"] :kind :variable}
+    (is (= {:label "foo" :documentation [(str "a/foo\n\n----\nSome docs\n----\n" (h/file-path "/a.clj"))] :kind :variable}
            (f.completion/resolve-item {:label "foo"
                                        :kind :variable
                                        :data {:name "foo"
-                                              :filename "/a.clj"
+                                              :filename (h/file-path "/a.clj")
                                               :name-row 1
                                               :name-col 13}}))))
   (testing "When element contains data of a element/knows the element"
-    (is (= {:label "foo" :documentation ["a/foo\n\n----\nSome docs\n----\n/a.clj"] :kind :function}
+    (is (= {:label "foo" :documentation [(str "a/foo\n\n----\nSome docs\n----\n" (h/file-path "/a.clj"))] :kind :function}
            (f.completion/resolve-item {:label "foo"
                                        :kind :function
                                        :data {:name "foo"
-                                              :filename "/a.clj"
+                                              :filename (h/file-path "/a.clj")
                                               :name-row 1
                                               :name-col 13
                                               :ns "a"}})))))
@@ -169,26 +169,26 @@
   (h/load-code-and-locs
    (h/code "(ns some-ns)"
            "(def foob 1)"
-           "(defn barb [] foo)") "file:///a.clj")
+           "(defn barb [] foo)") (h/file-uri "file:///a.clj"))
   (h/load-code-and-locs
    (h/code "(ns alpaca.ns)"
            "(def foo 1)"
-           "(defn bar [] foo)") "file:///b.clj")
+           "(defn bar [] foo)") (h/file-uri "file:///b.clj"))
   (let [[[refer-vec-r refer-vec-c]] (h/load-code-and-locs
                                      (h/code "(ns foo"
-                                             "  (:require [alpaca.ns :refer [|]]))") "file:///c.clj")
+                                             "  (:require [alpaca.ns :refer [|]]))") (h/file-uri "file:///c.clj"))
         [[ba-refer-r ba-refer-c]] (h/load-code-and-locs
                                      (h/code "(ns foo"
-                                             "  (:require [alpaca.ns :refer [ba|]]))") "file:///d.clj")]
+                                             "  (:require [alpaca.ns :refer [ba|]]))") (h/file-uri "file:///d.clj"))]
     (testing "completing all available refers"
       (h/assert-submaps
         [{:label "bar" :kind :function}
          {:label "foo" :kind :variable}]
-       (f.completion/completion "file:///c.clj" refer-vec-r refer-vec-c)))
+       (f.completion/completion (h/file-uri "file:///c.clj") refer-vec-r refer-vec-c)))
     (testing "completing specific refer"
       (h/assert-submaps
         [{:label "bar" :kind :function}]
-       (f.completion/completion "file:///d.clj" ba-refer-r ba-refer-c)))))
+       (f.completion/completion (h/file-uri "file:///d.clj") ba-refer-r ba-refer-c)))))
 
 (deftest completing-known-snippets
   (h/load-code-and-locs
@@ -199,7 +199,7 @@
     (swap! db/db merge {:client-capabilities {:text-document {:completion {:completion-item {:snippet-support false}}}}})
     (h/assert-submaps
       []
-      (f.completion/completion "file:///a.clj" 2 9)))
+      (f.completion/completion (h/file-uri "file:///a.clj") 2 9)))
 
   (testing "completing with snippets enable return all available snippets"
     (swap! db/db merge {:client-capabilities {:text-document {:completion {:completion-item {:snippet-support true}}}}})
@@ -209,7 +209,7 @@
         :insert-text "(comment\n  $0\n  )"
         :kind :snippet
         :insert-text-format :snippet}]
-      (filter (comp #(= "comment$" %) :label) (f.completion/completion "file:///a.clj" 2 9)))))
+      (filter (comp #(= "comment$" %) :label) (f.completion/completion (h/file-uri "file:///a.clj") 2 9)))))
 
 (deftest completing-user-snippets
   (h/load-code-and-locs
@@ -231,4 +231,4 @@
                     :new-text "(let [$1] $0(+ 1 2))"}
         :kind :snippet
         :insert-text-format :snippet}]
-      (filter (comp #(= "wrap-in-let-sexpr$" %) :label) (f.completion/completion "file:///a.clj" 3 10)))))
+      (filter (comp #(= "wrap-in-let-sexpr$" %) :label) (f.completion/completion (h/file-uri "file:///a.clj") 3 10)))))

--- a/test/clojure_lsp/features/diagnostics_test.clj
+++ b/test/clojure_lsp/features/diagnostics_test.clj
@@ -9,11 +9,11 @@
 
 (deftest lint-project-public-vars
   (h/load-code-and-locs "(ns some-ns) (defn foo [a b] (+ a b))")
-  (h/load-code-and-locs "(ns some-ns) (defn -main [& _args] 1)" "file:///b.clj")
+  (h/load-code-and-locs "(ns some-ns) (defn -main [& _args] 1)" (h/file-uri "file:///b.clj"))
   (testing "when linter level is :off"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:level :off}}}})
     (is (= []
-           (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db))))
+           (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db))))
   (testing "when linter level is :info"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:level :info}}}})
     (h/assert-submaps
@@ -23,7 +23,7 @@
        :tags [1]
        :severity 3
        :source "clojure-lsp"}]
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "when linter level is :warning"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:level :warning}}}})
     (h/assert-submaps
@@ -33,7 +33,7 @@
        :tags [1]
        :severity 2
        :source "clojure-lsp"}]
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "when linter level is :error"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:level :error}}}})
     (h/assert-submaps
@@ -43,7 +43,7 @@
        :tags [1]
        :severity 1
        :source "clojure-lsp"}]
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "linter level by default is :info"
     (swap! db/db merge {:settings {}})
     (h/assert-submaps
@@ -53,35 +53,35 @@
        :tags [1]
        :severity 3
        :source "clojure-lsp"}]
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "excluding the whole ns"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:exclude #{'some-ns}}}}})
     (h/assert-submaps
      []
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "excluding the simple var from ns"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:exclude #{'foo}}}}})
     (h/assert-submaps
      []
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "excluding the specific function"
     (swap! db/db merge {:settings {:linters {:unused-public-var {:exclude #{'some-ns/foo}}}}})
     (h/assert-submaps
      []
-     (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "excluding specific syms"
     (swap! db/db merge {})
     (h/assert-submaps
       []
-     (#'f.diagnostic/find-diagnostics "file:///b.clj" @db/db))))
+     (#'f.diagnostic/find-diagnostics (h/file-uri "file:///b.clj") @db/db))))
 
 (deftest lint-clj-kondo-findings
   (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))")
-  (h/load-code-and-locs "(ns other-ns) (assert )" "file:///b.clj")
+  (h/load-code-and-locs "(ns other-ns) (assert )" (h/file-uri "file:///b.clj"))
   (testing "when linter level is :off"
     (swap! db/db merge {:settings {:linters {:clj-kondo {:level :off}}}})
     (is (= []
-           (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db))))
+           (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db))))
   (testing "when linter level is not :off"
     (swap! db/db merge {:settings {:linters {:clj-kondo {:level :error}}}})
     (h/assert-submaps [{:range {:start {:line 0 :character 29} :end {:line 0 :character 32}}
@@ -90,7 +90,7 @@
                         :tags [1]
                         :severity 2
                         :source "clj-kondo"}]
-                      (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+                      (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "when linter is not specified"
     (swap! db/db merge {:settings {}})
     (h/assert-submaps [{:range {:start {:line 0 :character 29} :end {:line 0 :character 32}}
@@ -99,7 +99,7 @@
                         :tags [1]
                         :severity 2
                         :source "clj-kondo"}]
-                      (#'f.diagnostic/find-diagnostics "file:///a.clj" @db/db)))
+                      (#'f.diagnostic/find-diagnostics (h/file-uri "file:///a.clj") @db/db)))
   (testing "when inside expression?"
     (swap! db/db merge {:settings {}})
     (h/assert-submaps [{:range {:start {:line 0 :character 14} :end {:line 0 :character 23}}
@@ -108,4 +108,4 @@
                         :tags []
                         :severity 1
                         :source "clj-kondo"}]
-                      (#'f.diagnostic/find-diagnostics "file:///b.clj" @db/db))))
+                      (#'f.diagnostic/find-diagnostics (h/file-uri "file:///b.clj") @db/db))))

--- a/test/clojure_lsp/features/file_management_test.clj
+++ b/test/clojure_lsp/features/file_management_test.clj
@@ -24,18 +24,18 @@
   (testing "when it has a project root and not a source-path"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
                                    :source-paths #{(h/file-uri "file:///user/project/bla")}}
-                        :project-root (h/file-uri "file:///user/project")})
+                        :project-root-uri (h/file-uri "file:///user/project")})
     (is (nil? (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj")))))
   (testing "when it has a project root and a source-path"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
                                    :source-paths #{(h/file-path "/user/project/src")}}
-                        :project-root (h/file-uri "file:///user/project")})
+                        :project-root-uri (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
            (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj")))))
   (testing "when it has a project root a source-path on mono repos"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
                                    :source-paths #{(h/file-path "/user/project/src/clj")
                                                    (h/file-path "/user/project/src/cljs")}}
-                        :project-root (h/file-uri "file:///user/project")})
+                        :project-root-uri (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
            (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/clj/foo/bar.clj"))))))

--- a/test/clojure_lsp/features/file_management_test.clj
+++ b/test/clojure_lsp/features/file_management_test.clj
@@ -20,22 +20,22 @@
 (deftest uri->namespace
   (testing "when don't have a project root"
     (reset! db/db {})
-    (is (nil? (#'f.file-management/uri->namespace "file:///user/project/src/foo/bar.clj"))))
+    (is (nil? (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj")))))
   (testing "when it has a project root and not a source-path"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
-                                   :source-paths #{"file:///user/project/bla"}}
-                        :project-root "file:///user/project"})
-    (is (nil? (#'f.file-management/uri->namespace "file:///user/project/src/foo/bar.clj"))))
+                                   :source-paths #{(h/file-uri "file:///user/project/bla")}}
+                        :project-root (h/file-uri "file:///user/project")})
+    (is (nil? (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj")))))
   (testing "when it has a project root and a source-path"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
-                                   :source-paths #{"/user/project/src"}}
-                        :project-root "file:///user/project"})
+                                   :source-paths #{(h/file-path "/user/project/src")}}
+                        :project-root (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
-           (#'f.file-management/uri->namespace "file:///user/project/src/foo/bar.clj"))))
+           (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj")))))
   (testing "when it has a project root a source-path on mono repos"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
-                                   :source-paths #{"/user/project/src/clj"
-                                                   "/user/project/src/cljs"}}
-                        :project-root "file:///user/project"})
+                                   :source-paths #{(h/file-path "/user/project/src/clj")
+                                                   (h/file-path "/user/project/src/cljs")}}
+                        :project-root (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
-           (#'f.file-management/uri->namespace "file:///user/project/src/clj/foo/bar.clj")))))
+           (#'f.file-management/uri->namespace (h/file-uri "file:///user/project/src/clj/foo/bar.clj"))))))

--- a/test/clojure_lsp/features/hover_test.clj
+++ b/test/clojure_lsp/features/hover_test.clj
@@ -25,7 +25,7 @@
       (let [sym "a/foo"
             sig "[x]"
             doc "Some cool docs :foo"
-            filename "/a.clj"]
+            filename (h/file-path "/a.clj")]
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
             (is (= [(join [sym
@@ -34,7 +34,7 @@
                            doc
                            "----"
                            filename])]
-                   (:contents (f.hover/hover "/a.clj" foo-row foo-col)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col)))))
           (testing "markdown"
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
@@ -44,7 +44,7 @@
                                   doc
                                   "\n----"
                                   (str "*[" filename "](" filename ")*")])}
-                   (:contents (f.hover/hover "/a.clj" foo-row foo-col))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
@@ -54,7 +54,7 @@
                            doc
                            "----"
                            filename])]
-                   (:contents (f.hover/hover "/a.clj" foo-row foo-col)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col)))))
 
           (testing "markdown"
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -64,12 +64,12 @@
                                   doc
                                   "\n----"
                                   (str "*[" filename "](" filename ")*")])}
-                   (:contents (f.hover/hover "/a.clj" foo-row foo-col))))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col))))))))
 
     (testing "without docs"
       (let [sym "a/bar"
             sig "[y]"
-            filename "/a.clj"]
+            filename (h/file-path "/a.clj")]
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
             (swap! db/db merge {:settings {:show-docs-arity-on-same-line? false} :client-capabilities nil})
@@ -77,7 +77,7 @@
                            sig
                            "" "----"
                            filename])]
-                   (:contents (f.hover/hover "/a.clj" bar-row bar-col)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col)))))
           (testing "markdown"
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
@@ -85,7 +85,7 @@
                                   start-code sig end-code
                                   "----"
                                   (str "*[" filename "](" filename ")*")])}
-                   (:contents (f.hover/hover "/a.clj" bar-row bar-col))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
@@ -93,7 +93,7 @@
             (is (= [(join [(str sym " " sig)
                            "" "----"
                            filename])]
-                   (:contents (f.hover/hover "/a.clj" bar-row bar-col)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col)))))
 
           (testing "markdown"
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -101,4 +101,4 @@
                     :value (join [start-code (str sym " " sig) end-code
                                   "----"
                                   (str "*[" filename "](" filename ")*")])}
-                   (:contents (f.hover/hover "/a.clj" bar-row bar-col))))))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col))))))))))

--- a/test/clojure_lsp/features/rename_test.clj
+++ b/test/clojure_lsp/features/rename_test.clj
@@ -11,16 +11,16 @@
          a-binding-start a-binding-stop
          a-local-usage-start a-local-usage-stop] (h/load-code-and-locs
                                                    "|:a| (let [{:keys [:|a|]} {}] |a|)"
-                                                   "file:///a.cljc")]
+                                                   (h/file-uri "file:///a.cljc"))]
     (testing "should not rename plain keywords"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename "file:///a.cljc" ":b" row col))]
+            changes (:changes (f.rename/rename (h/file-uri "file:///a.cljc") ":b" row col))]
         (is (= nil changes))))
 
     (testing "should rename local in destructure not keywords"
       (let [[row col] a-binding-start
-            changes (:changes (f.rename/rename "file:///a.cljc" ":b" row col))]
-        (is (= {"file:///a.cljc" [{:new-text "b" :range (h/->range a-binding-start a-binding-stop)}
+            changes (:changes (f.rename/rename (h/file-uri "file:///a.cljc") ":b" row col))]
+        (is (= {(h/file-uri "file:///a.cljc") [{:new-text "b" :range (h/->range a-binding-start a-binding-stop)}
                                   {:new-text "b" :range (h/->range a-local-usage-start a-local-usage-stop)}]}
                changes))))))
 
@@ -35,10 +35,10 @@
                   "    :c/d 2"
                   "    :_/e 3"
                   "    ::f 4}")
-          "file:///a.cljc")]
+          (h/file-uri "file:///a.cljc"))]
     (testing "renaming keywords renames correctly namespaced maps as well"
       (let [[row col] a-b-start
-            changes (:changes (f.rename/rename "file:///a.cljc" ":a/g" row col))]
-        (is (= {"file:///a.cljc" [{:new-text ":a/g" :range (h/->range a-b-start a-b-stop)}
+            changes (:changes (f.rename/rename (h/file-uri "file:///a.cljc") ":a/g" row col))]
+        (is (= {(h/file-uri "file:///a.cljc") [{:new-text ":a/g" :range (h/->range a-b-start a-b-stop)}
                                   {:new-text ":g" :range (h/->range b-ns-start b-ns-stop)}]}
                changes))))))

--- a/test/clojure_lsp/features/resolve_macro_test.clj
+++ b/test/clojure_lsp/features/resolve_macro_test.clj
@@ -15,9 +15,9 @@
                                 "(+ 1 2)"))
   (testing "inside a macro usage"
     (is (= 'some-ns/foo
-           (f.resolve-macro/find-full-macro-symbol-to-resolve "file:///a.clj" 3 7))))
+           (f.resolve-macro/find-full-macro-symbol-to-resolve (h/file-uri "file:///a.clj") 3 7))))
   (testing "not inside a macro usage"
-    (is (not (f.resolve-macro/find-full-macro-symbol-to-resolve "file:///a.clj" 4 5)))))
+    (is (not (f.resolve-macro/find-full-macro-symbol-to-resolve (h/file-uri "file:///a.clj") 4 5)))))
 
 (deftest resolve-macro-as
   (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
@@ -27,4 +27,4 @@
                                 "(+ 1 2)"))
   (testing "resolving macro as def"
     (is (= "{:lint-as {some-ns/foo clojure.core/def}}\n"
-           (#'f.resolve-macro/resolve-macro-as "file:///a.clj" 3 7 "clojure.core/def" ".any-clj-kondo/config.edn")))))
+           (#'f.resolve-macro/resolve-macro-as (h/file-uri "file:///a.clj") 3 7 "clojure.core/def" ".any-clj-kondo/config.edn")))))

--- a/test/clojure_lsp/features/semantic_tokens_test.clj
+++ b/test/clojure_lsp/features/semantic_tokens_test.clj
@@ -82,30 +82,30 @@
             0 2 3 1 -1
             2 0 3 1 -1
             1 1 7 2 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "macro refered tokens"
     (h/load-code-and-locs
       (code "(ns some.ns (:require [clojure.test :refer [deftest]]))"
             "(deftest some-test 1)"))
     (is (= [0 44 7 2 -1
             1 1 7 2 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "macro core tokens"
     (h/load-code-and-locs (code "(comment 1)"))
     (is (= [0 1 7 2 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "function declared tokens"
     (h/load-code-and-locs (code "(def foo 1)"
                                 "foo"))
     (is (= [0 1 3 2 -1
             1 0 3 1 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "type alias for function tokens"
     (h/load-code-and-locs (code "(ns some.ns (:require [foo.bar :as fb]))"
                                 "fb/some-foo-bar"))
     (is (= [1 0 2 0 -1
             0 3 12 1 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "java classes for function tokens"
     (h/load-code-and-locs (code "(ns some.ns)"
                                 "^java.lang.String \"\""
@@ -114,7 +114,7 @@
     (is (= [1 1 16 1 -1
             1 0 6 4 -1
             1 1 6 4 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "keywords for keyword tokens"
     (h/load-code-and-locs (code "(ns some.ns)"
                                 ":foo"
@@ -123,7 +123,7 @@
     (is (= [1 0 4 3 -1
             1 0 12 3 -1
             1 0 5 3 -1]
-           (semantic-tokens/full-tokens "file:///a.clj"))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj")))))
   (testing "locals destructuring for variable tokens"
     (h/load-code-and-locs (code "(fn [{:keys [foo bar]}])"))
     (is (= [0 1 2 2 -1
@@ -131,7 +131,7 @@
             0 0 5 3 -1
             0 7 3 5 -1
             0 4 3 5 -1]
-           (semantic-tokens/full-tokens "file:///a.clj")))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj"))))))
 
 (deftest range-tokens
   (testing "tokens only for range"
@@ -143,4 +143,4 @@
             "baz"))
     (is (= [2 0 3 1 -1
             1 1 7 2 -1]
-           (semantic-tokens/range-tokens "file:///a.clj" {:name-row 3 :name-col 0 :name-end-row 4 :name-end-col 0})))))
+           (semantic-tokens/range-tokens (h/file-uri "file:///a.clj") {:name-row 3 :name-col 0 :name-end-row 4 :name-end-col 0})))))

--- a/test/clojure_lsp/features/signature_help_test.clj
+++ b/test/clojure_lsp/features/signature_help_test.clj
@@ -9,13 +9,13 @@
 (deftest signature-help-unavailable
   (testing "insider defn"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b]| (bar 1 2))")]
-      (is (= nil (f.signature-help/signature-help "file:///a.clj" row col)))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col)))))
   (testing "inside let binding"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b] (let [a 1]| (bar 1 2)))")]
-      (is (= nil (f.signature-help/signature-help "file:///a.clj" row col)))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col)))))
   (testing "inside unknown function"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b] (let [a 1] (bar |1 2)))")]
-      (is (= nil (f.signature-help/signature-help "file:///a.clj" row col))))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col))))))
 
 (deftest signature-help-cursor-position
   (let [[[before-r before-c]
@@ -31,31 +31,31 @@
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" before-r before-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") before-r before-c))))
     (testing "after function name"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" after-r after-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c))))
     (testing "on first arg"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" first-arg-r first-arg-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c))))
     (testing "on second arg"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" second-arg-r second-arg-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c))))
     (testing "outside function"
       (is (= nil
-             (f.signature-help/signature-help "file:///a.clj" outside-r outside-c))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") outside-r outside-c))))))
 
 (deftest signature-help-multiple-signatures
   (testing "With fixed arities"
@@ -80,7 +80,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" zero-r zero-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -91,7 +91,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" one-r one-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -102,7 +102,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" two-r two-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c))))
       (testing "three arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -113,7 +113,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help "file:///a.clj" three-r three-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c))))
       (testing "four arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -124,7 +124,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help "file:///a.clj" four-r four-c))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c))))))
   (testing "With & rest arity only"
     (let [[[zero-r zero-c]
            [one-r one-c]
@@ -138,19 +138,19 @@
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" zero-r zero-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [& rest])"
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" one-r one-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [& rest])"
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" two-r two-c))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c))))))
   (testing "With fixed arities and & rest arity"
     (let [[[zero-r zero-c]
            [one-r one-c]
@@ -171,7 +171,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" zero-r zero-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -180,7 +180,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help "file:///a.clj" one-r one-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -189,7 +189,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help "file:///a.clj" two-r two-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c))))
       (testing "three arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -198,7 +198,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help "file:///a.clj" three-r three-c))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c))))
       (testing "four arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -207,7 +207,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help "file:///a.clj" four-r four-c)))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c)))))))
 
 (deftest signature-help-active-parameter
   (let [[[first-arg-r first-arg-c]
@@ -222,25 +222,25 @@
                                          {:label "& more"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" first-arg-r first-arg-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c))))
     (testing "on second arg"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" second-arg-r second-arg-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c))))
     (testing "on third arg"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" third-arg-r third-arg-c))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") third-arg-r third-arg-c))))
     (testing "on end of the function"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help "file:///a.clj" end-function-r end-function-c))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") end-function-r end-function-c))))))

--- a/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -13,55 +13,55 @@
                                 "(defn alpacas [a b] alpac)"))
   (h/load-code-and-locs (h/code "(ns foo.goat.ns (:require [foo.alpaca.ns :as a]))"
                                 "(defn goats-from-alpacas [alpacas] (map inc alpacas))")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (testing "querying all symbols"
     (is (= [{:name "foo.alpaca.ns"
              :kind :namespace
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 0 :character 0} :end {:line 0 :character 17}}}}
             {:name "my-alpapapaca"
              :kind :variable
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}
             {:name "alpac"
              :kind :variable
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 2 :character 0} :end {:line 2 :character 13}}}}
             {:name "alpacas"
              :kind :function
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}
             {:kind :namespace,
              :location {:range {:end {:character 15, :line 0}, :start {:character 0, :line 0}},
-                        :uri "file:///b.clj"},
+                        :uri (h/file-uri "file:///b.clj")},
              :name "foo.goat.ns"}
             {:kind :function,
              :location {:range {:end {:character 53, :line 1}, :start {:character 0, :line 1}},
-                        :uri "file:///b.clj"},
+                        :uri (h/file-uri "file:///b.clj")},
              :name "goats-from-alpacas"}]
            (f.workspace-symbols/workspace-symbols ""))))
   (testing "querying a specific function using fuzzy search"
     (is (= [{:name "foo.alpaca.ns"
              :kind :namespace
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 0 :character 0} :end {:line 0 :character 17}}}}
             {:name "alpacas"
              :kind :function
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}
             {:name "my-alpapapaca"
              :kind :variable
              :location
-             {:uri "file:///a.clj"
+             {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}
             {:kind :function,
              :location {:range {:end {:character 53, :line 1}, :start {:character 0, :line 1}},
-                        :uri "file:///b.clj"},
+                        :uri (h/file-uri "file:///b.clj")},
              :name "goats-from-alpacas"}]
            (f.workspace-symbols/workspace-symbols "alpaca")))))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -12,6 +12,20 @@
 
 (defn code [& strings] (clojure.string/join "\n" strings))
 
+(deftest initialize
+  (testing "detects URI format with lower-case drive letter and encoded colons"
+    (reset! db/db {})
+    (handlers/initialize "file:///c%3A/project/root" {} {})
+    (is (= {:encode-colons-in-path?   true
+            :upper-case-drive-letter? false}
+           (get-in @db/db [:settings :uri-format]))))
+  (testing "detects URI format with upper-case drive letter and non-encoded colons"
+    (reset! db/db {})
+    (handlers/initialize "file:///C:/project/root" {} {})
+    (is (= {:encode-colons-in-path?   false
+            :upper-case-drive-letter? true}
+           (get-in @db/db [:settings :uri-format])))))
+
 (deftest did-open
   (reset! db/db {})
   (testing "opening a existing file"

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -26,7 +26,7 @@
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
                                    :source-paths #{(h/file-path "/project/src")}}
                         :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}
-                        :project-root (h/file-uri "file:///project")})
+                        :project-root-uri (h/file-uri "file:///project")})
     (alter-var-root #'db/edits-chan (constantly (async/chan 1)))
     (let [_ (h/load-code-and-locs "" (h/file-uri "file:///project/src/foo/bar.clj"))
           changes (:document-changes (h/edits-or-timeout))]
@@ -181,7 +181,7 @@
                                               {:new-text "::xx/bar" :range (h/->range ba2-kw-start ba2-kw-stop)}]}
                changes))))
     (testing "on a namespace"
-      (reset! db/db {:project-root (h/file-uri "file:///my-project")
+      (reset! db/db {:project-root-uri (h/file-uri "file:///my-project")
                      :settings {:source-paths #{(h/file-path "/my-project/src") (h/file-path "/my-project/test")}}
                      :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
       (h/load-code-and-locs "(ns foo.bar-baz)" (h/file-uri "file:///my-project/src/foo/bar_baz.clj"))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -10,7 +10,7 @@
 
 (h/reset-db-after-test)
 
-(defn code [& strings] (clojure.string/join "\n" strings))
+(defn code [& strings] (string/join "\n" strings))
 
 (deftest initialize
   (testing "detects URI format with lower-case drive letter and encoded colons"

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -17,25 +17,25 @@
   (testing "opening a existing file"
     (let [_ (h/load-code-and-locs "(ns a) (when)")
           diagnostics (h/diagnostics-or-timeout)]
-      (is (some? (get-in @db/db [:analysis "/a.clj"])))
+      (is (some? (get-in @db/db [:analysis (h/file-path "/a.clj")])))
       (h/assert-submaps
         [{:code "missing-body-in-when"}
          {:code "invalid-arity"}]
         diagnostics)))
   (testing "opening a new file adding the ns"
     (swap! db/db merge {:settings {:auto-add-ns-to-new-files? true
-                                   :source-paths #{"/project/src"}}
+                                   :source-paths #{(h/file-path "/project/src")}}
                         :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}
-                        :project-root "file:///project"})
+                        :project-root (h/file-uri "file:///project")})
     (alter-var-root #'db/edits-chan (constantly (async/chan 1)))
-    (let [_ (h/load-code-and-locs "" "file:///project/src/foo/bar.clj")
+    (let [_ (h/load-code-and-locs "" (h/file-uri "file:///project/src/foo/bar.clj"))
           changes (:document-changes (h/edits-or-timeout))]
       (h/assert-submaps
         [{:edits [{:range {:start {:line 0, :character 0}
                            :end {:line 0, :character 0}}
                    :new-text "(ns foo.bar)"}]}]
         changes)
-      (is (some? (get-in @db/db [:analysis "/project/src/foo/bar.clj"]))))))
+      (is (some? (get-in @db/db [:analysis (h/file-path "/project/src/foo/bar.clj")]))))))
 
 (deftest document-symbol
   (let [code "(ns a) (def bar ::bar) (def ^:m baz 1)"
@@ -54,41 +54,41 @@
     (testing "clj files"
       (h/load-code-and-locs code)
       (h/assert-submaps result
-                        (handlers/document-symbol {:textDocument "file:///a.clj"})))
+                        (handlers/document-symbol {:textDocument (h/file-uri "file:///a.clj")})))
     (testing "cljs files"
-      (h/load-code-and-locs code "file:///b.cljs")
+      (h/load-code-and-locs code (h/file-uri "file:///b.cljs"))
       (h/assert-submaps result
-                        (handlers/document-symbol {:textDocument "file:///b.cljs"})))
+                        (handlers/document-symbol {:textDocument (h/file-uri "file:///b.cljs")})))
     (testing "cljc files"
-      (h/load-code-and-locs code "file:///c.cljc")
+      (h/load-code-and-locs code (h/file-uri "file:///c.cljc"))
       (h/assert-submaps result
-                        (handlers/document-symbol {:textDocument "file:///c.cljc"})))))
+                        (handlers/document-symbol {:textDocument (h/file-uri "file:///c.cljc")})))))
 
 (deftest document-highlight
   (let [[bar-start] (h/load-code-and-locs "(ns a) (def |bar ::bar) (def ^:m baz 1)")]
     (h/assert-submaps
       [{:range {:start {:line 0 :character 12} :end {:line 0 :character 15}}}]
-      (handlers/document-highlight {:textDocument "file:///a.clj"
+      (handlers/document-highlight {:textDocument (h/file-uri "file:///a.clj")
                                     :position (h/->position bar-start)}))))
 
 (deftest references
   (testing "simple single reference"
     (let [[bar-def-pos] (h/load-code-and-locs "(ns a) (def |bar 1)")
-          _ (h/load-code-and-locs "(ns b (:require [a :as foo])) (foo/bar)" "file:///b.clj")]
+          _ (h/load-code-and-locs "(ns b (:require [a :as foo])) (foo/bar)" (h/file-uri "file:///b.clj"))]
       (h/assert-submaps
-        [{:uri "file:///b.clj"
+        [{:uri (h/file-uri "file:///b.clj")
           :range {:start {:line 0 :character 31} :end {:line 0 :character 38}}}]
-        (handlers/references {:textDocument "file:///a.clj"
+        (handlers/references {:textDocument (h/file-uri "file:///a.clj")
                               :position (h/->position bar-def-pos)}))))
   (testing "when including declaration"
     (let [[bar-def-pos] (h/load-code-and-locs "(ns a) (def |bar 1)")
-          _ (h/load-code-and-locs "(ns b (:require [a :as foo])) (foo/bar)" "file:///b.clj")]
+          _ (h/load-code-and-locs "(ns b (:require [a :as foo])) (foo/bar)" (h/file-uri "file:///b.clj"))]
       (h/assert-submaps
-        [{:uri "file:///a.clj"
+        [{:uri (h/file-uri "file:///a.clj")
           :range {:start {:line 0 :character 12} :end {:line 0 :character 15}}}
-         {:uri "file:///b.clj"
+         {:uri (h/file-uri "file:///b.clj")
           :range {:start {:line 0 :character 31} :end {:line 0 :character 38}}}]
-        (handlers/references {:textDocument "file:///a.clj"
+        (handlers/references {:textDocument (h/file-uri "file:///a.clj")
                               :position (h/->position bar-def-pos)
                               :context {:includeDeclaration true}})))))
 
@@ -97,105 +97,105 @@
          akw-start akwbar-start akwbar-stop
          abaz-start abaz-stop] (h/load-code-and-locs (code "(ns a.aa)"
                                                            "(def |bar| |::|bar|)"
-                                                           "(def ^:m |baz| 1)") "file:///a.clj")
+                                                           "(def ^:m |baz| 1)") (h/file-uri "file:///a.clj"))
         [balias-start balias-stop
          ba1-start _ba1-stop
          bbar-start bbar-stop
          ba2-kw-start ba2-kw-stop] (h/load-code-and-locs (code "(ns b.bb (:require [a.aa :as |aa|]))"
                                                                "(def x |aa|/|bar|)"
                                                                "|::aa/bar|"
-                                                               ":aa/bar") "file:///b.clj")
+                                                               ":aa/bar") (h/file-uri "file:///b.clj"))
         [cbar-start cbar-stop
          cbaz-start cbaz-stop] (h/load-code-and-locs (code "(ns c.cc (:require [a.aa :as aa]))"
                                                            "(def x aa/|bar|)"
-                                                           "^:xab aa/|baz|") "file:///c.clj")
+                                                           "^:xab aa/|baz|") (h/file-uri "file:///c.clj"))
         [d-name-kw-start d-name-kw-stop] (h/load-code-and-locs (code "(ns d.dd)"
-                                                                     "(def name |::name|)") "file:///d.clj")
+                                                                     "(def name |::name|)") (h/file-uri "file:///d.clj"))
         [kw-aliased-start kw-aliased-stop
          kw-unaliased-start kw-unaliased-stop] (h/load-code-and-locs (code "(ns e.ee (:require [d.dd :as dd]))"
                                                                            "(def name |::dd/name|)"
-                                                                           "(def other-name |:d.dd/name|)") "file:///e.clj")
+                                                                           "(def other-name |:d.dd/name|)") (h/file-uri "file:///e.clj"))
         [main-uname-kw-start main-uname-kw-end] (h/load-code-and-locs (code "(ns main (:require [user :as u]))"
-                                                                            "(def name |::u/name|)") "file:///main.cljc")
+                                                                            "(def name |::u/name|)") (h/file-uri "file:///main.cljc"))
         [uname-kw-start uname-kw-end] (h/load-code-and-locs (code "(ns user)"
-                                                                  "(def name |::name|)") "file:///user.cljc")]
+                                                                  "(def name |::name|)") (h/file-uri "file:///user.cljc"))]
     (testing "on symbol without namespace"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///a.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///a.clj")
                                                 :position (h/->position abar-start)
                                                 :newName "foo"}))]
-        (is (= {"file:///a.clj" [{:new-text "foo" :range (h/->range abar-start abar-stop)}]
-                "file:///b.clj" [{:new-text "foo" :range (h/->range bbar-start bbar-stop)}]
-                "file:///c.clj" [{:new-text "foo" :range (h/->range cbar-start cbar-stop)}]}
+        (is (= {(h/file-uri "file:///a.clj") [{:new-text "foo" :range (h/->range abar-start abar-stop)}]
+                (h/file-uri "file:///b.clj") [{:new-text "foo" :range (h/->range bbar-start bbar-stop)}]
+                (h/file-uri "file:///c.clj") [{:new-text "foo" :range (h/->range cbar-start cbar-stop)}]}
                changes))))
     (testing "on symbol with metadata namespace"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///a.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///a.clj")
                                                 :position (h/->position abaz-start)
                                                 :newName "qux"}))]
-        (is (= {"file:///a.clj" [{:new-text "qux" :range (h/->range abaz-start abaz-stop)}]
-                "file:///c.clj" [{:new-text "qux" :range (h/->range cbaz-start cbaz-stop)}]}
+        (is (= {(h/file-uri "file:///a.clj") [{:new-text "qux" :range (h/->range abaz-start abaz-stop)}]
+                (h/file-uri "file:///c.clj") [{:new-text "qux" :range (h/->range cbaz-start cbaz-stop)}]}
                changes))))
     (testing "on symbol with namespace adds existing namespace"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///b.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///b.clj")
                                                 :position (h/->position [(first bbar-start) (dec (second bbar-start))])
                                                 :newName "foo"}))]
-        (is (= {"file:///a.clj" [{:new-text "foo" :range (h/->range abar-start abar-stop)}]
-                "file:///b.clj" [{:new-text "foo" :range (h/->range bbar-start bbar-stop)}]
-                "file:///c.clj" [{:new-text "foo" :range (h/->range cbar-start cbar-stop)}]}
+        (is (= {(h/file-uri "file:///a.clj") [{:new-text "foo" :range (h/->range abar-start abar-stop)}]
+                (h/file-uri "file:///b.clj") [{:new-text "foo" :range (h/->range bbar-start bbar-stop)}]
+                (h/file-uri "file:///c.clj") [{:new-text "foo" :range (h/->range cbar-start cbar-stop)}]}
                changes))))
     (testing "on symbol with namespace removes passed-in namespace"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///b.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///b.clj")
                                                 :position (h/->position bbar-start)
                                                 :newName "aa/foo"}))]
-        (is (= {"file:///a.clj" [{:new-text "foo" :range (h/->range abar-start abar-stop)}]
-                "file:///b.clj" [{:new-text "foo" :range (h/->range bbar-start bbar-stop)}]
-                "file:///c.clj" [{:new-text "foo" :range (h/->range cbar-start cbar-stop)}]}
+        (is (= {(h/file-uri "file:///a.clj") [{:new-text "foo" :range (h/->range abar-start abar-stop)}]
+                (h/file-uri "file:///b.clj") [{:new-text "foo" :range (h/->range bbar-start bbar-stop)}]
+                (h/file-uri "file:///c.clj") [{:new-text "foo" :range (h/->range cbar-start cbar-stop)}]}
                changes))))
     (testing "on ::keyword"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///a.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///a.clj")
                                                 :position (h/->position akwbar-start)
                                                 :newName "::foo"}))]
-        (is (= {"file:///a.clj" [{:new-text "::foo" :range (h/->range akw-start akwbar-stop)}]
-                "file:///b.clj" [{:new-text "::aa/foo" :range (h/->range ba2-kw-start ba2-kw-stop)}]}
+        (is (= {(h/file-uri "file:///a.clj") [{:new-text "::foo" :range (h/->range akw-start akwbar-stop)}]
+                (h/file-uri "file:///b.clj") [{:new-text "::aa/foo" :range (h/->range ba2-kw-start ba2-kw-stop)}]}
                changes))))
     (testing "on single-name-namespace'd keyword"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///main.cljc"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///main.cljc")
                                                 :position (h/->position main-uname-kw-start)
                                                 :newName "::full-name"}))]
-        (is (= {"file:///main.cljc" [{:new-text "::u/full-name" :range (h/->range main-uname-kw-start main-uname-kw-end)}]
-                "file:///user.cljc" [{:new-text "::full-name" :range (h/->range uname-kw-start uname-kw-end)}]}
+        (is (= {(h/file-uri "file:///main.cljc") [{:new-text "::u/full-name" :range (h/->range main-uname-kw-start main-uname-kw-end)}]
+                (h/file-uri "file:///user.cljc") [{:new-text "::full-name" :range (h/->range uname-kw-start uname-kw-end)}]}
                changes))))
     (testing "on qualified keyword without alias"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///d.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///d.clj")
                                                 :position (h/->position d-name-kw-start)
                                                 :newName "::other-name"}))]
-        (is (= {"file:///d.clj" [{:new-text "::other-name" :range (h/->range d-name-kw-start d-name-kw-stop)}]
-                "file:///e.clj" [{:new-text "::dd/other-name" :range (h/->range kw-aliased-start kw-aliased-stop)}
-                                 {:new-text ":d.dd/other-name" :range (h/->range kw-unaliased-start kw-unaliased-stop)}]}
+        (is (= {(h/file-uri "file:///d.clj") [{:new-text "::other-name" :range (h/->range d-name-kw-start d-name-kw-stop)}]
+                (h/file-uri "file:///e.clj") [{:new-text "::dd/other-name" :range (h/->range kw-aliased-start kw-aliased-stop)}
+                                              {:new-text ":d.dd/other-name" :range (h/->range kw-unaliased-start kw-unaliased-stop)}]}
                changes))))
     (testing "on alias changes namespaces inside file"
-      (let [changes (:changes (handlers/rename {:textDocument "file:///b.clj"
+      (let [changes (:changes (handlers/rename {:textDocument (h/file-uri "file:///b.clj")
                                                 :position (h/->position balias-start)
                                                 :newName "xx"}))]
-        (is (= {"file:///b.clj" [{:new-text "xx" :range (h/->range balias-start balias-stop)}
-                                 {:new-text "xx/bar" :range (h/->range ba1-start bbar-stop)}
-                                 {:new-text "::xx/bar" :range (h/->range ba2-kw-start ba2-kw-stop)}]}
+        (is (= {(h/file-uri "file:///b.clj") [{:new-text "xx" :range (h/->range balias-start balias-stop)}
+                                              {:new-text "xx/bar" :range (h/->range ba1-start bbar-stop)}
+                                              {:new-text "::xx/bar" :range (h/->range ba2-kw-start ba2-kw-stop)}]}
                changes))))
     (testing "on a namespace"
-      (reset! db/db {:project-root "file:///my-project"
-                     :settings {:source-paths #{"/my-project/src" "/my-project/test"}}
+      (reset! db/db {:project-root (h/file-uri "file:///my-project")
+                     :settings {:source-paths #{(h/file-path "/my-project/src") (h/file-path "/my-project/test")}}
                      :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
-      (h/load-code-and-locs "(ns foo.bar-baz)" "file:///my-project/src/foo/bar_baz.clj")
+      (h/load-code-and-locs "(ns foo.bar-baz)" (h/file-uri "file:///my-project/src/foo/bar_baz.clj"))
       (is (= {:document-changes
               [{:text-document {:version 0
-                                :uri "file:///my-project/src/foo/bar_baz.clj"}
+                                :uri (h/file-uri "file:///my-project/src/foo/bar_baz.clj")}
                 :edits [{:range
                          {:start {:line 0 :character 4}
                           :end {:line 0 :character 15}}
                          :new-text "foo.baz-qux"}]}
                {:kind "rename"
-                :old-uri "file:///my-project/src/foo/bar_baz.clj"
-                :new-uri "file:///my-project/src/foo/baz_qux.clj"}]}
-             (handlers/rename {:textDocument "file:///my-project/src/foo/bar_baz.clj"
+                :old-uri (h/file-uri "file:///my-project/src/foo/bar_baz.clj")
+                :new-uri (h/file-uri "file:///my-project/src/foo/baz_qux.clj")}]}
+             (handlers/rename {:textDocument (h/file-uri "file:///my-project/src/foo/bar_baz.clj")
                                :position {:line 0 :character 4}
                                :newName "foo.baz-qux"}))))))
 
@@ -301,43 +301,43 @@
             (map :message usages))))))
 
 (deftest test-formatting
-  (reset! db/db {:documents {"file:///a.clj" {:text "(a  )\n(b c d)"}}})
+  (reset! db/db {:documents {(h/file-uri "file:///a.clj") {:text "(a  )\n(b c d)"}}})
   (is (= "(a)\n(b c d)"
-         (:new-text (first (handlers/formatting {:textDocument "file:///a.clj"}))))))
+         (:new-text (first (handlers/formatting {:textDocument (h/file-uri "file:///a.clj")}))))))
 
 (deftest test-formatting-noop
-  (reset! db/db {:documents {"file:///a.clj" {:text "(a)\n(b c d)"}}})
-  (let [r (handlers/formatting {:textDocument "file:///a.clj"})]
+  (reset! db/db {:documents {(h/file-uri "file:///a.clj") {:text "(a)\n(b c d)"}}})
+  (let [r (handlers/formatting {:textDocument (h/file-uri "file:///a.clj")})]
     (is (empty? r))
     (is (vector? r))))
 
 (deftest test-range-formatting
-  (reset! db/db {:documents {"file:///a.clj" {:text "(a  )\n(b c d)"}}})
+  (reset! db/db {:documents {(h/file-uri "file:///a.clj") {:text "(a  )\n(b c d)"}}})
   (is (= [{:range {:start {:line 0 :character 0}
                    :end {:line 0 :character 5}}
            :new-text "(a)"}]
-         (handlers/range-formatting "file:///a.clj" {:row 1 :col 1 :end-row 1 :end-col 4}))))
+         (handlers/range-formatting (h/file-uri "file:///a.clj") {:row 1 :col 1 :end-row 1 :end-col 4}))))
 
 (deftest test-code-actions-handle
   (h/load-code-and-locs (str "(ns some-ns)\n"
                              "(def foo)")
-                        "file:///a.clj")
+                        (h/file-uri "file:///a.clj"))
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"
                              "(defn baz []\n"
                              "  bar)")
-                        "file:///b.clj")
+                        (h/file-uri "file:///b.clj"))
   (h/load-code-and-locs (str "(ns another-ns)\n"
                              "(def bar ons/bar)\n"
                              "(def foo sns/foo)\n"
                              "(deftest some-test)\n"
                              "MyClass.\n"
                              "Date.")
-                        "file:///c.clj")
+                        (h/file-uri "file:///c.clj"))
   (testing "when it has unresolved-namespace and can find namespace"
     (is (some #(= (:title %) "Add missing 'some-ns' require")
               (handlers/code-actions
-                {:textDocument "file:///c.clj"
+                {:textDocument (h/file-uri "file:///c.clj")
                  :context {:diagnostics [{:code "unresolved-namespace"
                                           :range {:start {:line 2 :character 10}}}]}
                  :range {:start {:line 2 :character 10}}}))))
@@ -345,14 +345,14 @@
     (swap! db/db merge {:client-capabilities {:workspace {:workspace-edit false}}})
     (is (not-any? #(= (:title %) "Clean namespace")
                   (handlers/code-actions
-                    {:textDocument "file:///b.clj"
+                    {:textDocument (h/file-uri "file:///b.clj")
                      :context {:diagnostics []}
                      :range {:start {:line 1 :character 1}}}))))
   (testing "with workspace edit client capability"
     (swap! db/db merge {:client-capabilities {:workspace {:workspace-edit true}}})
     (is (some #(= (:title %) "Clean namespace")
               (handlers/code-actions
-                {:textDocument "file:///b.clj"
+                {:textDocument (h/file-uri "file:///b.clj")
                  :context {:diagnostics []}
                  :range {:start {:line 1 :character 1}}})))))
 
@@ -366,16 +366,16 @@
                              "(s/defn baz []\n"
                              "  (bar 2 3))\n"))
   (testing "references lens"
-    (is (= '({:range
-              {:start {:line 1 :character 5} :end {:line 1 :character 8}}
-              :data ["file:///a.clj" 2 6]}
-             {:range
-              {:start {:line 2 :character 7} :end {:line 2 :character 11}}
-              :data ["file:///a.clj" 3 8]}
-             {:range
-              {:start {:line 4 :character 6} :end {:line 4 :character 9}}
-              :data ["file:///a.clj" 5 7]})
-           (handlers/code-lens {:textDocument "file:///a.clj"})))))
+    (is (= (list {:range
+                  {:start {:line 1 :character 5} :end {:line 1 :character 8}}
+                  :data [(h/file-uri "file:///a.clj") 2 6]}
+                 {:range
+                  {:start {:line 2 :character 7} :end {:line 2 :character 11}}
+                  :data [(h/file-uri "file:///a.clj") 3 8]}
+                 {:range
+                  {:start {:line 4 :character 6} :end {:line 4 :character 9}}
+                  :data [(h/file-uri "file:///a.clj") 5 7]})
+           (handlers/code-lens {:textDocument (h/file-uri "file:///a.clj")})))))
 
 (deftest test-code-lens-resolve
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -394,8 +394,8 @@
                                 :character 12}}
               :command {:title   "0 references"
                         :command "code-lens-references"
-                        :arguments ["file:///a.clj" 0 5]}}
-             (handlers/code-lens-resolve {:data ["file:///a.clj" 0 5]
+                        :arguments [(h/file-uri "file:///a.clj") 0 5]}}
+             (handlers/code-lens-resolve {:data [(h/file-uri "file:///a.clj") 0 5]
                                           :range {:start {:line 0 :character 5} :end {:line 0 :character 12}}}))))
     (testing "some lens"
       (is (= {:range   {:start {:line      1
@@ -404,8 +404,8 @@
                                 :character 12}}
               :command {:title   "1 reference"
                         :command "code-lens-references"
-                        :arguments ["file:///a.clj" 2 6]}}
-             (handlers/code-lens-resolve {:data ["file:///a.clj" 2 6]
+                        :arguments [(h/file-uri "file:///a.clj") 2 6]}}
+             (handlers/code-lens-resolve {:data [(h/file-uri "file:///a.clj") 2 6]
                                           :range {:start {:line 1 :character 5} :end {:line 1 :character 12}}})))
       (is (= {:range   {:start {:line      2
                                 :character 7}
@@ -413,6 +413,6 @@
                                 :character 11}}
               :command {:title   "1 reference"
                         :command "code-lens-references"
-                        :arguments ["file:///a.clj" 3 8]}}
-             (handlers/code-lens-resolve {:data ["file:///a.clj" 3 8]
+                        :arguments [(h/file-uri "file:///a.clj") 3 8]}}
+             (handlers/code-lens-resolve {:data [(h/file-uri "file:///a.clj") 3 8]
                                           :range {:start {:line 2 :character 7} :end {:line 2 :character 11}}}))))))

--- a/test/clojure_lsp/interop_test.clj
+++ b/test/clojure_lsp/interop_test.clj
@@ -5,10 +5,10 @@
   (:import
     (org.eclipse.lsp4j TextDocumentIdentifier)))
 
-(deftest document->decoded-uri
-    (is (= (interop/document->decoded-uri (TextDocumentIdentifier. ""))  ""))
-    (is (= (interop/document->decoded-uri (TextDocumentIdentifier. "http%3A%2F%2Ffoo%20bar%2F"))  "http://foo bar/"))
-    (is (= (interop/document->decoded-uri (TextDocumentIdentifier. "http://foo bar/"))  "http://foo bar/"))
-    (is (= (interop/document->decoded-uri (TextDocumentIdentifier. "jar:file:///Users/clojure-1.9.0.jar!/clojure/string.clj"))  "jar:file:///Users/clojure-1.9.0.jar!/clojure/string.clj"))
-    (is (= (interop/document->decoded-uri (TextDocumentIdentifier. "zipfile:///something.jar::something/file.cljc"))  "zipfile:///something.jar::something/file.cljc"))
-    (is (= (interop/document->decoded-uri (TextDocumentIdentifier. "zipfile:///something.jar%3A%3Asomething/file.cljc"))  "zipfile:///something.jar::something/file.cljc")))
+(deftest document->uri
+  (is (= ""
+         (interop/document->uri (TextDocumentIdentifier. ""))))
+  (is (= "http://example.com/foo"
+         (interop/document->uri (TextDocumentIdentifier. "http://example.com/foo"))))
+  (is (= "file:///foo/bar/c.clj"
+         (interop/document->uri (TextDocumentIdentifier. "file:///foo/bar/c.clj")))))

--- a/test/clojure_lsp/queries_test.clj
+++ b/test/clojure_lsp/queries_test.clj
@@ -11,43 +11,43 @@
 (deftest project-analysis
   (testing "when dependency-scheme is zip"
     (reset! db/db {})
-    (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 2 (count (q/filter-project-analysis (:analysis @db/db))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db merge {:settings {:dependency-scheme "jar"}})
-    (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 2 (count (q/filter-project-analysis (:analysis @db/db)))))))
 
 (deftest external-analysis
   (testing "when dependency-scheme is zip"
     (reset! db/db {})
-    (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (q/filter-external-analysis (:analysis @db/db))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db merge {:settings {:dependency-scheme "jar"}})
-    (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (q/filter-external-analysis (:analysis @db/db)))))))
 
 (deftest find-first-order-by-project-analysis
   (testing "with pred that applies for both project and external analysis"
     (reset! db/db {})
-    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (let [element (#'q/find-first-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (reset! db/db {})
-    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (let [element (#'q/find-first-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
       (is (= (h/file-path "/a.clj") (:filename element))))))
 
@@ -85,12 +85,12 @@
          [alias-use-r alias-use-c]
          [x-use-r x-use-c]
          [unknown-r unknown-c]] (h/load-code-and-locs a-code)
-        [[a-foo-kw-r a-foo-kw-c]] (h/load-code-and-locs "|:foo-kw" "file:///b.clj")
+        [[a-foo-kw-r a-foo-kw-c]] (h/load-code-and-locs "|:foo-kw" (h/file-uri "file:///b.clj"))
         [[b-foo-kw-r b-foo-kw-c]
          [c-foo-kw-r c-foo-kw-c]
          [d-foo-kw-r d-foo-kw-c]] (h/load-code-and-locs (h/code "|:foo-kw"
                                                                 "(let [{:keys [|foo-kw]} {|:foo-kw 1}]"
-                                                                "  foo-kw)") "file:///c.clj")
+                                                                "  foo-kw)") (h/file-uri "file:///c.clj"))
         ana (:analysis @db/db)]
     (h/assert-submaps
      [{:name 'x :name-row x-r :name-col x-c}
@@ -124,7 +124,7 @@
          [param-use-r param-use-c]
          [alias-use-r alias-use-c]
          [x-use-r x-use-c]
-         [unknown-r unknown-c]] (h/load-code-and-locs code "file:///a.cljc")
+         [unknown-r unknown-c]] (h/load-code-and-locs code (h/file-uri "file:///a.cljc"))
         ana (:analysis @db/db)]
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
@@ -153,7 +153,7 @@
          [alias-use-r alias-use-c]
          [x-use-r x-use-c]
          [unknown-r unknown-c]] (h/load-code-and-locs code)
-        _ (h/load-code-and-locs "(ns d.e.f) (def foo 1)" "file:///b.clj")
+        _ (h/load-code-and-locs "(ns d.e.f) (def foo 1)" (h/file-uri "file:///b.clj"))
         ana (:analysis @db/db)]
     (h/assert-submap
       {:name 'x :name-row x-r :name-col x-c}
@@ -172,9 +172,9 @@
 
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
   (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
-        _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///a.clj")
+        _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "file:///a.clj"))
         [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
-                                                      "|f/bar") "file:///b.clj")
+                                                      "|f/bar") (h/file-uri "file:///b.clj"))
         ana (:analysis @db/db)]
     (h/assert-submap
      {:name 'bar :filename (h/file-path "/a.clj")}
@@ -182,28 +182,28 @@
 
 (deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
   (testing "when on a clj file"
-    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
-          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/other-jar.cljs")
+    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
+          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
           [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
-                                                        "|f/bar") "file:///b.clj")
+                                                        "|f/bar") (h/file-uri "file:///b.clj"))
           ana (:analysis @db/db)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
         (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
   (testing "when on a cljs file"
-    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
-          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/other-jar.cljs")
+    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
+          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
           [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
-                                                        "|f/bar") "file:///b.cljs")
+                                                        "|f/bar") (h/file-uri "file:///b.cljs"))
           ana (:analysis @db/db)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
         (q/find-definition-from-cursor ana (h/file-path "/b.cljs") bar-r bar-c))))
   (testing "when on a cljc file"
-    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
-          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/other-jar.cljs")
+    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
+          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
           [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
-                                                        "|f/bar") "file:///b.cljc")
+                                                        "|f/bar") (h/file-uri "file:///b.cljc"))
           ana (:analysis @db/db)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
@@ -214,7 +214,7 @@
                           (h/code "(ns foo)"
                                   "(declare bar)"
                                   "(|bar)"
-                                  "(defn bar [] 1)") "file:///a.clj")
+                                  "(defn bar [] 1)") (h/file-uri "file:///a.clj"))
         ana (:analysis @db/db)]
     (h/assert-submap
      {:name 'bar :filename (h/file-path "/a.clj") :defined-by 'clojure.core/defn :row 4}

--- a/test/clojure_lsp/queries_test.clj
+++ b/test/clojure_lsp/queries_test.clj
@@ -13,13 +13,13 @@
     (reset! db/db {})
     (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///some.jar:some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
     (is (= 2 (count (q/filter-project-analysis (:analysis @db/db))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db merge {:settings {:dependency-scheme "jar"}})
     (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///some.jar:some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
     (is (= 2 (count (q/filter-project-analysis (:analysis @db/db)))))))
 
 (deftest external-analysis
@@ -27,29 +27,29 @@
     (reset! db/db {})
     (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///some.jar:some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
     (is (= 1 (count (q/filter-external-analysis (:analysis @db/db))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db merge {:settings {:dependency-scheme "jar"}})
     (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
-    (h/load-code-and-locs "(ns foo.bar)" "file:///some.jar:some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
     (is (= 1 (count (q/filter-external-analysis (:analysis @db/db)))))))
 
 (deftest find-first-order-by-project-analysis
   (testing "with pred that applies for both project and external analysis"
     (reset! db/db {})
-    (h/load-code-and-locs "(ns foo.bar)" "file:///some.jar:some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
     (let [element (#'q/find-first-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
-      (is (= "/a.clj" (:filename element)))))
+      (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (reset! db/db {})
-    (h/load-code-and-locs "(ns foo.bar)" "file:///some.jar:some-file.clj")
+    (h/load-code-and-locs "(ns foo.bar)" "jar:file:///some.jar!/some-file.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///a.clj")
     (h/load-code-and-locs "(ns foo.bar)" "file:///b.clj")
     (let [element (#'q/find-first-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
-      (is (= "/a.clj" (:filename element))))))
+      (is (= (h/file-path "/a.clj") (:filename element))))))
 
 (deftest find-element-under-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -63,16 +63,16 @@
         ana (:analysis @db/db)]
     (h/assert-submap
       '{:alias f-alias}
-      (q/find-element-under-cursor ana "/a.clj" alias-r alias-c))
+      (q/find-element-under-cursor ana (h/file-path "/a.clj") alias-r alias-c))
     (h/assert-submap
       '{:name x}
-      (q/find-element-under-cursor ana "/a.clj" x-r x-c))
+      (q/find-element-under-cursor ana (h/file-path "/a.clj") x-r x-c))
     (h/assert-submap
       '{:name filename}
-      (q/find-element-under-cursor ana "/a.clj" param-r param-c))
+      (q/find-element-under-cursor ana (h/file-path "/a.clj") param-r param-c))
     (h/assert-submap
       '{:name unknown}
-      (q/find-element-under-cursor ana "/a.clj" unknown-r unknown-c))))
+      (q/find-element-under-cursor ana (h/file-path "/a.clj") unknown-r unknown-c))))
 
 (deftest find-references-from-cursor
   (let [a-code (h/code "(ns a.b.c (:require [d.e.f :as |f-alias]))"
@@ -95,24 +95,24 @@
     (h/assert-submaps
      [{:name 'x :name-row x-r :name-col x-c}
       {:name 'x :name-row x-use-r :name-col x-use-c}]
-     (q/find-references-from-cursor ana "/a.clj" x-r x-c true))
+     (q/find-references-from-cursor ana (h/file-path "/a.clj") x-r x-c true))
     (h/assert-submaps
      [{:name 'filename :name-row param-r :name-col param-c}
       {:name 'filename :name-row param-use-r :name-col param-use-c}]
-     (q/find-references-from-cursor ana "/a.clj" param-r param-c true))
+     (q/find-references-from-cursor ana (h/file-path "/a.clj") param-r param-c true))
     (h/assert-submaps
      ['{:name unknown}]
-     (q/find-references-from-cursor ana "/a.clj" unknown-r unknown-c true))
+     (q/find-references-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c true))
     (h/assert-submaps
      [{:alias 'f-alias :name-row alias-r :name-col alias-c}
       {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-     (q/find-references-from-cursor ana "/a.clj" alias-r alias-c true))
+     (q/find-references-from-cursor ana (h/file-path "/a.clj") alias-r alias-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-foo-kw-r :name-col a-foo-kw-c}
        {:name "foo-kw" :name-row b-foo-kw-r :name-col b-foo-kw-c}
        {:name "foo-kw" :name-row d-foo-kw-r :name-col d-foo-kw-c}
        {:name "foo-kw" :name-row c-foo-kw-r :name-col c-foo-kw-c}]
-     (q/find-references-from-cursor ana "/c.clj" b-foo-kw-r b-foo-kw-c true))))
+     (q/find-references-from-cursor ana (h/file-path "/c.clj") b-foo-kw-r b-foo-kw-c true))))
 
 (deftest find-references-from-cursor-cljc
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -129,18 +129,18 @@
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor ana "/a.cljc" x-r x-c true))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor ana "/a.cljc" param-r param-c true))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor ana "/a.cljc" unknown-r unknown-c true))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor ana "/a.cljc" alias-r alias-c true))))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") alias-r alias-c true))))
 
 (deftest find-definition-from-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -157,57 +157,57 @@
         ana (:analysis @db/db)]
     (h/assert-submap
       {:name 'x :name-row x-r :name-col x-c}
-      (q/find-definition-from-cursor ana "/a.clj" x-use-r x-use-c))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") x-use-r x-use-c))
     (h/assert-submap
       {:name 'filename :name-row param-r :name-col param-c}
-      (q/find-definition-from-cursor ana "/a.clj" param-use-r param-use-c))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") param-use-r param-use-c))
     (is (= nil
-           (q/find-definition-from-cursor ana "/a.clj" unknown-r unknown-c)))
+           (q/find-definition-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c)))
     (h/assert-submap
-      {:name 'foo :filename "/b.clj" :ns 'd.e.f}
-      (q/find-definition-from-cursor ana "/a.clj" alias-use-r alias-use-c))
+      {:name 'foo :filename (h/file-path "/b.clj") :ns 'd.e.f}
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-use-r alias-use-c))
     (h/assert-submap
       {:alias 'f-alias :name-row alias-r :name-col alias-c}
-      (q/find-definition-from-cursor ana "/a.clj" alias-r alias-c))))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-r alias-c))))
 
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
-  (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:some-jar.clj")
+  (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
         _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///a.clj")
         [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                       "|f/bar") "file:///b.clj")
         ana (:analysis @db/db)]
     (h/assert-submap
-     {:name 'bar :filename "/a.clj"}
-     (q/find-definition-from-cursor ana "/b.clj" bar-r bar-c))))
+     {:name 'bar :filename (h/file-path "/a.clj")}
+     (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
 
 (deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
   (testing "when on a clj file"
-    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:some-jar.clj")
-          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:other-jar.cljs")
+    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
+          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/other-jar.cljs")
           [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") "file:///b.clj")
           ana (:analysis @db/db)]
       (h/assert-submap
-        {:name 'bar :filename "/some.jar:some-jar.clj"}
-        (q/find-definition-from-cursor ana "/b.clj" bar-r bar-c))))
+        {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
+        (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
   (testing "when on a cljs file"
-    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:some-jar.clj")
-          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:other-jar.cljs")
+    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
+          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/other-jar.cljs")
           [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") "file:///b.cljs")
           ana (:analysis @db/db)]
       (h/assert-submap
-        {:name 'bar :filename "/some.jar:other-jar.cljs"}
-        (q/find-definition-from-cursor ana "/b.cljs" bar-r bar-c))))
+        {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
+        (q/find-definition-from-cursor ana (h/file-path "/b.cljs") bar-r bar-c))))
   (testing "when on a cljc file"
-    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:some-jar.clj")
-          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "file:///some.jar:other-jar.cljs")
+    (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
+          _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/other-jar.cljs")
           [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") "file:///b.cljc")
           ana (:analysis @db/db)]
       (h/assert-submap
-        {:name 'bar :filename "/some.jar:some-jar.clj"}
-        (q/find-definition-from-cursor ana "/b.cljc" bar-r bar-c)))))
+        {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
+        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r bar-c)))))
 
 (deftest find-definition-from-cursor-when-declared
   (let [[[bar-r bar-c]] (h/load-code-and-locs
@@ -217,74 +217,74 @@
                                   "(defn bar [] 1)") "file:///a.clj")
         ana (:analysis @db/db)]
     (h/assert-submap
-     {:name 'bar :filename "/a.clj" :defined-by 'clojure.core/defn :row 4}
-     (q/find-definition-from-cursor ana "/a.clj" bar-r bar-c))))
+     {:name 'bar :filename (h/file-path "/a.clj") :defined-by 'clojure.core/defn :row 4}
+     (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c))))
 
 (deftest find-unused-aliases
   (testing "used require via alias"
     (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo")
     (is (= '#{}
-           (q/find-unused-aliases (:findings @db/db) "/a.clj"))))
+           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "used require via full-ns"
     (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo")
     (is (= '#{}
-           (q/find-unused-aliases (:findings @db/db) "/a.clj"))))
+           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "full-ns require"
     (h/load-code-and-locs "(ns a (:require [x] y)) foo")
     (is (= '#{}
-           (q/find-unused-aliases (:findings @db/db) "/a.clj"))))
+           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "single unused-alias"
     (h/load-code-and-locs "(ns a (:require [x :as f]))")
     (is (= '#{x}
-           (q/find-unused-aliases (:findings @db/db) "/a.clj"))))
+           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "used and unused aliases"
     (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o")
     (is (= '#{y bar}
-           (q/find-unused-aliases (:findings @db/db) "/a.clj")))))
+           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj"))))))
 
 (deftest find-unused-refers
   (testing "used require via refer"
     (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo")
     (is (= '#{}
-           (q/find-unused-refers (:findings @db/db) "/a.clj"))))
+           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "multiple used refers"
     (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz")
     (is (= '#{}
-           (q/find-unused-refers (:findings @db/db) "/a.clj"))))
+           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "single unused refer"
     (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))")
     (is (= '#{x/foo}
-           (q/find-unused-refers (:findings @db/db) "/a.clj"))))
+           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "multiple unused refer"
     (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))")
     (is (= '#{x/foo x/bar}
-           (q/find-unused-refers (:findings @db/db) "/a.clj"))))
+           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "multiple unused refer and used"
     (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar")
     (is (= '#{x/foo x/baz}
-           (q/find-unused-refers (:findings @db/db) "/a.clj")))))
+           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj"))))))
 
 (deftest find-unused-imports
   (testing "single used full import"
     (h/load-code-and-locs "(ns a (:import java.util.Date)) Date.")
     (is (= '#{}
-           (q/find-unused-imports (:findings @db/db) "/a.clj"))))
+           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "single unused full import"
     (h/load-code-and-locs "(ns a (:import java.util.Date))")
     (is (= '#{java.util.Date}
-           (q/find-unused-imports (:findings @db/db) "/a.clj"))))
+           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "multiple unused full imports"
     (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))")
     (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-           (q/find-unused-imports (:findings @db/db) "/a.clj"))))
+           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "multiple unused package imports"
     (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))")
     (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-           (q/find-unused-imports (:findings @db/db) "/a.clj"))))
+           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
   (testing "multiple unused and used imports"
     (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime.")
     (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-           (q/find-unused-imports (:findings @db/db) "/a.clj")))))
+           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj"))))))
 
 (deftest find-local-usages-under-cursor
   (testing "inside let"
@@ -293,11 +293,11 @@
           (h/load-code-and-locs "(ns a) (let [a 2 b 1] |(+ 2 b)| (- 2 a))")]
       (h/assert-submaps
         [{:name 'b}]
-        (q/find-local-usages-under-form (:analysis @db/db) "/a.clj" sum-pos-r sum-pos-c sum-end-pos-r sum-end-pos-c))))
+        (q/find-local-usages-under-form (:analysis @db/db) (h/file-path "/a.clj") sum-pos-r sum-pos-c sum-end-pos-r sum-end-pos-c))))
   (testing "inside defn"
     (let [[[let-pos-r let-pos-c]
            [let-end-pos-r let-end-pos-c]]
           (h/load-code-and-locs "(ns a) (defn ab [b] |(let [a 1] (b a))|) (defn other [c] c)")]
       (h/assert-submaps
         [{:name 'b}]
-        (q/find-local-usages-under-form (:analysis @db/db) "/a.clj" let-pos-r let-pos-c let-end-pos-r let-end-pos-c)))))
+        (q/find-local-usages-under-form (:analysis @db/db) (h/file-path "/a.clj") let-pos-r let-pos-c let-end-pos-r let-end-pos-c)))))

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -3,7 +3,6 @@
     [clojure-lsp.db :as db]
     [clojure-lsp.shared :as shared]
     [clojure-lsp.test-helper :as h]
-    [clojure.string :as string]
     [clojure.test :refer [deftest is testing]]))
 
 (deftest uri->filename

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -6,41 +6,54 @@
     [clojure.string :as string]
     [clojure.test :refer [deftest is testing]]))
 
-(deftest filename->uri
-  (testing "when it is not a jar"
-    (reset! db/db {})
-    (is (= (if h/windows? "file:///C:/some%20project/foo/bar_baz.clj" "file:///some%20project/foo/bar_baz.clj")
-           (shared/filename->uri "/some project/foo/bar_baz.clj"))))
-  (testing "when it is a jar via zipfile"
-    (reset! db/db {})
-    (is (= (if h/windows? "zipfile:///C:/home/some/.m2/some-jar.jar::clojure/core.clj" "zipfile:///home/some/.m2/some-jar.jar::clojure/core.clj")
-           (shared/filename->uri "/home/some/.m2/some-jar.jar:clojure/core.clj"))))
-  (testing "when it is a jar via jarfile"
-    (reset! db/db {:settings {:dependency-scheme "jar"}})
-    (is (= (if h/windows? "jar:file:///C:/home/some/.m2/some-jar.jar!/clojure/core.clj" "jar:file:///home/some/.m2/some-jar.jar!/clojure/core.clj")
-           (shared/filename->uri "/home/some/.m2/some-jar.jar:clojure/core.clj"))))
-  (testing "Windows URIs"
-    (is (= (when h/windows? "file:///c:/c.clj")
-           (when h/windows? (shared/filename->uri "c:\\c.clj"))))))
-
 (deftest uri->filename
   (testing "should decode special characters in file URI"
     (is (= (h/file-path "/path+/encoded characters!")
-           (shared/uri->filename "file:///path%2B/encoded%20characters%21"))))
+           (shared/uri->filename (h/file-uri "file:///path%2B/encoded%20characters%21")))))
   (testing "when it is a jar via zipfile"
     (is (= (h/file-path "/something.jar:something/file.cljc")
-           (shared/uri->filename "zipfile:///something.jar::something/file.cljc"))))
+           (shared/uri->filename (h/file-uri "zipfile:///something.jar::something/file.cljc")))))
   (testing "when it is a jar via zipfile with encoding"
     (is (= (h/file-path "/something.jar:something/file.cljc")
-           (shared/uri->filename "zipfile:///something.jar%3A%3Asomething/file.cljc"))))
+           (shared/uri->filename (h/file-uri "zipfile:///something.jar%3A%3Asomething/file.cljc")))))
   (testing "when it is a jar via jarfile"
     (is (= (str (h/file-path "/Users/clojure-1.9.0.jar") ":clojure/string.clj")
-           (shared/uri->filename "jar:file:///Users/clojure-1.9.0.jar!/clojure/string.clj"))))
+           (shared/uri->filename (h/file-uri "jar:file:///Users/clojure-1.9.0.jar!/clojure/string.clj")))))
   (testing "Windows URIs"
-    (is (= (when h/windows? "c:\\c.clj")
+    (is (= (when h/windows? "C:\\c.clj")
            (when h/windows? (shared/uri->filename "file:/c:/c.clj"))))
-    (is (= (when h/windows? "c:\\c.clj")
+    (is (= (when h/windows? "C:\\c.clj")
            (when h/windows? (shared/uri->filename "file:///c:/c.clj"))))))
+
+(deftest filename->uri
+  (testing "when it is not a jar"
+    (reset! db/db {})
+    (is (= (if h/windows? "file:///c:/some%20project/foo/bar_baz.clj" "file:///some%20project/foo/bar_baz.clj")
+           (shared/filename->uri (h/file-path "/some project/foo/bar_baz.clj")))))
+  (testing "when it is a jar via zipfile"
+    (reset! db/db {})
+    (is (= (if h/windows? "zipfile:///c:/home/some/.m2/some-jar.jar::clojure/core.clj" "zipfile:///home/some/.m2/some-jar.jar::clojure/core.clj")
+           (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj")))))
+  (testing "when it is a jar via jarfile"
+    (reset! db/db {:settings {:dependency-scheme "jar"}})
+    (is (= (if h/windows? "jar:file:///c:/home/some/.m2/some-jar.jar!/clojure/core.clj" "jar:file:///home/some/.m2/some-jar.jar!/clojure/core.clj")
+           (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj")))))
+  (testing "Windows URIs"
+    (reset! db/db {})
+    (is (= (when h/windows? "file:///c:/c.clj")
+           (when h/windows? (shared/filename->uri "c:\\c.clj"))))))
+
+(deftest conform-uri
+  (testing "lower case drive letter and encode colons"
+    (reset! db/db {:settings {:uri-format {:encode-colons-in-path?   true
+                                           :upper-case-drive-letter? false}}})
+    (is (= "file:///c%3A/path"
+           (shared/conform-uri "file:///C:/path"))))
+  (testing "upper case drive letter and do not encode colons"
+    (reset! db/db {:settings {:uri-format {:encode-colons-in-path?   false
+                                           :upper-case-drive-letter? true}}})
+    (is (= "file:///C:/path"
+           (shared/conform-uri "file:///c:/path")))))
 
 (deftest relativize-filepath
   (is (= (h/file-path "some/path.clj")
@@ -55,8 +68,8 @@
 (deftest join-filepaths
   (is (= (h/file-path "/users/melon/toasty/onion")
          (if h/windows?
-           (shared/join-filepaths "C:\\users" "melon\\toasty" "onion")
-           (shared/join-filepaths "/users" "melon/toasty" "onion")))))
+           (shared/join-filepaths (h/file-path "/users") "melon\\toasty" "onion")
+           (shared/join-filepaths (h/file-path "/users") "melon/toasty" "onion")))))
 
 (deftest ->range-test
   (testing "should subtract 1 from row and col values"

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -1,35 +1,62 @@
 (ns clojure-lsp.shared-test
   (:require
-   [clojure-lsp.db :as db]
-   [clojure-lsp.shared :as shared]
-   [clojure.test :refer [deftest is testing]]))
-
-(deftest uri->project-related-path
-  (is (= "/src/my-project/some/ns.clj"
-         (shared/uri->project-related-path "file:///home/foo/bar/my-project/src/my-project/some/ns.clj" "file:///home/foo/bar/my-project"))))
+    [clojure-lsp.db :as db]
+    [clojure-lsp.shared :as shared]
+    [clojure-lsp.test-helper :as h]
+    [clojure.string :as string]
+    [clojure.test :refer [deftest is testing]]))
 
 (deftest filename->uri
-  (testing "when it is not a jar and contains slash"
+  (testing "when it is not a jar"
     (reset! db/db {})
-    (is (= "file:///some-project/foo/bar_baz.clj"
-           (shared/filename->uri "/some-project/foo/bar_baz.clj"))))
-  (testing "when it is not a jar and do not contains slash"
-    (reset! db/db {})
-    (is (= "file:///some-project/foo/bar_baz.clj"
-           (shared/filename->uri "some-project/foo/bar_baz.clj"))))
+    (is (= (if h/windows? "file:///C:/some%20project/foo/bar_baz.clj" "file:///some%20project/foo/bar_baz.clj")
+           (shared/filename->uri "/some project/foo/bar_baz.clj"))))
   (testing "when it is a jar via zipfile"
     (reset! db/db {})
-    (is (= "zipfile:///home/some/.m2/some-jar.jar::clojure/core.clj"
+    (is (= (if h/windows? "zipfile:///C:/home/some/.m2/some-jar.jar::clojure/core.clj" "zipfile:///home/some/.m2/some-jar.jar::clojure/core.clj")
            (shared/filename->uri "/home/some/.m2/some-jar.jar:clojure/core.clj"))))
   (testing "when it is a jar via jarfile"
     (reset! db/db {:settings {:dependency-scheme "jar"}})
-    (is (= "jar:file:////home/some/.m2/some-jar.jar!/clojure/core.clj"
-           (shared/filename->uri "/home/some/.m2/some-jar.jar:clojure/core.clj")))))
+    (is (= (if h/windows? "jar:file:///C:/home/some/.m2/some-jar.jar!/clojure/core.clj" "jar:file:///home/some/.m2/some-jar.jar!/clojure/core.clj")
+           (shared/filename->uri "/home/some/.m2/some-jar.jar:clojure/core.clj"))))
+  (testing "Windows URIs"
+    (is (= (when h/windows? "file:///c:/c.clj")
+           (when h/windows? (shared/filename->uri "c:\\c.clj"))))))
 
 (deftest uri->filename
   (testing "should decode special characters in file URI"
-    (is (= "/path+/encoded characters!"
-           (shared/uri->filename "file:///path%2B/encoded%20characters%21")))))
+    (is (= (h/file-path "/path+/encoded characters!")
+           (shared/uri->filename "file:///path%2B/encoded%20characters%21"))))
+  (testing "when it is a jar via zipfile"
+    (is (= (h/file-path "/something.jar:something/file.cljc")
+           (shared/uri->filename "zipfile:///something.jar::something/file.cljc"))))
+  (testing "when it is a jar via zipfile with encoding"
+    (is (= (h/file-path "/something.jar:something/file.cljc")
+           (shared/uri->filename "zipfile:///something.jar%3A%3Asomething/file.cljc"))))
+  (testing "when it is a jar via jarfile"
+    (is (= (str (h/file-path "/Users/clojure-1.9.0.jar") ":clojure/string.clj")
+           (shared/uri->filename "jar:file:///Users/clojure-1.9.0.jar!/clojure/string.clj"))))
+  (testing "Windows URIs"
+    (is (= (when h/windows? "c:\\c.clj")
+           (when h/windows? (shared/uri->filename "file:/c:/c.clj"))))
+    (is (= (when h/windows? "c:\\c.clj")
+           (when h/windows? (shared/uri->filename "file:///c:/c.clj"))))))
+
+(deftest relativize-filepath
+  (is (= (h/file-path "some/path.clj")
+         (shared/relativize-filepath
+           (h/file-path "/User/rich/some/path.clj")
+           (h/file-path "/User/rich")))))
+
+(deftest uri->relative-filepath
+  (is (= (h/file-path "some foo/path.clj")
+         (shared/uri->relative-filepath "file:///User/ricky%20bar/some%20foo/path.clj" "file:///User/ricky%20bar"))))
+
+(deftest join-filepaths
+  (is (= (h/file-path "/users/melon/toasty/onion")
+         (if h/windows?
+           (shared/join-filepaths "C:\\users" "melon\\toasty" "onion")
+           (shared/join-filepaths "/users" "melon/toasty" "onion")))))
 
 (deftest ->range-test
   (testing "should subtract 1 from row and col values"

--- a/test/clojure_lsp/test_helper.clj
+++ b/test/clojure_lsp/test_helper.clj
@@ -12,7 +12,7 @@
 
 (defn file-path [path]
   (cond-> path windows?
-          (-> (string/replace #"^/" "C:\\\\")
+          (-> (string/replace-first #"^/" "C:\\\\")
               (->> (re-matches #"(.+?)(\.jar:.*)?"))
               (update 1 string/replace "/" "\\")
               rest
@@ -20,7 +20,7 @@
 
 (defn file-uri [uri]
   (cond-> uri windows?
-          (string/replace #"file:///(?!\w:/)" "file:///C:/")))
+          (string/replace #"^(file|zipfile|jar:file):///(?!\w:/)" "$1:///c:/")))
 
 (defn code [& strings] (string/join "\n" strings))
 


### PR DESCRIPTION
This is a follow-up to #437, which I found was not a full solution to its problem. In fact, it might have introduced more problems on the native image due to reflection and a lack of type hints.

## Problems:

- Both encoded and 'decoded' URIs are being passed around. The URIs supplied to the server are being decoded by `interop/document->decoded-uri` and `handlers/did-open` before they reach `uri->filename`, which causes an exception when constructing a `java.net.URI` and prevents features from working.
    - E.g. in the handlers, `file:///some%20path` gets converted to `file:///some path` (the latter is no longer a valid URI)
    - **Proposed solution:**
        - Do not decode URIs unless converting them to a file path (relates to assumption 1)
- `:source-paths` in `crawler/initialize-project` are set using `.getAbsolutePath` (uses native path representation) which on Windows may be inconsistent with the unix-style output of `shared/uri->filename`
    - **Proposed solution:**
        - Ensure all filenames are correct absolute paths in the representation native to the current platform (assumption 5)

## Assumptions:

1. URIs should have a valid format:
    - Windows file URIs should contain a drive letter (or an authority component)
    - URIs should be properly %-encoded (ie no spaces)
    - URIs should always be absolute
    - `"jar:file:////home/some/.m2/some-jar.jar!/clojure/core.clj"` with four slashes is an invalid URI unless this is a UNC path where 'home' is a server
    - `URLDecoder` should not be used to decode URIs.
2. All URIs processed by the server are encoded the same way
    - i.e. the program will never see both `"zipfile:///something.jar%3A%3Asomething/file.cljc"` and `"zipfile:///something.jar::something/file.cljc"`; Windows drive letters will always be either lower case or upper case.
    - This is because URIs are used for uniquely identifying files.
3. `Paths.get().toAbsolutePath()` is the most reliable way of converting a URI into a unique, absolute file path.
    - Assumes (1)
4. `Paths/get` cannot be used for non-`file:` URIs
5. "filename"s are absolute paths in the representation matching the current platform (eg `C:\path` for Windows and `/path` for Unix)
6. Jar filenames are in the format: `C:\canonical\native\path.jar:entry/name.clj` — the entry path always uses `/` delimiters.
    - Assumes:
        - This is also how clj-kondo formats these paths
        - clojure-lsp only obtains its jar filenames from clj-kondo
        - (5)
7. On Windows devices that run the unit tests: the result of `(-> "/" io/file .getCanonicalPath)` is `"C:\\"`

## Summary of Changes

- Assuming (1)
    - Modify test: `shared-test/filename→uri` "when it is a jar via jarfile" — use three slashes for the URI as 'home' is probably not a server in `"jar:file:////home/some/.m2/some-jar.jar!/clojure/core.clj"`
    - For `shared/filename->uri`, add tests for URIs containing Windows drive letters
    - Use correct URI encoding for `integration-test.integration.helper/file->uri`
    - Use valid `jar:file` scheme for jar file URIs in `queries-test`
    - Use `file-uri` helper to ensure URIs used in tests contain a drive letter (`C:`)on Windows.
    - Replace `document->decoded-uri` with `document->uri` (which does not decode the URI) and remove tests for the decoding.
- Assuming (1), (3), (4), (5), (6)
    - Modify `shared/uri->filename` to handle `jar:file` and `zipfile` and to output a native, absolute file path.
- Assuming (1), (5), (6)
    - Modify `shared/filename->uri` to use correct URI encoding. Assume the function only receives absolute paths, and remove the test for relative path inputs.
- Assuming (5)
    - Use `file-path` helper to ensure file paths used in tests use the Windows path representation (with backslashes and drive letter `C:`)
    - In `file-management/uri->namespace`, use the correct file path separator and a new `shared/relativize-filepath` function to ensure the namespace is also obtained on Windows.
    - In `feature.rename/namespace->uri`, use new `shared/join-filepaths` function to ensure a correct URI for the current platform.
- Replace `shared/project-related-path` with the more general `shared/relativize-filepath` — Note: the output no longer has a leading slash (as it is a relative path).
- Given that in most parts of the code, `project-root` is a URI
    - In `db.clj`, replace `project-root` with `project-root-path` to avoid confusion.
    - Modify tests for `config/resolve-config` to pass URIs for the `project-root` instead of file paths.
- Use type hints to avoid reflection which can cause exceptions with the GraalVM native image.

## Further questions

- Should `project-root` be renamed to `project-root-uri` or `project-uri`?
- Should `filename` be renamed to `filepath`? (To me, 'name' implies solely the name of the file without the directory information)