### PR TITLE
Respect XDG specification regarding empty XDG_CONFIG_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- API/CLI
+  - Fix empty `XDG_CONFIG_HOME` not defaulting to `$HOME/.config` #474
+
 ## 2021.07.12-12.30.59
 
 - Editor

--- a/src/clojure_lsp/config.clj
+++ b/src/clojure_lsp/config.clj
@@ -63,12 +63,13 @@
   (.exists f))
 
 (defn ^:private get-home-config-file []
-  (if-let [xdg-config-home (get-env "XDG_CONFIG_HOME")]
-    (io/file xdg-config-home ".lsp" "config.edn")
-    (let [xdg-config-default (io/file (get-property "user.home") ".config" ".lsp" "config.edn")]
-      (if (file-exists? xdg-config-default)
-        xdg-config-default 
-        (io/file (get-property "user.home") ".lsp" "config.edn")))))
+  (let [xdg-config-home (or (get-env "XDG_CONFIG_HOME")
+                            (io/file (get-property "user.home") ".config"))
+        xdg-config (io/file xdg-config-home ".lsp" "config.edn")
+        home-config (io/file (get-property "user.home") ".lsp" "config.edn")]
+    (if (file-exists? xdg-config)
+      xdg-config
+      home-config)))
 
 (defn ^:private resolve-home-config [^java.io.File home-dir-file]
   (when (file-exists? home-dir-file)

--- a/src/clojure_lsp/config.clj
+++ b/src/clojure_lsp/config.clj
@@ -68,7 +68,7 @@
     (let [xdg-config-default (io/file (get-property "user.home") ".config" ".lsp" "config.edn")]
       (if (file-exists? xdg-config-default)
         xdg-config-default 
-        (io/file (get-property "user.home") ".lsp" "config.edn")))
+        (io/file (get-property "user.home") ".lsp" "config.edn")))))
 
 (defn ^:private resolve-home-config [^java.io.File home-dir-file]
   (when (file-exists? home-dir-file)

--- a/src/clojure_lsp/config.clj
+++ b/src/clojure_lsp/config.clj
@@ -65,7 +65,10 @@
 (defn ^:private get-home-config-file []
   (if-let [xdg-config-home (get-env "XDG_CONFIG_HOME")]
     (io/file xdg-config-home ".lsp" "config.edn")
-    (io/file (get-property "user.home") ".lsp" "config.edn")))
+    (let [xdg-config-default (io/file (get-property "user.home") ".config" ".lsp" "config.edn")]
+      (if (file-exists? xdg-config-default)
+        xdg-config-default 
+        (io/file (get-property "user.home") ".lsp" "config.edn")))
 
 (defn ^:private resolve-home-config [^java.io.File home-dir-file]
   (when (file-exists? home-dir-file)


### PR DESCRIPTION
fix #474

This changes the `get-home-config-file` function to respect XDG specification regarding empty `XDG_CONFIG_HOME`