### PR TITLE
Unescape URI for opening up JAR files.

### DIFF
--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -92,13 +92,19 @@
   (-> uri Paths/get .toString
       (string/replace #"^[a-z]:\\" string/upper-case)))
 
+(defn- unescape-uri
+  [uri]
+  (-> (string/replace uri #"%3A" ":")
+      (string/replace #"%21" "!")))
+
 (defn uri->filename
   "Converts a URI string into an absolute file path.
 
   The output path representation matches that of the operating system."
   [^String uri]
   (if (string/starts-with? uri "jar:")
-    (let [conn ^JarURLConnection (.openConnection (URL. uri))
+    (let [unescaped-uri (unescape-uri uri)
+          conn ^JarURLConnection (.openConnection (URL. unescaped-uri))
           jar-file (uri-obj->filepath ^URI (.toURI ^URL (.getJarFileURL conn)))]
       (str jar-file ":" (.getEntryName conn)))
     (let [uri-obj (URI. uri)

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -83,3 +83,10 @@
             :end   {:line      0
                     :character 0}}
            (shared/->range {:row 0 :end-row 0 :col 0 :end-col 0})))))
+
+(def unescape-uri-var #'shared/unescape-uri)
+
+(deftest unescape-uri
+  (testing "unescaping a URI containing %3A and %21 characters"
+    (is (= "jar:file:///home/foo/bar.jar!foo.bar"
+           (unescape-uri-var "jar:file%3A///home/foo/bar.jar%21foo.bar")))))


### PR DESCRIPTION
Fixes #492

-=david=-
