### PR TITLE
Use last definition when showing signature help

### DIFF
--- a/src/clojure_lsp/queries.clj
+++ b/src/clojure_lsp/queries.clj
@@ -39,10 +39,6 @@
   (->> analysis
        (remove-keys #(string/starts-with? (-> % name shared/filename->uri) "file://"))))
 
-(defn ^:private find-first-order-by-project-analysis [pred? analysis]
-  (or (find-first pred? (mapcat val (filter-project-analysis analysis)))
-      (find-first pred? (mapcat val (filter-external-analysis analysis)))))
-
 (defn ^:private find-last-order-by-project-analysis [pred? analysis]
   (or (find-last pred? (mapcat val (filter-project-analysis analysis)))
       (find-last pred? (mapcat val (filter-external-analysis analysis)))))
@@ -91,7 +87,7 @@
 
 (defmethod find-definition :namespace-usages
   [analysis element]
-  (find-first-order-by-project-analysis
+  (find-last-order-by-project-analysis
     #(and (= (:bucket %) :namespace-definitions)
           (= (:name %) (:name element))
           (match-file-lang % element))
@@ -115,7 +111,7 @@
 (defmethod find-definition :keywords
   [analysis element]
   (when (:ns element)
-    (find-first-order-by-project-analysis
+    (find-last-order-by-project-analysis
       #(and (= (:bucket %) :keywords)
             (= (:name %) (:name element))
             (:reg %)

--- a/src/clojure_lsp/queries.clj
+++ b/src/clojure_lsp/queries.clj
@@ -25,6 +25,9 @@
     nil
     coll))
 
+(defn- find-last [pred coll]
+  (find-first pred (reverse coll)))
+
 (defn ^:private remove-keys [pred m]
   (apply dissoc m (filter pred (keys m))))
 
@@ -39,6 +42,10 @@
 (defn ^:private find-first-order-by-project-analysis [pred? analysis]
   (or (find-first pred? (mapcat val (filter-project-analysis analysis)))
       (find-first pred? (mapcat val (filter-external-analysis analysis)))))
+
+(defn ^:private find-last-order-by-project-analysis [pred? analysis]
+  (or (find-last pred? (mapcat val (filter-project-analysis analysis)))
+      (find-last pred? (mapcat val (filter-external-analysis analysis)))))
 
 (defn ^:private match-file-lang
   [check-element match-element]
@@ -92,7 +99,7 @@
 
 (defmethod find-definition :var-usages
   [analysis element]
-  (find-first-order-by-project-analysis
+  (find-last-order-by-project-analysis
     #(and (= (:bucket %) :var-definitions)
           (= (:name %) (:name element))
           (not (= (:defined-by %) 'clojure.core/declare))

--- a/test/clojure_lsp/features/signature_help_test.clj
+++ b/test/clojure_lsp/features/signature_help_test.clj
@@ -57,6 +57,19 @@
       (is (= nil
              (f.signature-help/signature-help (h/file-uri "file:///a.clj") outside-r outside-c))))))
 
+(deftest signature-help-multiple-definitions
+  (let [[[after-r after-c]] (h/load-code-and-locs
+                              (h/code "(def bar)"
+                                      "(defn bar [a b] 1)"
+                                      "(defn foo [a b] (bar| 1 2))"))]
+    (testing "after function name"
+      (is (= {:signatures [{:label "(bar [a b])"
+                            :parameters [{:label "a"}
+                                         {:label "b"}]}]
+              :active-parameter 0
+              :active-signature 0}
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c))))))
+
 (deftest signature-help-multiple-signatures
   (testing "With fixed arities"
     (let [[[zero-r zero-c]

--- a/test/clojure_lsp/queries_test.clj
+++ b/test/clojure_lsp/queries_test.clj
@@ -206,7 +206,7 @@
                                                         "|f/bar") (h/file-uri "file:///b.cljc"))
           ana (:analysis @db/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
+        {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
         (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r bar-c)))))
 
 (deftest find-definition-from-cursor-when-declared

--- a/test/clojure_lsp/queries_test.clj
+++ b/test/clojure_lsp/queries_test.clj
@@ -36,20 +36,20 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (q/filter-external-analysis (:analysis @db/db)))))))
 
-(deftest find-first-order-by-project-analysis
+(deftest find-last-order-by-project-analysis
   (testing "with pred that applies for both project and external analysis"
     (reset! db/db {})
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
-    (let [element (#'q/find-first-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
+    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (reset! db/db {})
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
-    (let [element (#'q/find-first-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
-      (is (= (h/file-path "/a.clj") (:filename element))))))
+    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db))]
+      (is (= (h/file-path "/b.clj") (:filename element))))))
 
 (deftest find-element-under-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"


### PR DESCRIPTION
**Problem**
In case there are redefinitions, clojure-lsp seems to show signature help for first definition. Last definition should be used as it overwrites previous definitions.

**Example**
Clojure itself is using redefinition of `map` where first definition should probably use `declare` instead of `def` (maybe `declare` didn't exist at the time the code was written?). This probably causes `map` to not have signature help.

- here `map` is declared using `def`: https://github.com/clojure/clojure/blob/3c9307e27479d450e3f1cdf7903458b83ebf52d7/src/clj/clojure/core.clj#L1713
- and here it's implemented: https://github.com/clojure/clojure/blob/3c9307e27479d450e3f1cdf7903458b83ebf52d7/src/clj/clojure/core.clj#L2731

**Side effect**
As a side effect of this change, cljs is preferred over clj in this test: https://github.com/clojure-lsp/clojure-lsp/compare/master...nenadalm:signature_help?expand=1#diff-1a73eefdddf48f04bcc32d792584b66cf82fd4ea953f2087304e271daab95015R209 - I don't know if it matters which dialect is used? I guess not, so I just updated the test.