### PR TITLE
Unescape JAR URI.

### DIFF
--- a/resources/META-INF/native-image/clojure-lsp/clojure-lsp/reflect-config.json
+++ b/resources/META-INF/native-image/clojure-lsp/clojure-lsp/reflect-config.json
@@ -63,6 +63,10 @@
   "allPublicMethods":true
 },
 {
+  "name":"java.net.URLDecoder",
+  "allPublicMethods":true
+},
+{
   "name":"java.util.ArrayList",
   "allPublicConstructors":true
 },

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -83,3 +83,16 @@
             :end   {:line      0
                     :character 0}}
            (shared/->range {:row 0 :end-row 0 :col 0 :end-col 0})))))
+
+(def unescape-uri #'shared/unescape-uri)
+
+(deftest unescape-uri-test
+  (testing "URI should unescape."
+    (is (= "jar:file:///home/foo/bar.jar!baz.clj"
+           (unescape-uri "jar:file%3A///home/foo/bar.jar%21baz.clj"))))
+  (testing "URI should remain the same."
+    (is (= "file:///home/foo/bar.jar"
+           (unescape-uri "file:///home/foo/bar.jar"))))
+  (testing "URI should remain the same as IllegalArgumentException is thrown."
+    (is (= "file:///home/foo/bar.jar%%"
+           (unescape-uri "file:///home/foo/bar.jar%%")))))


### PR DESCRIPTION
It appears that certain clients send to clojure-lsp, the URI (following
the scheme) encoded - namely the characters `:` and `!` which are
encoded as `%3A` and `%21` respectively.

This encoding unfortunately prevents the JAR from being opened for
returning back to the client for display.

By using `java.net.Decoder/decode`, the URI is unescaped back to its
original form, thus allowing the JAR to be opened successfully.

Fixes #492

-=david=-