### PR TITLE
Clean up hover output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Editor
+  - Improve hover output, both markdown and plain text forms.
+
 - API/CLI
   - Fix empty `XDG_CONFIG_HOME` not defaulting to `$HOME/.config` #474
 

--- a/src/clojure_lsp/feature/hover.clj
+++ b/src/clojure_lsp/feature/hover.clj
@@ -53,7 +53,7 @@
                 doc-line (str line-break doc-line)
                 filename (str (format "%s*[%s](%s)*"
                                       line-break
-                                      (string/replace filename #"\\" #"\\\\")
+                                      (string/replace filename #"\\" "\\\\")
                                       (shared/filename->uri filename))))}
       ;; Default to plaintext
       (cond->> []

--- a/src/clojure_lsp/feature/hover.clj
+++ b/src/clojure_lsp/feature/hover.clj
@@ -53,7 +53,7 @@
                 doc-line (str line-break doc-line)
                 filename (str (format "%s*[%s](%s)*"
                                       line-break
-                                      (string/replace filename #"\\" "#\\\\")
+                                      (string/replace filename #"\\" #"\\\\")
                                       (shared/filename->uri filename))))}
       ;; Default to plaintext
       (cond->> []

--- a/src/clojure_lsp/feature/hover.clj
+++ b/src/clojure_lsp/feature/hover.clj
@@ -6,7 +6,7 @@
    [clojure-lsp.shared :as shared]
    [clojure.string :as string]))
 
-(def line-break "\n----\n")
+(def line-break "\n\n----\n\n")
 (def opening-code "```clojure\n")
 (def closing-code "\n```")
 

--- a/src/clojure_lsp/feature/hover.clj
+++ b/src/clojure_lsp/feature/hover.clj
@@ -34,13 +34,15 @@
 (defn hover-documentation [{sym-ns :ns sym-name :name :keys [doc filename arglist-strs] :as _definition}]
   (let [[content-format] (get-in @db/db [:client-capabilities :text-document :hover :content-format])
         show-docs-arity-on-same-line? (get-in @db/db [:settings :show-docs-arity-on-same-line?])
-        signatures (some->> arglist-strs (remove nil?) (string/join "\n"))
+        join-char (if show-docs-arity-on-same-line? " " "\n")
+        signatures (some->> arglist-strs
+                            (remove nil?)
+                            (string/join join-char))
         sym (cond->> sym-name
               sym-ns (str sym-ns "/"))
+        sym-line (str sym (when signatures
+                            (str join-char signatures)))
         markdown? (= "markdown" content-format)
-        sym-line (str sym (when show-docs-arity-on-same-line? (str " " signatures)))
-        signatures-line (when (not show-docs-arity-on-same-line?)
-                          signatures)
         doc-line (when (seq doc)
                    (if markdown?
                      (docstring->formatted-markdown doc)
@@ -48,17 +50,21 @@
     (if markdown?
       {:kind "markdown"
        :value (cond-> (str opening-code sym-line closing-code)
-                signatures-line (str "\n" opening-code signatures-line closing-code)
-                doc-line (str line-break doc-line "\n")
+                doc-line (str line-break doc-line)
                 filename (str (format "%s*[%s](%s)*"
                                       line-break
                                       (string/replace filename #"\\" "#\\\\")
                                       (shared/filename->uri filename))))}
       ;; Default to plaintext
-      [(cond-> (str sym-line "\n")
-         signatures-line (str signatures-line "\n")
-         doc-line (str line-break doc-line)
-         filename (str line-break filename))])))
+      (cond->> []
+        filename (cons filename)
+        doc-line (cons doc-line)
+        (and signatures
+             (not show-docs-arity-on-same-line?))
+        (cons {:language "clojure"
+               :value signatures})
+        sym (cons {:language "clojure"
+                   :value (if show-docs-arity-on-same-line? sym-line sym)})))))
 
 (defn hover [filename line column]
   (let [analysis (:analysis @db/db)

--- a/test/clojure_lsp/features/completion_test.clj
+++ b/test/clojure_lsp/features/completion_test.clj
@@ -141,7 +141,11 @@
     (is (= {:label "Some" :kind :module}
            (f.completion/resolve-item {:label "Some" :kind :module}))))
   (testing "When element contains data of a element/knows the element"
-    (is (= {:label "foo" :documentation [(str "a/foo\n\n----\nSome docs\n----\n" (h/file-path "/a.clj"))] :kind :variable}
+    (is (= {:label "foo"
+            :documentation [{:language "clojure" :value "a/foo"}
+                            "Some docs"
+                            (h/file-path "/a.clj")]
+            :kind :variable}
            (f.completion/resolve-item {:label "foo"
                                        :kind :variable
                                        :data {:name "foo"
@@ -149,7 +153,11 @@
                                               :name-row 1
                                               :name-col 13}}))))
   (testing "When element contains data of a element/knows the element"
-    (is (= {:label "foo" :documentation [(str "a/foo\n\n----\nSome docs\n----\n" (h/file-path "/a.clj"))] :kind :function}
+    (is (= {:label "foo"
+            :documentation [{:language "clojure" :value "a/foo"}
+                            "Some docs"
+                            (h/file-path "/a.clj")]
+            :kind :function}
            (f.completion/resolve-item {:label "foo"
                                        :kind :function
                                        :data {:name "foo"

--- a/test/clojure_lsp/features/hover_test.clj
+++ b/test/clojure_lsp/features/hover_test.clj
@@ -14,6 +14,7 @@
 (deftest hover
   (let [start-code "```clojure"
         end-code "```"
+        line-break "\n----\n"
         code (str "(ns a)\n"
                   "(defn foo \"Some cool docs :foo\" [x] x)\n"
                   "(defn bar [y] y)\n"
@@ -37,9 +38,9 @@
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
-                                  "----"
+                                  line-break
                                   doc
-                                  "----"
+                                  line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col))))))
 
@@ -55,9 +56,9 @@
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code (str sym " " sig) end-code
-                                  "----"
+                                  line-break
                                   doc
-                                  "----"
+                                  line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col))))))))
 
@@ -76,7 +77,7 @@
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
-                                  "----"
+                                  line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col))))))
 
