### PR TITLE
clojure-lsp as API / CLI

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
+        org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.clojure/tools.reader {:mvn/version "1.3.5"}
         org.eclipse.lsp4j/org.eclipse.lsp4j {:mvn/version "0.12.0"  :exclusions [org.eclipse.xtend/org.eclipse.xtend.lib]}
         org.eclipse.xtend/org.eclipse.xtend.lib {:mvn/version "2.25.0" :exclusions [com.google.guava/guava]}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,17 @@
+# API (experimental)
+
+clojure-lsp is commonly used in a text editor, but it has its own API featuring the same features that can be used as a library or via CLI. An example is calling the CLI in a CI for cleaning the project namespaces.
+
+## Usage
+
+### CLI
+
+`clojure-lsp --help` should show all available commands and options, clojure-lsp will consider the same rules of configuration, checking `.lsp/config.edn`.
+
+At the moment the features available are:
+
+`clean-ns` - clean the ns form removing unused requires/refers/imports, sorting the form.
+
+### Library
+
+The namespace [`clojure-lsp.api`](https://github.com/clojure-lsp/clojure-lsp/tree/master/src/clojure_lsp/api.clj) should be used as the entrypoint for available features as API, feel free to open a issue for missing features.

--- a/integration-test/integration/api/clean_ns_test.clj
+++ b/integration-test/integration/api/clean_ns_test.clj
@@ -1,0 +1,28 @@
+(ns integration.api.clean-ns-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [integration.lsp :as lsp]))
+
+(lsp/clean-after-test)
+
+(def a-subject-path "./integration-test/sample-test/src/api/clean_ns/a.clj")
+(def a-subject-text (slurp a-subject-path))
+(def a-expected-path "./integration-test/sample-test/fixtures/api/clean_ns/a.clj")
+(def a-expected-text (slurp a-expected-path))
+
+(deftest clean-ns
+  (testing "passing a single namespace"
+    (with-open [rdr (lsp/cli! "clean-ns"
+                              "--project-root" "./integration-test/sample-test"
+                              "--namespace" "api.clean-ns.a")]
+      (is (= "Cleaned api.clean-ns.a\n" (slurp rdr)))
+      (is (= a-expected-text (slurp a-subject-path))))
+    (spit a-subject-path a-subject-text))
+  (testing "passing multiple namespaces but only one is cleanable"
+    (with-open [rdr (lsp/cli! "clean-ns"
+                              "--project-root" "./integration-test/sample-test"
+                              "--namespace" "api.clean-ns.b"
+                              "--namespace" "api.clean-ns.a")]
+      (is (= "Cleaned api.clean-ns.a\n" (slurp rdr)))
+      (is (= a-expected-text (slurp a-subject-path))))
+    (spit a-subject-path a-subject-text)))

--- a/integration-test/integration/lsp.clj
+++ b/integration-test/integration/lsp.clj
@@ -75,6 +75,11 @@
     (alter-var-root #'*stdout* (constantly (io/reader (:out *clojure-lsp-process*))))
     (alter-var-root #'*clojure-lsp-listener* (constantly (listen-output!)))))
 
+(defn cli! [& args]
+  (let [clojure-lsp-binary (first *command-line-args*)]
+    (alter-var-root #'*clojure-lsp-process* (constantly (p/process (into [clojure-lsp-binary] args))))
+    (io/reader (:out *clojure-lsp-process*))))
+
 (defn clean! []
   (reset! server-requests {})
   (reset! server-responses {})

--- a/integration-test/run-all.clj
+++ b/integration-test/run-all.clj
@@ -19,7 +19,8 @@
     integration.formatting-test
     integration.rename-test
     integration.document-highlight-test
-    integration.document-symbol-test])
+    integration.document-symbol-test
+    integration.api.clean-ns-test])
 
 (defn timeout [timeout-ms callback]
   (let [fut (future (callback))

--- a/integration-test/sample-test/fixtures/api/clean_ns/a.clj
+++ b/integration-test/sample-test/fixtures/api/clean_ns/a.clj
@@ -1,0 +1,7 @@
+(ns api.clean-ns.a
+  (:require
+   [api.clean-ns.c :refer [a b c]]))
+
+a
+b
+c

--- a/integration-test/sample-test/src/api/clean_ns/a.clj
+++ b/integration-test/sample-test/src/api/clean_ns/a.clj
@@ -1,0 +1,8 @@
+(ns api.clean-ns.a
+  (:require
+   [clojure.string :as string]
+   [api.clean-ns.c :refer [b c a]]))
+
+a
+b
+c

--- a/integration-test/sample-test/src/api/clean_ns/b.clj
+++ b/integration-test/sample-test/src/api/clean_ns/b.clj
@@ -1,0 +1,5 @@
+(ns api.clean-ns.b)
+
+(def a nil)
+(def b nil)
+(def c nil)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
     - Capabilities: capabilities.md
   - Features: features.md
   - Installation: installation.md
+  - API: api.md
   - Support Us: https://opencollective.com/clojure-lsp
   - Changelog: CHANGELOG.md
 

--- a/src-java/clojure_lsp/ClojureExtensions.java
+++ b/src-java/clojure_lsp/ClojureExtensions.java
@@ -21,8 +21,8 @@ public class ClojureExtensions {
     @SuppressWarnings("unchecked")
     CompletableFuture<String> dependencyContents(TextDocumentIdentifier documentUri) {
         IFn require = Clojure.var("clojure.core", "require");
-        require.invoke(Clojure.read("clojure-lsp.main"));
-        IFn extension = Clojure.var("clojure-lsp.main", "extension");
+        require.invoke(Clojure.read("clojure-lsp.server"));
+        IFn extension = Clojure.var("clojure-lsp.server", "extension");
         return (CompletableFuture<String>) extension.invoke("dependencyContents", documentUri);
     }
 }

--- a/src/clojure_lsp/api.clj
+++ b/src/clojure_lsp/api.clj
@@ -1,44 +1,15 @@
 (ns clojure-lsp.api
   (:require
-   [clojure-lsp.client :as client]
-   [clojure-lsp.crawler :as crawler]
-   [clojure-lsp.db :as db]
-   [clojure-lsp.handlers :as handlers]
-   [clojure-lsp.interop :as interop]
-   [clojure-lsp.queries :as q]
-   [clojure-lsp.shared :as shared]))
+    [clojure-lsp.internal-api :as internal-api]))
 
-(defn ^:private start-analysis!
-  [project-root]
-  (let [project-uri (shared/filename->uri project-root)]
-    (crawler/initialize-project
-      project-uri
-      {:workspace {:workspace-edit {:document-changes true}}}
-      (interop/clean-client-settings {:dependency-scheme "jar"})
-      {:lint-project-files-after-startup? false
-       :text-document-sync-kind :full})))
+(defn clean-ns!
+  "Organize ns form, removing unused requires/refers/imports and sorting
+  alphabetically.
+  Options should be passed as keyword arguments and it accepts:
 
-(defn ^:private ns->uri [namespace]
-  (let [source-paths (-> @db/db :settings :source-paths)
-        filename (:filename (q/find-namespace-definition-by-namespace (:analysis @db/db) namespace))]
-    (shared/namespace->uri namespace source-paths filename)))
+  `:project-root` a string representing the path to the project root.
 
-(defn ^:private open-file! [namespace]
-  (let [uri (ns->uri namespace)
-        text (slurp uri)]
-    (handlers/did-open {:textDocument {:uri uri
-                                       :text text}})))
-
-(defn clean-ns! [{:keys [project-root namespaces]}]
-  (start-analysis! project-root)
-  (let [namespaces (or (seq namespaces)
-                       (->> (:analysis @db/db)
-                            q/filter-project-analysis
-                            q/find-all-ns-definitions
-                            (map name)))]
-    (doseq [namespace namespaces]
-      (open-file! namespace)
-      (println "Checking" namespace)
-      (when-let [edits (handlers/execute-command {:command "clean-ns"
-                                                  :arguments [(ns->uri namespace) 0 0]})]
-        (client/apply-workspace-edits edits)))))
+  `:namespaces` a coll of symbols representing the namespaces which should be cleaned,
+  if empty all project namespaces will be considered."
+  [& {:as options}]
+  (internal-api/clean-ns! options))

--- a/src/clojure_lsp/api.clj
+++ b/src/clojure_lsp/api.clj
@@ -1,0 +1,44 @@
+(ns clojure-lsp.api
+  (:require
+   [clojure-lsp.client :as client]
+   [clojure-lsp.crawler :as crawler]
+   [clojure-lsp.db :as db]
+   [clojure-lsp.handlers :as handlers]
+   [clojure-lsp.interop :as interop]
+   [clojure-lsp.queries :as q]
+   [clojure-lsp.shared :as shared]))
+
+(defn ^:private start-analysis!
+  [project-root]
+  (let [project-uri (shared/filename->uri project-root)]
+    (crawler/initialize-project
+      project-uri
+      {:workspace {:workspace-edit {:document-changes true}}}
+      (interop/clean-client-settings {:dependency-scheme "jar"})
+      {:lint-project-files-after-startup? false
+       :text-document-sync-kind :full})))
+
+(defn ^:private ns->uri [namespace]
+  (let [source-paths (-> @db/db :settings :source-paths)
+        filename (:filename (q/find-namespace-definition-by-namespace (:analysis @db/db) namespace))]
+    (shared/namespace->uri namespace source-paths filename)))
+
+(defn ^:private open-file! [namespace]
+  (let [uri (ns->uri namespace)
+        text (slurp uri)]
+    (handlers/did-open {:textDocument {:uri uri
+                                       :text text}})))
+
+(defn clean-ns! [{:keys [project-root namespaces]}]
+  (start-analysis! project-root)
+  (let [namespaces (or (seq namespaces)
+                       (->> (:analysis @db/db)
+                            q/filter-project-analysis
+                            q/find-all-ns-definitions
+                            (map name)))]
+    (doseq [namespace namespaces]
+      (open-file! namespace)
+      (println "Checking" namespace)
+      (when-let [edits (handlers/execute-command {:command "clean-ns"
+                                                  :arguments [(ns->uri namespace) 0 0]})]
+        (client/apply-workspace-edits edits)))))

--- a/src/clojure_lsp/api.clj
+++ b/src/clojure_lsp/api.clj
@@ -1,15 +1,19 @@
 (ns clojure-lsp.api
   (:require
-    [clojure-lsp.internal-api :as internal-api]))
+   [clojure-lsp.internal-api :as internal-api])
+  (:import
+   [java.io File]))
 
 (defn clean-ns!
   "Organize ns form, removing unused requires/refers/imports and sorting
   alphabetically.
   Options should be passed as keyword arguments and it accepts:
 
-  `:project-root` a string representing the path to the project root.
+  `:project-root` a java.io.File representing the project root.
 
   `:namespaces` a coll of symbols representing the namespaces which should be cleaned,
   if empty all project namespaces will be considered."
-  [& {:as options}]
+  [& {:keys [project-root] :as options}]
+  {:pre [(instance? File project-root)
+         (.exists project-root)]}
   (internal-api/clean-ns! options))