@@ -91,6 +92,6 @@
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind "markdown"
                     :value (join [start-code (str sym " " sig) end-code
-                                  "----"
+                                  line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col))))))))))

--- a/test/clojure_lsp/features/hover_test.clj
+++ b/test/clojure_lsp/features/hover_test.clj
@@ -28,32 +28,27 @@
             filename (h/file-path "/a.clj")]
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
-            (is (= [(join [sym
-                           sig
-                           "" "----"
-                           doc
-                           "----"
-                           filename])]
+            (is (= [{:language "clojure" :value sym}
+                    {:language "clojure" :value sig}
+                    doc
+                    filename]
                    (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col)))))
           (testing "markdown"
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
-                    :value (join [start-code sym end-code
-                                  start-code sig end-code
+                    :value (join [start-code sym sig end-code
                                   "----"
                                   doc
-                                  "\n----"
+                                  "----"
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db merge {:settings {:show-docs-arity-on-same-line? true} :client-capabilities nil})
-            (is (= [(join [(str sym " " sig)
-                           "" "----"
-                           doc
-                           "----"
-                           filename])]
+            (is (= [{:language "clojure" :value (str sym " " sig)}
+                    doc
+                    filename]
                    (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col)))))
 
           (testing "markdown"
@@ -62,7 +57,7 @@
                     :value (join [start-code (str sym " " sig) end-code
                                   "----"
                                   doc
-                                  "\n----"
+                                  "----"
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col))))))))
 
@@ -73,16 +68,14 @@
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
             (swap! db/db merge {:settings {:show-docs-arity-on-same-line? false} :client-capabilities nil})
-            (is (= [(join [sym
-                           sig
-                           "" "----"
-                           filename])]
+            (is (= [{:language "clojure" :value sym}
+                    {:language "clojure" :value sig}
+                    filename]
                    (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col)))))
           (testing "markdown"
             (swap! db/db merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
-                    :value (join [start-code sym end-code
-                                  start-code sig end-code
+                    :value (join [start-code sym sig end-code
                                   "----"
                                   (str "*[" filename "](file:///a.clj)*")])}
                    (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col))))))
@@ -90,9 +83,8 @@
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db merge {:settings {:show-docs-arity-on-same-line? true} :client-capabilities nil})
-            (is (= [(join [(str sym " " sig)
-                           "" "----"
-                           filename])]
+            (is (= [{:language "clojure" :value (str sym " " sig)}
+                    filename]
                    (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col)))))
 
           (testing "markdown"


### PR DESCRIPTION
Instead of returning a text string to the editor, we can return multiple strings or objects, each of which will be formatted as a unit. (Per the [spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover).) This removes the need for hand-writing the dashes in most cases. I also removed the additional linebreak in the docstring portion, and merged the symbol and signature into a single code block.

With markdown and multi-arity params on separate lines: 
<img width="737" alt="image" src="https://user-images.githubusercontent.com/603677/125525833-769d95fb-5c5a-4fea-a814-cf2ddd5b12c9.png">

With markdown and multi-arity params on same line:
<img width="726" alt="image" src="https://user-images.githubusercontent.com/603677/125525914-5da9e300-2e10-4417-98d4-b345afd45081.png">

With text and multi-arity params on separate lines:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/603677/125526047-7c4cd306-0a8b-4aaa-a6f2-f39efb155806.png">

With text and multi-arity params on same line:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/603677/125526127-81476dd1-6059-4b1e-a27b-26e654517b29.png">

I briefly tried this out with vs code and Calva and it looks good there as well, tho I don't have screenshots handy.