--- a/src/clojure_lsp/api.clj
+++ b/src/clojure_lsp/api.clj
@@ -1,4 +1,5 @@
 (ns clojure-lsp.api
+  "Entrypoint for main clojure-lsp features"
   (:require
    [clojure-lsp.internal-api :as internal-api])
   (:import
@@ -12,8 +13,12 @@
   `:project-root` a java.io.File representing the project root.
 
   `:namespaces` a coll of symbols representing the namespaces which should be cleaned,
-  if empty all project namespaces will be considered."
-  [& {:keys [project-root] :as options}]
+  if empty all project namespaces will be considered.
+
+  `settings` map of settings following https://clojure-lsp.github.io/clojure-lsp/settings/"
+  [& {:keys [project-root settings] :as options}]
   {:pre [(instance? File project-root)
-         (.exists project-root)]}
+         (.exists project-root)
+         (or (nil? settings)
+             (map? settings))]}
   (internal-api/clean-ns! options))

--- a/src/clojure_lsp/client.clj
+++ b/src/clojure_lsp/client.clj
@@ -5,24 +5,31 @@
     [clojure-lsp.handlers :as handlers]))
 
 (defn apply-workspace-edit [{:keys [text-document edits]}]
-  (loop [uri (:uri text-document)
-         text (get-in @db/db [:documents uri :text])
-         i 0]
-    (if-let [{:keys [range new-text]} (nth edits i nil)]
-      (let [new-full-text (f.file-management/replace-text text
-                                                          new-text
-                                                          (-> range :start :line)
-                                                          (-> range :start :character)
-                                                          (-> range :end :line)
-                                                          (-> range :end :character))]
-        (recur uri new-full-text (inc i)))
-      {:uri uri
-       :version (get-in @db/db [:documents uri :version] 0)
-       :new-text text})))
+  (let [uri (:uri text-document)
+        old-text (get-in @db/db [:documents uri :text])]
+    (loop [text old-text
+           i 0]
+      (if-let [{:keys [range new-text]} (nth edits i nil)]
+        (let [new-full-text (f.file-management/replace-text text
+                                                            new-text
+                                                            (-> range :start :line)
+                                                            (-> range :start :character)
+                                                            (-> range :end :line)
+                                                            (-> range :end :character))]
+          (recur new-full-text (inc i)))
+        {:uri uri
+         :changed? (not= text old-text)
+         :version (get-in @db/db [:documents uri :version] 0)
+         :new-text text}))))
 
 (defn apply-workspace-edits [{:keys [document-changes]}]
-  (doseq [{:keys [uri new-text version]} (map apply-workspace-edit document-changes)]
-    (spit uri new-text)
-    (handlers/did-change {:textDocument {:uri uri
-                                         :version (inc version)}
-                          :contentChanges new-text})))
+  (->> document-changes
+       (map apply-workspace-edit)
+       (mapv (fn [{:keys [uri new-text version changed?]}]
+              (when changed?
+                (spit uri new-text)
+                (handlers/did-change {:textDocument {:uri uri
+                                                     :version (inc version)}
+                                      :contentChanges new-text})
+                uri)))
+       (remove nil?)))

--- a/src/clojure_lsp/client.clj
+++ b/src/clojure_lsp/client.clj
@@ -1,0 +1,28 @@
+(ns clojure-lsp.client
+  (:require
+    [clojure-lsp.db :as db]
+    [clojure-lsp.feature.file-management :as f.file-management]
+    [clojure-lsp.handlers :as handlers]))
+
+(defn apply-workspace-edit [{:keys [text-document edits]}]
+  (loop [uri (:uri text-document)
+         text (get-in @db/db [:documents uri :text])
+         i 0]
+    (if-let [{:keys [range new-text]} (nth edits i nil)]
+      (let [new-full-text (f.file-management/replace-text text
+                                                          new-text
+                                                          (-> range :start :line)
+                                                          (-> range :start :character)
+                                                          (-> range :end :line)
+                                                          (-> range :end :character))]
+        (recur uri new-full-text (inc i)))
+      {:uri uri
+       :version (get-in @db/db [:documents uri :version] 0)
+       :new-text text})))
+
+(defn apply-workspace-edits [{:keys [document-changes]}]
+  (doseq [{:keys [uri new-text version]} (map apply-workspace-edit document-changes)]
+    (spit uri new-text)
+    (handlers/did-change {:textDocument {:uri uri
+                                         :version (inc version)}
+                          :contentChanges new-text})))

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -248,7 +248,7 @@
   (let [source-paths (resolve-source-paths root-path settings given-source-paths)]
     (mapv #(->> % (to-file root-path) .getAbsolutePath str) source-paths)))
 
-(defn initialize-project [project-root-uri client-capabilities client-settings]
+(defn initialize-project [project-root-uri client-capabilities client-settings force-settings]
   (let [project-settings (config/resolve-config project-root-uri)
         root-path (shared/uri->path project-root-uri)
         encoding-settings {:uri-format {:upper-case-drive-letter? (->> project-root-uri URI. .getPath
@@ -257,7 +257,8 @@
                                         :encode-colons-in-path? (string/includes? project-root-uri "%3A")}}
         raw-settings (merge encoding-settings
                             client-settings
-                            project-settings)
+                            project-settings
+                            force-settings)
         _ (when-let [log-path (:log-path raw-settings)]
             (logging/update-log-path log-path))
         settings (-> raw-settings

--- a/src/clojure_lsp/feature/file_management.clj
+++ b/src/clojure_lsp/feature/file_management.clj
@@ -94,7 +94,7 @@
              (+ offset (count (first lines)))
              (inc idx)))))
 
-(defn ^:private replace-text [original replacement line col end-line end-col]
+(defn replace-text [original replacement line col end-line end-col]
   (let [lines (string/split original #"\n") ;; don't use OS specific line delimiter!
         [start-offset end-offset] (offsets lines line col end-line end-col)
         [prefix suffix] [(subs original 0 start-offset)

--- a/src/clojure_lsp/feature/hover.clj
+++ b/src/clojure_lsp/feature/hover.clj
@@ -1,10 +1,10 @@
 (ns clojure-lsp.feature.hover
   (:require
     [clojure-lsp.db :as db]
-    [clojure.string :as string]
+    [clojure-lsp.feature.hover :as f.hover]
     [clojure-lsp.queries :as q]
     [clojure-lsp.shared :as shared]
-    [clojure-lsp.feature.hover :as f.hover]))
+    [clojure.string :as string]))
 
 (def line-break "\n----\n")
 (def opening-code "```clojure\n")

--- a/src/clojure_lsp/feature/refactor.clj
+++ b/src/clojure_lsp/feature/refactor.clj
@@ -3,8 +3,8 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.refactor.transform :as r.transform]
    [clojure-lsp.shared :as shared]
-   [taoensso.timbre :as log]
-   [rewrite-clj.zip :as z]))
+   [rewrite-clj.zip :as z]
+   [taoensso.timbre :as log]))
 
 (defn client-changes [changes]
   (if (get-in @db/db [:client-capabilities :workspace :workspace-edit :document-changes])

--- a/src/clojure_lsp/feature/rename.clj
+++ b/src/clojure_lsp/feature/rename.clj
@@ -9,15 +9,6 @@
     [clojure.string :as string]
     [taoensso.timbre :as log]))
 
-(defn ^:private namespace->uri [namespace source-paths filename]
-  (let [file-type (shared/uri->file-type filename)]
-    (shared/filename->uri
-      (shared/join-filepaths (first (filter #(string/starts-with? filename %) source-paths))
-                             (-> namespace
-                                 (string/replace "." (System/getProperty "file.separator"))
-                                 (string/replace "-" "_")
-                                 (str "." (name file-type)))))))
-
 (defn ^:private rename-keyword [replacement {:keys [ns alias name filename
                                                     name-col name-end-col
                                                     namespace-from-prefix] :as reference}]
@@ -131,7 +122,7 @@
                                      :edits (mapv #(dissoc % :text-document) edits)})))]
         (if (and (= (:bucket definition) :namespace-definitions)
                  (get-in @db/db [:client-capabilities :workspace :workspace-edit :document-changes]))
-          (let [new-uri (namespace->uri replacement source-paths (:filename definition))]
+          (let [new-uri (shared/namespace->uri replacement source-paths (:filename definition))]
             (swap! db/db (fn [db] (-> db
                                       (update :documents #(set/rename-keys % {filename (shared/uri->filename new-uri)}))
                                       (update :analysis #(set/rename-keys % {filename (shared/uri->filename new-uri)})))))

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -46,7 +46,7 @@
 
 (defn initialize [project-root-uri client-capabilities client-settings]
   (when project-root-uri
-    (crawler/initialize-project project-root-uri client-capabilities client-settings)))
+    (crawler/initialize-project project-root-uri client-capabilities client-settings {})))
 
 (defn did-open [{:keys [textDocument]}]
   (let [uri (:uri textDocument)
@@ -191,7 +191,9 @@
 
     (some #(= % command) f.refactor/available-refactors)
     (when-let [result (refactor command arguments)]
-      (producer/workspace-apply-edit result))))
+      (if (:client @db/db)
+        (producer/workspace-apply-edit result)
+        result))))
 
 (defn hover [{:keys [textDocument position]}]
   (let [[line column] (shared/position->line-column position)

--- a/src/clojure_lsp/internal_api.clj
+++ b/src/clojure_lsp/internal_api.clj
@@ -19,9 +19,9 @@
        :text-document-sync-kind :full})))
 
 (defn ^:private ns->uri [namespace]
-  (let [source-paths (-> @db/db :settings :source-paths)
-        filename (:filename (q/find-namespace-definition-by-namespace (:analysis @db/db) namespace))]
-    (shared/namespace->uri (name namespace) source-paths filename)))
+  (let [source-paths (-> @db/db :settings :source-paths)]
+    (when-let [filename (:filename (q/find-namespace-definition-by-namespace (:analysis @db/db) namespace))]
+      (shared/namespace->uri (name namespace) source-paths filename))))
 
 (defn ^:private open-file! [uri]
   (handlers/did-open {:textDocument {:uri uri :text (slurp uri)}}))
@@ -33,9 +33,11 @@
                          q/filter-project-analysis
                          q/find-all-ns-definitions))]
     (doseq [namespace namespaces]
-      (let [uri (ns->uri namespace)]
-        (open-file! uri)
-        (when-let [edits (handlers/execute-command {:command "clean-ns"
-                                                    :arguments [uri 0 0]})]
-          (when (seq (client/apply-workspace-edits edits))
-            (println "Cleaned" namespace)))))))
+      (if-let [uri (ns->uri namespace)]
+        (do
+          (open-file! uri)
+          (when-let [edits (handlers/execute-command {:command "clean-ns"
+                                                      :arguments [uri 0 0]})]
+            (when (seq (client/apply-workspace-edits edits))
+              (println "Cleaned" namespace))))
+        (println "Namespace" namespace "not found")))))

--- a/src/clojure_lsp/internal_api.clj
+++ b/src/clojure_lsp/internal_api.clj
@@ -1,0 +1,41 @@
+(ns clojure-lsp.internal-api
+  (:require
+   [clojure-lsp.client :as client]
+   [clojure-lsp.crawler :as crawler]
+   [clojure-lsp.db :as db]
+   [clojure-lsp.handlers :as handlers]
+   [clojure-lsp.interop :as interop]
+   [clojure-lsp.queries :as q]
+   [clojure-lsp.shared :as shared]))
+
+(defn ^:private start-analysis!
+  [project-root]
+  (let [project-uri (shared/filename->uri project-root)]
+    (crawler/initialize-project
+      project-uri
+      {:workspace {:workspace-edit {:document-changes true}}}
+      (interop/clean-client-settings {:dependency-scheme "jar"})
+      {:lint-project-files-after-startup? false
+       :text-document-sync-kind :full})))
+
+(defn ^:private ns->uri [namespace]
+  (let [source-paths (-> @db/db :settings :source-paths)
+        filename (:filename (q/find-namespace-definition-by-namespace (:analysis @db/db) namespace))]
+    (shared/namespace->uri (name namespace) source-paths filename)))
+
+(defn ^:private open-file! [uri]
+  (handlers/did-open {:textDocument {:uri uri :text (slurp uri)}}))
+
+(defn clean-ns! [{:keys [project-root namespace]}]
+  (start-analysis! project-root)
+  (let [namespaces (or (seq namespace)
+                       (->> (:analysis @db/db)
+                         q/filter-project-analysis
+                         q/find-all-ns-definitions))]
+    (doseq [namespace namespaces]
+      (let [uri (ns->uri namespace)]
+        (open-file! uri)
+        (when-let [edits (handlers/execute-command {:command "clean-ns"
+                                                    :arguments [uri 0 0]})]
+          (when (seq (client/apply-workspace-edits edits))
+            (println "Cleaned" namespace)))))))

--- a/src/clojure_lsp/internal_api.clj
+++ b/src/clojure_lsp/internal_api.clj
@@ -30,8 +30,8 @@
   (start-analysis! project-root)
   (let [namespaces (or (seq namespace)
                        (->> (:analysis @db/db)
-                         q/filter-project-analysis
-                         q/find-all-ns-definitions))]
+                            q/filter-project-analysis
+                            q/find-all-ns-definitions))]
     (doseq [namespace namespaces]
       (if-let [uri (ns->uri namespace)]
         (do

--- a/src/clojure_lsp/internal_api.clj
+++ b/src/clojure_lsp/internal_api.clj
@@ -8,9 +8,8 @@
    [clojure-lsp.queries :as q]
    [clojure-lsp.shared :as shared]))
 
-(defn ^:private start-analysis!
-  [project-root]
-  (let [project-uri (shared/filename->uri project-root)]
+(defn ^:private start-analysis! [project-root]
+  (let [project-uri (shared/filename->uri (.getCanonicalPath project-root))]
     (crawler/initialize-project
       project-uri
       {:workspace {:workspace-edit {:document-changes true}}}

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -1,442 +1,91 @@
 (ns clojure-lsp.main
   (:require
-    borkdude.dynaload
-    [clojure-lsp.config :as config]
-    [clojure-lsp.db :as db]
-    [clojure-lsp.feature.file-management :as f.file-management]
-    [clojure-lsp.feature.refactor :as f.refactor]
-    [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
-    [clojure-lsp.handlers :as handlers]
-    [clojure-lsp.interop :as interop]
-    [clojure-lsp.logging :as logging]
-    [clojure-lsp.nrepl :as nrepl]
-    [clojure-lsp.producer :as producer]
-    [clojure-lsp.shared :as shared]
-    [clojure.core.async :refer [<! go-loop thread timeout]]
-    [taoensso.timbre :as log])
-  (:import
-    (clojure_lsp
-      ClojureExtensions
-      ExtraMethods
-      CursorInfoParams)
-    (java.util.concurrent CompletableFuture)
-    (java.util.function Supplier)
-    (java.util List)
-    (org.eclipse.lsp4j
-      CallHierarchyIncomingCallsParams
-      CallHierarchyOutgoingCallsParams
-      CallHierarchyPrepareParams
-      CodeActionParams
-      CodeAction
-      CodeActionOptions
-      CodeLens
-      CodeLensParams
-      CodeLensOptions
-      CompletionItem
-      CompletionOptions
-      CompletionParams
-      DefinitionParams
-      DidChangeConfigurationParams
-      DidChangeTextDocumentParams
-      DidChangeWatchedFilesParams
-      DidChangeWatchedFilesRegistrationOptions
-      DidCloseTextDocumentParams
-      DidOpenTextDocumentParams
-      DidSaveTextDocumentParams
-      DocumentFormattingParams
-      DocumentHighlightParams
-      DocumentRangeFormattingParams
-      DocumentSymbolParams
-      ExecuteCommandOptions
-      ExecuteCommandParams
-      FileSystemWatcher
-      HoverParams
-      InitializeParams
-      InitializeResult
-      InitializedParams
-      ReferenceParams
-      Registration
-      RegistrationParams
-      RenameParams
-      SaveOptions
-      SemanticTokensLegend
-      SemanticTokensParams
-      SemanticTokensRangeParams
-      SemanticTokensWithRegistrationOptions
-      ServerCapabilities
-      SignatureHelpOptions
-      SignatureHelpParams
-      TextDocumentSyncKind
-      TextDocumentSyncOptions
-      WorkspaceSymbolParams)
-    (org.eclipse.lsp4j.launch LSPLauncher)
-    (org.eclipse.lsp4j.services LanguageServer TextDocumentService WorkspaceService LanguageClient))
+   borkdude.dynaload
+   [clojure-lsp.api :as api]
+   [clojure-lsp.config :as config]
+   [clojure-lsp.logging :as logging]
+   [clojure-lsp.server :as server]
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.tools.cli :refer [parse-opts]])
   (:gen-class))
 
-(defonce formatting (atom false))
+(defn ^:private version []
+  (->> [(str "clojure-lsp " config/clojure-lsp-version)
+        (str "clj-kondo " config/clj-kondo-version)]
+       (string/join \newline)))
 
-(defmacro start [id & body]
-  `(let [~'_start-time (System/nanoTime)
-         ~'_id ~id]
-     (do ~@body)))
+(defn ^:private help [options-summary]
+  (->> ["Clojure development tool implementing LSP"
+        ""
+        "Usage: clojure-lsp <command> [<options>]"
+        ""
+        "Options:"
+        options-summary
+        ""
+        "Available commands:"
+        "  listen (or empty)    Start clojure-lsp as server, listening to stdin."
+        "  clean-ns             Organize ns form, removing unused requires/refers/imports and sorting alphabetically."
+        ""
+        "Run \"clojure-lsp help <command>\" for more information about a command."
+        "See https://clojure-lsp.github.io/clojure-lsp/settings/ for detailed documentation."]
+       (string/join \newline)))
 
-(defmacro end [expr]
-  `(try
-     ~expr
-     (catch Throwable ex#
-       (log/error ex#))
-     (finally
-       (try
-         (let [duration# (quot (- (System/nanoTime) ~'_start-time) 1000000)]
-           (log/debug ~'_id (format "%sms" duration#)))
-         (catch Throwable ex#
-           (log/error ex#))))))
+(def ^:private cli-options
+  [["-h" "--help" "Print the available commands and its options"]
+   [nil "--version" "Print clojure-lsp version"]
+   ["-p" "--project-root PATH" "Specify the path to the project root to clojure-lsp consider during analysis startup."
+    :id :project-root
+    :default (System/getProperty "user.dir")
+    :parse-fn io/file
+    :validate-fn #(.exists %)
+    :validate-msg "Invalid --project-root path"
+    :assoc-fn #(assoc %1 %2 (.getCanonicalPath %3))
+    ]
+   [nil "--namespaces NS" "The optional namespaces to apply the action, all if not supplied."
+    :default []
+    :multi true
+    :update-fn conj]])
 
-(defmacro ^:private sync-handler
-  ([params handler]
-   `(end
-      (->> ~params
-           interop/java->clj
-           ~handler)))
-  ([params handler response-spec]
-   `(end
-      (->> ~params
-           interop/java->clj
-           ~handler
-           (interop/conform-or-log ~response-spec)))))
+(defn ^:private error-msg [errors]
+  (str "The following errors occurred while parsing your command:\n\n"
+       (string/join \newline errors)))
 
-(defmacro ^:private async-handler
-  [params handler response-spec]
-  `(CompletableFuture/supplyAsync
-     (reify Supplier
-       (get [this]
-         (sync-handler ~params ~handler ~response-spec)))))
+(defn ^:private parse [args]
+  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    (cond
+      (:help options)
+      {:exit-message (help summary) :ok? true}
 
-(deftype LSPTextDocumentService []
-  TextDocumentService
-  (^void didOpen [_ ^DidOpenTextDocumentParams params]
-    (start :didOpen
-           (sync-handler params handlers/did-open)))
+      (:version options)
+      {:exit-message (version) :ok? true}
 
-  (^void didChange [_ ^DidChangeTextDocumentParams params]
-    (start :didChange
-           (sync-handler params handlers/did-change)))
+      errors
+      {:exit-message (error-msg errors)}
 
-  (^void didSave [_ ^DidSaveTextDocumentParams params]
-    (start :didSave
-           (future
-             (sync-handler params handlers/did-save)))
-    (CompletableFuture/completedFuture 0))
+      (= 0 (count arguments))
+      {:action "listen" :options options}
 
-  (^void didClose [_ ^DidCloseTextDocumentParams _params]
-    (start :didClose
-           nil))
+      (and (= 1 (count arguments))
+           (#{"clean-ns" "listen"} (first arguments)))
+      {:action (first arguments) :options options}
 
-  (^CompletableFuture references [_ ^ReferenceParams params]
-    (start :references
-           (async-handler params handlers/references ::interop/references)))
+      :else
+      {:exit-message (help summary)})))
 
-  (^CompletableFuture completion [_ ^CompletionParams params]
-    (start :completion
-           (async-handler params handlers/completion ::interop/completion-items)))
+(defn ^:private exit [status msg]
+  (println msg)
+  (System/exit status))
 
-  (^CompletableFuture resolveCompletionItem [_ ^CompletionItem item]
-    (start :resolveCompletionItem
-           (async-handler item handlers/completion-resolve-item ::interop/completion-item)))
-
-  (^CompletableFuture rename [_ ^RenameParams params]
-    (start :rename
-           (async-handler params handlers/rename ::interop/workspace-edit)))
-
-  (^CompletableFuture hover [_ ^HoverParams params]
-    (start :hover
-           (async-handler params handlers/hover ::interop/hover)))
-
-  (^CompletableFuture signatureHelp [_ ^SignatureHelpParams params]
-    (start :signatureHelp
-           (async-handler params handlers/signature-help ::interop/signature-help)))
-
-  (^CompletableFuture formatting [_ ^DocumentFormattingParams params]
-    (start :formatting
-           (async-handler params handlers/formatting ::interop/edits)))
-
-  (^CompletableFuture rangeFormatting [_this ^DocumentRangeFormattingParams params]
-    (start :rangeFormatting
-           (end
-             (let [result (when (compare-and-set! formatting false true)
-                            (try
-                              (let [doc-id (interop/document->uri (.getTextDocument params))
-                                    range (.getRange params)
-                                    start (.getStart range)
-                                    end (.getEnd range)]
-                                (interop/conform-or-log ::interop/edits (#'handlers/range-formatting
-                                                                         doc-id
-                                                                         {:row (inc (.getLine start))
-                                                                          :col (inc (.getCharacter start))
-                                                                          :end-row (inc (.getLine end))
-                                                                          :end-col (inc (.getCharacter end))})))
-                              (catch Exception e
-                                (log/error e))
-                              (finally
-                                (reset! formatting false))))]
-               (CompletableFuture/completedFuture
-                 result)))))
-
-  (^CompletableFuture codeAction [_ ^CodeActionParams params]
-    (start :codeAction
-           (async-handler params handlers/code-actions ::interop/code-actions)))
-
-  (^CompletableFuture resolveCodeAction [_ ^CodeAction unresolved]
-    (start :resolveCodeAction
-           (async-handler unresolved handlers/resolve-code-action ::interop/code-action)))
-
-  (^CompletableFuture codeLens [_ ^CodeLensParams params]
-    (start :codeLens
-           (async-handler params handlers/code-lens ::interop/code-lenses)))
-
-  (^CompletableFuture resolveCodeLens [_ ^CodeLens params]
-    (start :resolveCodeLens
-           (async-handler params handlers/code-lens-resolve ::interop/code-lens)))
-
-  (^CompletableFuture definition [_ ^DefinitionParams params]
-    (start :definition
-           (async-handler params handlers/definition ::interop/location)))
-
-  (^CompletableFuture documentSymbol [_ ^DocumentSymbolParams params]
-    (start :documentSymbol
-           (async-handler params handlers/document-symbol ::interop/document-symbols)))
-
-  (^CompletableFuture documentHighlight [_ ^DocumentHighlightParams params]
-    (start :documentHighlight
-           (async-handler params handlers/document-highlight ::interop/document-highlights)))
-
-  (^CompletableFuture semanticTokensFull [_ ^SemanticTokensParams params]
-    (start :semanticTokensFull
-           (async-handler params handlers/semantic-tokens-full ::interop/semantic-tokens)))
-
-  (^CompletableFuture semanticTokensRange [_ ^SemanticTokensRangeParams params]
-    (start :semanticTokensRange
-           (async-handler params handlers/semantic-tokens-range ::interop/semantic-tokens)))
-
-  (^CompletableFuture prepareCallHierarchy [_ ^CallHierarchyPrepareParams params]
-    (start :prepareCallHierarchy
-           (async-handler params handlers/prepare-call-hierarchy ::interop/call-hierarchy-items)))
-
-  (^CompletableFuture callHierarchyIncomingCalls [_ ^CallHierarchyIncomingCallsParams params]
-    (start :callHierarchyIncomingCalls
-           (async-handler params handlers/call-hierarchy-incoming ::interop/call-hierarchy-incoming-calls)))
-
-  (^CompletableFuture callHierarchyOutgoingCalls [_ ^CallHierarchyOutgoingCallsParams params]
-    (start :callHierarchyOutgoingCalls
-           (async-handler params handlers/call-hierarchy-outgoing ::interop/call-hierarchy-outgoing-calls))))
-
-(deftype LSPWorkspaceService []
-  WorkspaceService
-  (^CompletableFuture executeCommand [_ ^ExecuteCommandParams params]
-    (start :executeCommand
-           (future
-             (sync-handler params handlers/execute-command)))
-    (CompletableFuture/completedFuture 0))
-
-  (^void didChangeConfiguration [_ ^DidChangeConfigurationParams params]
-    (log/warn (interop/java->clj params)))
-
-  (^void didChangeWatchedFiles [_ ^DidChangeWatchedFilesParams params]
-    (start :didChangeWatchedFiles
-           (end
-             (some->> params
-                      (.getChanges)
-                      (interop/conform-or-log ::interop/watched-files-changes)
-                      (handlers/did-change-watched-files)))))
-
-  ;; TODO wait for lsp4j release
-  #_(^void didDeleteFiles [_ ^DeleteFilesParams params]
-                          (start :didSave
-                                 (sync-handler params handlers/did-delete-files)))
-
-  (^CompletableFuture symbol [_ ^WorkspaceSymbolParams params]
-    (start :workspaceSymbol
-           (async-handler params handlers/workspace-symbols ::interop/workspace-symbols))))
-
-(defn ^:private client-settings [^InitializeParams params]
-  (-> params
-      interop/java->clj
-      :initializationOptions
-      (or {})
-      shared/keywordize-first-depth
-      (interop/clean-client-settings)))
-
-(defn ^:private client-capabilities [^InitializeParams params]
-  (some->> params
-           .getCapabilities
-           (interop/conform-or-log ::interop/client-capabilities)))
-
-;; Called from java
-(defn extension [method & args]
-  (start :extension
-         (CompletableFuture/completedFuture
-           (end
-             (apply #'handlers/extension method args)))))
-
-(defn ^:private start-parent-process-liveness-probe!
-  [ppid server]
-  (go-loop []
-    (<! (timeout 5000))
-    (if (shared/process-alive? ppid)
-      (recur)
-      (do
-        (log/info "Parent process" ppid "is not running - exiting server")
-        (.exit server)))))
-
-(def server
-  (proxy [ClojureExtensions LanguageServer ExtraMethods] []
-    (^CompletableFuture initialize [^InitializeParams params]
-      (start :initialize
-             (end
-               (do
-                 (log/info "Initializing...")
-                 (handlers/initialize (.getRootUri params)
-                                      (client-capabilities params)
-                                      (client-settings params))
-                 (when-let [parent-process-id (.getProcessId params)]
-                   (start-parent-process-liveness-probe! parent-process-id this))
-                 (let [settings (:settings @db/db)]
-                   (CompletableFuture/completedFuture
-                     (InitializeResult. (doto (ServerCapabilities.)
-                                          (.setDocumentHighlightProvider true)
-                                          (.setHoverProvider true)
-                                          (.setSignatureHelpProvider (SignatureHelpOptions. []))
-                                          (.setCallHierarchyProvider true)
-                                          (.setCodeActionProvider (doto (CodeActionOptions. interop/code-action-kind)
-                                                                    (.setResolveProvider true)))
-                                          (.setCodeLensProvider (CodeLensOptions. true))
-                                          (.setReferencesProvider true)
-                                          (.setRenameProvider true)
-                                          (.setDefinitionProvider true)
-                                          (.setDocumentFormattingProvider ^Boolean (:document-formatting? settings))
-                                          (.setDocumentRangeFormattingProvider ^Boolean (:document-range-formatting? settings))
-                                          (.setDocumentSymbolProvider true)
-                                          (.setWorkspaceSymbolProvider true)
-                                          (.setSemanticTokensProvider (when (or (not (contains? settings :semantic-tokens?))
-                                                                                (:semantic-tokens? settings))
-                                                                        (doto (SemanticTokensWithRegistrationOptions.)
-                                                                          (.setLegend (doto (SemanticTokensLegend.
-                                                                                              semantic-tokens/token-types-str
-                                                                                              semantic-tokens/token-modifiers)))
-                                                                          (.setRange true)
-                                                                          (.setFull true))))
-                                          (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
-                                                                        (.setCommands f.refactor/available-refactors)))
-                                          (.setTextDocumentSync (doto (TextDocumentSyncOptions.)
-                                                                  (.setOpenClose true)
-                                                                  (.setChange (case (:text-document-sync-kind settings)
-                                                                                :full TextDocumentSyncKind/Full
-                                                                                :incremental TextDocumentSyncKind/Incremental
-                                                                                TextDocumentSyncKind/Full))
-                                                                  (.setSave (SaveOptions. true))))
-                                          (.setCompletionProvider (CompletionOptions. true []))))))))))
-
-    (^void initialized [^InitializedParams params]
-      (start :initialized
-             (end
-               (do
-                 (log/info "Initialized!")
-                 (let [client ^LanguageClient (:client @db/db)]
-                   (.registerCapability client
-                                        (RegistrationParams. [(Registration. "id" "workspace/didChangeWatchedFiles"
-                                                                             (DidChangeWatchedFilesRegistrationOptions. [(FileSystemWatcher. "**")]))])))))))
-
-    (^CompletableFuture serverInfoRaw []
-      (CompletableFuture/completedFuture
-        (->> (handlers/server-info-raw)
-             (interop/conform-or-log ::interop/server-info-raw))))
-
-    (^void serverInfoLog []
-      (start :server-info-log
-             (future
-               (end
-                 (handlers/server-info-log)))))
-
-    (^void cursorInfoLog [^CursorInfoParams params]
-      (start :cursor-info-log
-             (future
-               (sync-handler params handlers/cursor-info-log))))
-
-    (^CompletableFuture shutdown []
-      (log/info "Shutting down")
-      (reset! db/db {:documents {}}) ;; TODO confirm this is correct
-      (CompletableFuture/completedFuture
-        {:result nil}))
-    (exit []
-      (log/info "Exitting...")
-      (shutdown-agents)
-      (System/exit 0))
-    (getTextDocumentService []
-      (LSPTextDocumentService.))
-    (getWorkspaceService []
-      (LSPWorkspaceService.))))
-
-(defn tee-system-in [system-in]
-  (let [buffer-size 1024
-        os (java.io.PipedOutputStream.)
-        is (java.io.PipedInputStream. os)]
-    (thread
-      (try
-        (let [buffer (byte-array buffer-size)]
-          (loop [chs (.read system-in buffer 0 buffer-size)]
-            (when (pos? chs)
-              (log/warn "FROM STDIN" chs (String. (java.util.Arrays/copyOfRange buffer 0 chs)))
-              (.write os buffer 0 chs)
-              (recur (.read system-in buffer 0 buffer-size)))))
-        (catch Exception e
-          (log/error e "in thread"))))
-    is))
-
-(defn tee-system-out [system-out]
-  (let [buffer-size 1024
-        is (java.io.PipedInputStream.)
-        os (java.io.PipedOutputStream. is)]
-    (thread
-      (try
-        (let [buffer (byte-array buffer-size)]
-          (loop [chs (.read is buffer 0 buffer-size)]
-            (when (pos? chs)
-              (log/warn "FROM STDOUT" chs (String. (java.util.Arrays/copyOfRange buffer 0 chs)))
-              (.write system-out buffer)
-              (recur (.read is buffer 0 buffer-size)))))
-        (catch Exception e
-          (log/error e "in thread"))))
-    os))
-
-(defn- run []
-  (log/info "Starting server...")
-  (let [is (or System/in (tee-system-in System/in))
-        os (or System/out (tee-system-out System/out))
-        launcher (LSPLauncher/createServerLauncher server is os)
-        debounced-diags (shared/debounce-by db/diagnostics-chan config/diagnostics-debounce-ms :uri)
-        debounced-changes (shared/debounce-by db/current-changes-chan config/change-debounce-ms :uri)]
-    (nrepl/setup-nrepl)
-    (swap! db/db assoc :client ^LanguageClient (.getRemoteProxy launcher))
-    (go-loop [edit (<! db/edits-chan)]
-      (producer/workspace-apply-edit edit)
-      (recur (<! db/edits-chan)))
-    (go-loop []
-      (producer/publish-diagnostic (<! debounced-diags))
-      (recur))
-    (go-loop []
-      (try
-        (f.file-management/analyze-changes (<! debounced-changes))
-        (catch Exception e
-          (log/error e "Error during analyzing buffer file changes")))
-      (recur))
-    (.startListening launcher)))
-
-(defn ^:private print-version []
-  (println "clojure-lsp" config/clojure-lsp-version)
-  (println "clj-kondo" config/clj-kondo-version))
+(defn ^:private handle-action
+  [action options]
+  (case action
+    "listen" (with-out-str (server/run-server!))
+    "clean-ns" (api/clean-ns! options)))
 
 (defn -main [& args]
   (logging/setup-logging)
-  (if (empty? args)
-    (with-out-str (run))
-    (print-version)))
+  (let [{:keys [action options exit-message ok?]} (parse args)]
+    (if exit-message
+      (exit (if ok? 0 1) exit-message)
+      (handle-action action options))))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -1,8 +1,8 @@
 (ns clojure-lsp.main
   (:require
    borkdude.dynaload
-   [clojure-lsp.api :as api]
    [clojure-lsp.config :as config]
+   [clojure-lsp.internal-api :as internal-api]
    [clojure-lsp.logging :as logging]
    [clojure-lsp.server :as server]
    [clojure.java.io :as io]
@@ -38,12 +38,11 @@
     :id :project-root
     :default (System/getProperty "user.dir")
     :parse-fn io/file
-    :validate-fn #(.exists %)
-    :validate-msg "Invalid --project-root path"
-    :assoc-fn #(assoc %1 %2 (.getCanonicalPath %3))
-    ]
-   [nil "--namespaces NS" "The optional namespaces to apply the action, all if not supplied."
+    :validate [#(.exists %) "Specify a valid path after --project-root"]
+    :assoc-fn #(assoc %1 %2 (.getCanonicalPath %3))]
+   ["-n" "--namespace NS" "The optional namespace to apply the action, all if not supplied. This flag accepts multiple values"
     :default []
+    :parse-fn symbol
     :multi true
     :update-fn conj]])
 
@@ -81,7 +80,7 @@
   [action options]
   (case action
     "listen" (with-out-str (server/run-server!))
-    "clean-ns" (api/clean-ns! options)))
+    "clean-ns" (internal-api/clean-ns! options)))
 
 (defn -main [& args]
   (logging/setup-logging)

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -5,6 +5,7 @@
    [clojure-lsp.internal-api :as internal-api]
    [clojure-lsp.logging :as logging]
    [clojure-lsp.server :as server]
+   [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.tools.cli :refer [parse-opts]])
@@ -39,11 +40,17 @@
     :default (io/file (System/getProperty "user.dir"))
     :parse-fn io/file
     :validate [#(.exists %) "Specify a valid path after --project-root"]]
-   ["-n" "--namespace NS" "The optional namespace to apply the action, all if not supplied. This flag accepts multiple values"
+   ["-n" "--namespace NS" "Optional namespace to apply the action, all if not supplied. This flag accepts multiple values"
+    :id :namespace
     :default []
     :parse-fn symbol
     :multi true
-    :update-fn conj]])
+    :update-fn conj]
+   ["-s" "--settings SETTINGS" "Optional settings as edn to use for the specified command. For all available settings, check https://clojure-lsp.github.io/clojure-lsp/settings"
+    :id :settings
+    :validate [#(try (edn/read-string %) true (catch Exception _ false))
+               "Invalid --settings EDN"]
+    :update-fn edn/read-string]])
 
 (defn ^:private error-msg [errors]
   (str "The following errors occurred while parsing your command:\n\n"

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -36,10 +36,9 @@
    [nil "--version" "Print clojure-lsp version"]
    ["-p" "--project-root PATH" "Specify the path to the project root to clojure-lsp consider during analysis startup."
     :id :project-root
-    :default (System/getProperty "user.dir")
+    :default (io/file (System/getProperty "user.dir"))
     :parse-fn io/file
-    :validate [#(.exists %) "Specify a valid path after --project-root"]
-    :assoc-fn #(assoc %1 %2 (.getCanonicalPath %3))]
+    :validate [#(.exists %) "Specify a valid path after --project-root"]]
    ["-n" "--namespace NS" "The optional namespace to apply the action, all if not supplied. This flag accepts multiple values"
     :default []
     :parse-fn symbol

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -3,9 +3,9 @@
     [clojure-lsp.db :as db]
     [clojure-lsp.refactor.edit :as edit]
     [clojure.string :as string]
-    [taoensso.timbre :as log]
     [rewrite-clj.node :as n]
-    [rewrite-clj.zip :as z]))
+    [rewrite-clj.zip :as z]
+    [taoensso.timbre :as log]))
 
 (defmacro zspy [loc]
   `(do

--- a/src/clojure_lsp/producer.clj
+++ b/src/clojure_lsp/producer.clj
@@ -4,9 +4,9 @@
     [clojure-lsp.interop :as interop]
     [taoensso.timbre :as log])
   (:import
-   (org.eclipse.lsp4j.services LanguageClient)
    (org.eclipse.lsp4j
-     ApplyWorkspaceEditParams)))
+     ApplyWorkspaceEditParams)
+   (org.eclipse.lsp4j.services LanguageClient)))
 
 (defn window-show-message
   ([message type]

--- a/src/clojure_lsp/queries.clj
+++ b/src/clojure_lsp/queries.clj
@@ -271,3 +271,9 @@
        (filter (comp #(= % :unused-import) :type))
        (map :class)
        set))
+
+(defn find-namespace-definition-by-namespace [analysis namespace]
+  (find-last-order-by-project-analysis
+    #(and (= (:bucket %) :namespace-definitions)
+          (= (:name %) (symbol namespace)))
+    analysis))

--- a/src/clojure_lsp/queries.clj
+++ b/src/clojure_lsp/queries.clj
@@ -275,5 +275,5 @@
 (defn find-namespace-definition-by-namespace [analysis namespace]
   (find-last-order-by-project-analysis
     #(and (= (:bucket %) :namespace-definitions)
-          (= (:name %) (symbol namespace)))
+          (= (:name %) namespace))
     analysis))

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -1,0 +1,429 @@
+(ns clojure-lsp.server
+  (:require
+    [clojure-lsp.config :as config]
+    [clojure-lsp.db :as db]
+    [clojure-lsp.feature.file-management :as f.file-management]
+    [clojure-lsp.feature.refactor :as f.refactor]
+    [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
+    [clojure-lsp.handlers :as handlers]
+    [clojure-lsp.interop :as interop]
+    [clojure-lsp.nrepl :as nrepl]
+    [clojure-lsp.producer :as producer]
+    [clojure-lsp.shared :as shared]
+    [clojure.core.async :refer [<! go-loop thread timeout]]
+    [taoensso.timbre :as log])
+  (:import
+    (clojure_lsp
+      ClojureExtensions
+      ExtraMethods
+      CursorInfoParams)
+    (java.util.concurrent CompletableFuture)
+    (java.util.function Supplier)
+    (org.eclipse.lsp4j
+      CallHierarchyIncomingCallsParams
+      CallHierarchyOutgoingCallsParams
+      CallHierarchyPrepareParams
+      CodeActionParams
+      CodeAction
+      CodeActionOptions
+      CodeLens
+      CodeLensParams
+      CodeLensOptions
+      CompletionItem
+      CompletionOptions
+      CompletionParams
+      DefinitionParams
+      DidChangeConfigurationParams
+      DidChangeTextDocumentParams
+      DidChangeWatchedFilesParams
+      DidChangeWatchedFilesRegistrationOptions
+      DidCloseTextDocumentParams
+      DidOpenTextDocumentParams
+      DidSaveTextDocumentParams
+      DocumentFormattingParams
+      DocumentHighlightParams
+      DocumentRangeFormattingParams
+      DocumentSymbolParams
+      ExecuteCommandOptions
+      ExecuteCommandParams
+      FileSystemWatcher
+      HoverParams
+      InitializeParams
+      InitializeResult
+      InitializedParams
+      ReferenceParams
+      Registration
+      RegistrationParams
+      RenameParams
+      SaveOptions
+      SemanticTokensLegend
+      SemanticTokensParams
+      SemanticTokensRangeParams
+      SemanticTokensWithRegistrationOptions
+      ServerCapabilities
+      SignatureHelpOptions
+      SignatureHelpParams
+      TextDocumentSyncKind
+      TextDocumentSyncOptions
+      WorkspaceSymbolParams)
+    (org.eclipse.lsp4j.launch LSPLauncher)
+    (org.eclipse.lsp4j.services LanguageServer TextDocumentService WorkspaceService LanguageClient))
+  (:gen-class))
+
+(defonce formatting (atom false))
+
+(defmacro ^:private start [id & body]
+  `(let [~'_start-time (System/nanoTime)
+         ~'_id ~id]
+     (do ~@body)))
+
+(defmacro ^:private end [expr]
+  `(try
+     ~expr
+     (catch Throwable ex#
+       (log/error ex#))
+     (finally
+       (try
+         (let [duration# (quot (- (System/nanoTime) ~'_start-time) 1000000)]
+           (log/debug ~'_id (format "%sms" duration#)))
+         (catch Throwable ex#
+           (log/error ex#))))))
+
+(defmacro ^:private sync-handler
+  ([params handler]
+   `(end
+      (->> ~params
+           interop/java->clj
+           ~handler)))
+  ([params handler response-spec]
+   `(end
+      (->> ~params
+           interop/java->clj
+           ~handler
+           (interop/conform-or-log ~response-spec)))))
+
+(defmacro ^:private async-handler
+  [params handler response-spec]
+  `(CompletableFuture/supplyAsync
+     (reify Supplier
+       (get [this]
+         (sync-handler ~params ~handler ~response-spec)))))
+
+(deftype LSPTextDocumentService []
+  TextDocumentService
+  (^void didOpen [_ ^DidOpenTextDocumentParams params]
+    (start :didOpen
+           (sync-handler params handlers/did-open)))
+
+  (^void didChange [_ ^DidChangeTextDocumentParams params]
+    (start :didChange
+           (sync-handler params handlers/did-change)))
+
+  (^void didSave [_ ^DidSaveTextDocumentParams params]
+    (start :didSave
+           (future
+             (sync-handler params handlers/did-save)))
+    (CompletableFuture/completedFuture 0))
+
+  (^void didClose [_ ^DidCloseTextDocumentParams _params]
+    (start :didClose
+           nil))
+
+  (^CompletableFuture references [_ ^ReferenceParams params]
+    (start :references
+           (async-handler params handlers/references ::interop/references)))
+
+  (^CompletableFuture completion [_ ^CompletionParams params]
+    (start :completion
+           (async-handler params handlers/completion ::interop/completion-items)))
+
+  (^CompletableFuture resolveCompletionItem [_ ^CompletionItem item]
+    (start :resolveCompletionItem
+           (async-handler item handlers/completion-resolve-item ::interop/completion-item)))
+
+  (^CompletableFuture rename [_ ^RenameParams params]
+    (start :rename
+           (async-handler params handlers/rename ::interop/workspace-edit)))
+
+  (^CompletableFuture hover [_ ^HoverParams params]
+    (start :hover
+           (async-handler params handlers/hover ::interop/hover)))
+
+  (^CompletableFuture signatureHelp [_ ^SignatureHelpParams params]
+    (start :signatureHelp
+           (async-handler params handlers/signature-help ::interop/signature-help)))
+
+  (^CompletableFuture formatting [_ ^DocumentFormattingParams params]
+    (start :formatting
+           (async-handler params handlers/formatting ::interop/edits)))
+
+  (^CompletableFuture rangeFormatting [_this ^DocumentRangeFormattingParams params]
+    (start :rangeFormatting
+           (end
+             (let [result (when (compare-and-set! formatting false true)
+                            (try
+                              (let [doc-id (interop/document->uri (.getTextDocument params))
+                                    range (.getRange params)
+                                    start (.getStart range)
+                                    end (.getEnd range)]
+                                (interop/conform-or-log ::interop/edits (#'handlers/range-formatting
+                                                                         doc-id
+                                                                         {:row (inc (.getLine start))
+                                                                          :col (inc (.getCharacter start))
+                                                                          :end-row (inc (.getLine end))
+                                                                          :end-col (inc (.getCharacter end))})))
+                              (catch Exception e
+                                (log/error e))
+                              (finally
+                                (reset! formatting false))))]
+               (CompletableFuture/completedFuture
+                 result)))))
+
+  (^CompletableFuture codeAction [_ ^CodeActionParams params]
+    (start :codeAction
+           (async-handler params handlers/code-actions ::interop/code-actions)))
+
+  (^CompletableFuture resolveCodeAction [_ ^CodeAction unresolved]
+    (start :resolveCodeAction
+           (async-handler unresolved handlers/resolve-code-action ::interop/code-action)))
+
+  (^CompletableFuture codeLens [_ ^CodeLensParams params]
+    (start :codeLens
+           (async-handler params handlers/code-lens ::interop/code-lenses)))
+
+  (^CompletableFuture resolveCodeLens [_ ^CodeLens params]
+    (start :resolveCodeLens
+           (async-handler params handlers/code-lens-resolve ::interop/code-lens)))
+
+  (^CompletableFuture definition [_ ^DefinitionParams params]
+    (start :definition
+           (async-handler params handlers/definition ::interop/location)))
+
+  (^CompletableFuture documentSymbol [_ ^DocumentSymbolParams params]
+    (start :documentSymbol
+           (async-handler params handlers/document-symbol ::interop/document-symbols)))
+
+  (^CompletableFuture documentHighlight [_ ^DocumentHighlightParams params]
+    (start :documentHighlight
+           (async-handler params handlers/document-highlight ::interop/document-highlights)))
+
+  (^CompletableFuture semanticTokensFull [_ ^SemanticTokensParams params]
+    (start :semanticTokensFull
+           (async-handler params handlers/semantic-tokens-full ::interop/semantic-tokens)))
+
+  (^CompletableFuture semanticTokensRange [_ ^SemanticTokensRangeParams params]
+    (start :semanticTokensRange
+           (async-handler params handlers/semantic-tokens-range ::interop/semantic-tokens)))
+
+  (^CompletableFuture prepareCallHierarchy [_ ^CallHierarchyPrepareParams params]
+    (start :prepareCallHierarchy
+           (async-handler params handlers/prepare-call-hierarchy ::interop/call-hierarchy-items)))
+
+  (^CompletableFuture callHierarchyIncomingCalls [_ ^CallHierarchyIncomingCallsParams params]
+    (start :callHierarchyIncomingCalls
+           (async-handler params handlers/call-hierarchy-incoming ::interop/call-hierarchy-incoming-calls)))
+
+  (^CompletableFuture callHierarchyOutgoingCalls [_ ^CallHierarchyOutgoingCallsParams params]
+    (start :callHierarchyOutgoingCalls
+           (async-handler params handlers/call-hierarchy-outgoing ::interop/call-hierarchy-outgoing-calls))))
+
+(deftype LSPWorkspaceService []
+  WorkspaceService
+  (^CompletableFuture executeCommand [_ ^ExecuteCommandParams params]
+    (start :executeCommand
+           (future
+             (sync-handler params handlers/execute-command)))
+    (CompletableFuture/completedFuture 0))
+
+  (^void didChangeConfiguration [_ ^DidChangeConfigurationParams params]
+    (log/warn (interop/java->clj params)))
+
+  (^void didChangeWatchedFiles [_ ^DidChangeWatchedFilesParams params]
+    (start :didChangeWatchedFiles
+           (end
+             (some->> params
+                      (.getChanges)
+                      (interop/conform-or-log ::interop/watched-files-changes)
+                      (handlers/did-change-watched-files)))))
+
+  ;; TODO wait for lsp4j release
+  #_(^void didDeleteFiles [_ ^DeleteFilesParams params]
+                          (start :didSave
+                                 (sync-handler params handlers/did-delete-files)))
+
+  (^CompletableFuture symbol [_ ^WorkspaceSymbolParams params]
+    (start :workspaceSymbol
+           (async-handler params handlers/workspace-symbols ::interop/workspace-symbols))))
+
+(defn ^:private client-settings [^InitializeParams params]
+  (-> params
+      interop/java->clj
+      :initializationOptions
+      (or {})
+      shared/keywordize-first-depth
+      (interop/clean-client-settings)))
+
+(defn ^:private client-capabilities [^InitializeParams params]
+  (some->> params
+           .getCapabilities
+           (interop/conform-or-log ::interop/client-capabilities)))
+
+;; Called from java
+(defn extension [method & args]
+  (start :extension
+         (CompletableFuture/completedFuture
+           (end
+             (apply #'handlers/extension method args)))))
+
+(defn ^:private start-parent-process-liveness-probe!
+  [ppid server]
+  (go-loop []
+    (<! (timeout 5000))
+    (if (shared/process-alive? ppid)
+      (recur)
+      (do
+        (log/info "Parent process" ppid "is not running - exiting server")
+        (.exit server)))))
+
+(def server
+  (proxy [ClojureExtensions LanguageServer ExtraMethods] []
+    (^CompletableFuture initialize [^InitializeParams params]
+      (start :initialize
+             (end
+               (do
+                 (log/info "Initializing...")
+                 (handlers/initialize (.getRootUri params)
+                                      (client-capabilities params)
+                                      (client-settings params))
+                 (when-let [parent-process-id (.getProcessId params)]
+                   (start-parent-process-liveness-probe! parent-process-id this))
+                 (let [settings (:settings @db/db)]
+                   (CompletableFuture/completedFuture
+                     (InitializeResult. (doto (ServerCapabilities.)
+                                          (.setDocumentHighlightProvider true)
+                                          (.setHoverProvider true)
+                                          (.setSignatureHelpProvider (SignatureHelpOptions. []))
+                                          (.setCallHierarchyProvider true)
+                                          (.setCodeActionProvider (doto (CodeActionOptions. interop/code-action-kind)
+                                                                    (.setResolveProvider true)))
+                                          (.setCodeLensProvider (CodeLensOptions. true))
+                                          (.setReferencesProvider true)
+                                          (.setRenameProvider true)
+                                          (.setDefinitionProvider true)
+                                          (.setDocumentFormattingProvider ^Boolean (:document-formatting? settings))
+                                          (.setDocumentRangeFormattingProvider ^Boolean (:document-range-formatting? settings))
+                                          (.setDocumentSymbolProvider true)
+                                          (.setWorkspaceSymbolProvider true)
+                                          (.setSemanticTokensProvider (when (or (not (contains? settings :semantic-tokens?))
+                                                                                (:semantic-tokens? settings))
+                                                                        (doto (SemanticTokensWithRegistrationOptions.)
+                                                                          (.setLegend (doto (SemanticTokensLegend.
+                                                                                              semantic-tokens/token-types-str
+                                                                                              semantic-tokens/token-modifiers)))
+                                                                          (.setRange true)
+                                                                          (.setFull true))))
+                                          (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
+                                                                        (.setCommands f.refactor/available-refactors)))
+                                          (.setTextDocumentSync (doto (TextDocumentSyncOptions.)
+                                                                  (.setOpenClose true)
+                                                                  (.setChange (case (:text-document-sync-kind settings)
+                                                                                :full TextDocumentSyncKind/Full
+                                                                                :incremental TextDocumentSyncKind/Incremental
+                                                                                TextDocumentSyncKind/Full))
+                                                                  (.setSave (SaveOptions. true))))
+                                          (.setCompletionProvider (CompletionOptions. true []))))))))))
+
+    (^void initialized [^InitializedParams params]
+      (start :initialized
+             (end
+               (do
+                 (log/info "Initialized!")
+                 (let [client ^LanguageClient (:client @db/db)]
+                   (.registerCapability client
+                                        (RegistrationParams. [(Registration. "id" "workspace/didChangeWatchedFiles"
+                                                                             (DidChangeWatchedFilesRegistrationOptions. [(FileSystemWatcher. "**")]))])))))))
+
+    (^CompletableFuture serverInfoRaw []
+      (CompletableFuture/completedFuture
+        (->> (handlers/server-info-raw)
+             (interop/conform-or-log ::interop/server-info-raw))))
+
+    (^void serverInfoLog []
+      (start :server-info-log
+             (future
+               (end
+                 (handlers/server-info-log)))))
+
+    (^void cursorInfoLog [^CursorInfoParams params]
+      (start :cursor-info-log
+             (future
+               (sync-handler params handlers/cursor-info-log))))
+
+    (^CompletableFuture shutdown []
+      (log/info "Shutting down")
+      (reset! db/db {:documents {}}) ;; TODO confirm this is correct
+      (CompletableFuture/completedFuture
+        {:result nil}))
+    (exit []
+      (log/info "Exitting...")
+      (shutdown-agents)
+      (System/exit 0))
+    (getTextDocumentService []
+      (LSPTextDocumentService.))
+    (getWorkspaceService []
+      (LSPWorkspaceService.))))
+
+(defn ^:private tee-system-in [system-in]
+  (let [buffer-size 1024
+        os (java.io.PipedOutputStream.)
+        is (java.io.PipedInputStream. os)]
+    (thread
+      (try
+        (let [buffer (byte-array buffer-size)]
+          (loop [chs (.read system-in buffer 0 buffer-size)]
+            (when (pos? chs)
+              (log/warn "FROM STDIN" chs (String. (java.util.Arrays/copyOfRange buffer 0 chs)))
+              (.write os buffer 0 chs)
+              (recur (.read system-in buffer 0 buffer-size)))))
+        (catch Exception e
+          (log/error e "in thread"))))
+    is))
+
+(defn ^:private tee-system-out [system-out]
+  (let [buffer-size 1024
+        is (java.io.PipedInputStream.)
+        os (java.io.PipedOutputStream. is)]
+    (thread
+      (try
+        (let [buffer (byte-array buffer-size)]
+          (loop [chs (.read is buffer 0 buffer-size)]
+            (when (pos? chs)
+              (log/warn "FROM STDOUT" chs (String. (java.util.Arrays/copyOfRange buffer 0 chs)))
+              (.write system-out buffer)
+              (recur (.read is buffer 0 buffer-size)))))
+        (catch Exception e
+          (log/error e "in thread"))))
+    os))
+
+(defn run-server! []
+  (log/info "Starting server...")
+  (let [is (or System/in (tee-system-in System/in))
+        os (or System/out (tee-system-out System/out))
+        launcher (LSPLauncher/createServerLauncher server is os)
+        debounced-diags (shared/debounce-by db/diagnostics-chan config/diagnostics-debounce-ms :uri)
+        debounced-changes (shared/debounce-by db/current-changes-chan config/change-debounce-ms :uri)]
+    (nrepl/setup-nrepl)
+    (swap! db/db assoc :client ^LanguageClient (.getRemoteProxy launcher))
+    (go-loop [edit (<! db/edits-chan)]
+      (producer/workspace-apply-edit edit)
+      (recur (<! db/edits-chan)))
+    (go-loop []
+      (producer/publish-diagnostic (<! debounced-diags))
+      (recur))
+    (go-loop []
+      (try
+        (f.file-management/analyze-changes (<! debounced-changes))
+        (catch Exception e
+          (log/error e "Error during analyzing buffer file changes")))
+      (recur))
+    (.startListening launcher)))

--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -147,6 +147,15 @@
   [& components]
   (.getPath ^java.io.File (apply io/file components)))
 
+(defn namespace->uri [namespace source-paths filename]
+  (let [file-type (uri->file-type filename)]
+    (filename->uri
+      (join-filepaths (first (filter #(string/starts-with? filename %) source-paths))
+                             (-> namespace
+                                 (string/replace "." (System/getProperty "file.separator"))
+                                 (string/replace "-" "_")
+                                 (str "." (name file-type)))))))
+
 (defn ->range [{:keys [name-row name-end-row name-col name-end-col row end-row col end-col] :as element}]
   (when element
     {:start {:line (max 0 (dec (or name-row row))) :character (max 0 (dec (or name-col col)))}

--- a/test/clojure_lsp/api_test.clj
+++ b/test/clojure_lsp/api_test.clj
@@ -1,0 +1,26 @@
+(ns clojure-lsp.api-test
+  (:require
+    [clojure-lsp.api :as api]
+    [clojure-lsp.db :as db]
+    [clojure-lsp.test-helper :as h]
+    [clojure.java.io :as io]
+    [clojure.test :refer [deftest is testing]]
+    [clojure.string :as string]))
+
+(h/reset-db-after-test)
+
+(deftest clean-ns!
+  (testing "when project-root is not a file"
+    (is (thrown? AssertionError
+                 (api/clean-ns! :project-root "integration-test/sample-test"))))
+  (testing "when project-root is not a existent file"
+    (is (thrown? AssertionError
+                 (api/clean-ns! :project-root (io/file "integration-test/sample-test/bla")))))
+  (testing "when project-root is a valid file"
+    (testing "when a single namespace is specified"
+      (reset! db/db {})
+      (with-redefs [spit #(is (= (slurp "integration-test/sample-test/fixtures/api/clean_ns/a.clj") %2))]
+        (is (string/includes?
+              (with-out-str (api/clean-ns! :project-root (io/file "integration-test/sample-test")
+                                            :namespace '[api.clean-ns.a]))
+              "Cleaned api.clean-ns.a\n"))))))

--- a/test/clojure_lsp/features/code_actions_test.clj
+++ b/test/clojure_lsp/features/code_actions_test.clj
@@ -5,7 +5,7 @@
     [clojure-lsp.parser :as parser]
     [clojure-lsp.test-helper :as h]
     [clojure.string :as string]
-    [clojure.test :refer [deftest testing is]]))
+    [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/completion_test.clj
+++ b/test/clojure_lsp/features/completion_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.feature.completion :as f.completion]
    [clojure-lsp.test-helper :as h]
    [clojure.string :as string]
-   [clojure.test :refer [deftest testing is]]))
+   [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/diagnostics_test.clj
+++ b/test/clojure_lsp/features/diagnostics_test.clj
@@ -3,7 +3,7 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.diagnostics :as f.diagnostic]
    [clojure-lsp.test-helper :as h]
-   [clojure.test :refer [deftest testing is]]))
+   [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/file_management_test.clj
+++ b/test/clojure_lsp/features/file_management_test.clj
@@ -3,7 +3,7 @@
     [clojure-lsp.db :as db]
     [clojure-lsp.feature.file-management :as f.file-management]
     [clojure-lsp.test-helper :as h]
-    [clojure.test :refer [deftest testing is]]))
+    [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/rename_test.clj
+++ b/test/clojure_lsp/features/rename_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure-lsp.feature.rename :as f.rename]
     [clojure-lsp.test-helper :as h]
-    [clojure.test :refer [deftest testing is]]))
+    [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/resolve_macro_test.clj
+++ b/test/clojure_lsp/features/resolve_macro_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.test-helper :as h]
    [clojure.core.async :as async]
-   [clojure.test :refer [deftest testing is]]))
+   [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/signature_help_test.clj
+++ b/test/clojure_lsp/features/signature_help_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure-lsp.feature.signature-help :as f.signature-help]
    [clojure-lsp.test-helper :as h]
-   [clojure.test :refer [deftest testing is]]))
+   [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -1,8 +1,8 @@
 (ns clojure-lsp.features.workspace-symbols-test
   (:require
-    [clojure.test :refer [deftest testing is]]
+    [clojure-lsp.feature.workspace-symbols :as f.workspace-symbols]
     [clojure-lsp.test-helper :as h]
-    [clojure-lsp.feature.workspace-symbols :as f.workspace-symbols]))
+    [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 

--- a/test/clojure_lsp/server_test.clj
+++ b/test/clojure_lsp/server_test.clj
@@ -1,6 +1,6 @@
-(ns clojure-lsp.main-test
+(ns clojure-lsp.server-test
   (:require
-   [clojure-lsp.main :as main]
+   [clojure-lsp.server :as server]
    [clojure.test :refer [deftest is testing]])
   (:import
    (org.eclipse.lsp4j
@@ -11,10 +11,10 @@
     (let [params (InitializeParams.)]
       (.setInitializationOptions params nil)
       (is (= "zipfile"
-             (get (#'main/client-settings params) :dependency-scheme)))))
+             (get (#'server/client-settings params) :dependency-scheme)))))
   (testing "document-formatting? is set to true if not provided"
     (let [params (InitializeParams.)]
-      (is (= true (:document-formatting? (#'main/client-settings params))))))
+      (is (= true (:document-formatting? (#'server/client-settings params))))))
   (testing "document-range-formatting? is set to true if not provided"
     (let [params (InitializeParams.)]
-      (is (= true (:document-range-formatting? (#'main/client-settings params)))))))
+      (is (= true (:document-range-formatting? (#'server/client-settings params)))))))


### PR DESCRIPTION
Fixes #https://github.com/clojure-lsp/clojure-lsp/issues/215

This PR introduces an API to be accessed as a lib and CLI to use clojure-lsp features outside an editor.
The first (only for now) method available is the `clean-ns` where it uses the `clean-ns` refactoring.

```bash
clojure-lsp clean-ns
```
with optional `--project-root` and `--namespace` argumetns