### PR TITLE
Improve clean-ns to checking analysis 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
         medley/medley {:mvn/version "1.3.0"}
         anonimitoraf/clj-flx {:mvn/version "1.2.0"}
-        clj-kondo/clj-kondo {:mvn/version "2021.08.07-20210813.083728-8"}}
+        clj-kondo/clj-kondo {:mvn/version "2021.08.07-20210822.045523-16"}}
  :paths ["src" "classes" "resources"]
  :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.861"}}
                   :extra-paths ["test"]

--- a/src/clojure_lsp/queries.clj
+++ b/src/clojure_lsp/queries.clj
@@ -316,6 +316,7 @@
          (filter (comp #(= % :unused-namespace) :type))
          (remove (fn [finding]
                    (some #(and (= :var-usages (:bucket %))
+                               (not (:refer %))
                                (= (:ns finding) (:to %)))
                          local-analysis)))
          (map :ns)

--- a/test/clojure_lsp/queries_test.clj
+++ b/test/clojure_lsp/queries_test.clj
@@ -264,7 +264,7 @@
              (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
     (testing "used and unused aliases"
       (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o")
-      (is (= '#{bar}
+      (is (= '#{y bar}
              (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj"))))))
   (testing "cljc"
     (testing "used require via alias"
@@ -285,7 +285,7 @@
              (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
     (testing "used and unused aliases"
       (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o" (h/file-uri "file:///a.cljc"))
-      (is (= '#{bar}
+      (is (= '#{y bar}
              (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
     (testing "used alias in a reader conditional"
       (h/load-code-and-locs "(ns a (:require [y :as o] [x :as f])) #?(:clj f/foo)" (h/file-uri "file:///a.cljc"))

--- a/test/clojure_lsp/queries_test.clj
+++ b/test/clojure_lsp/queries_test.clj
@@ -245,70 +245,148 @@
       (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c))))
 
 (deftest find-unused-aliases
-  (testing "used require via alias"
-    (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo")
-    (is (= '#{}
-           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "used require via full-ns"
-    (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo")
-    (is (= '#{}
-           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "full-ns require"
-    (h/load-code-and-locs "(ns a (:require [x] y)) foo")
-    (is (= '#{}
-           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "single unused-alias"
-    (h/load-code-and-locs "(ns a (:require [x :as f]))")
-    (is (= '#{x}
-           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "used and unused aliases"
-    (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o")
-    (is (= '#{y bar}
-           (q/find-unused-aliases (:findings @db/db) (h/file-path "/a.clj"))))))
+  (testing "clj"
+    (testing "used require via alias"
+      (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo")
+      (is (= '#{}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "used require via full-ns"
+      (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo")
+      (is (= '#{}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "full-ns require"
+      (h/load-code-and-locs "(ns a (:require [x] y)) foo")
+      (is (= '#{}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "single unused-alias"
+      (h/load-code-and-locs "(ns a (:require [x :as f]))")
+      (is (= '#{x}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "used and unused aliases"
+      (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o")
+      (is (= '#{bar}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj"))))))
+  (testing "cljc"
+    (testing "used require via alias"
+      (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo" (h/file-uri "file:///a.cljc"))
+      (is (= '#{}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "used require via full-ns"
+      (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo" (h/file-uri "file:///a.cljc"))
+      (is (= '#{}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "full-ns require"
+      (h/load-code-and-locs "(ns a (:require [x] y)) foo" (h/file-uri "file:///a.cljc"))
+      (is (= '#{}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "single unused-alias"
+      (h/load-code-and-locs "(ns a (:require [x :as f]))" (h/file-uri "file:///a.cljc"))
+      (is (= '#{x}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "used and unused aliases"
+      (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o" (h/file-uri "file:///a.cljc"))
+      (is (= '#{bar}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "used alias in a reader conditional"
+      (h/load-code-and-locs "(ns a (:require [y :as o] [x :as f])) #?(:clj f/foo)" (h/file-uri "file:///a.cljc"))
+      (is (= '#{y}
+             (q/find-unused-aliases (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))))
 
 (deftest find-unused-refers
-  (testing "used require via refer"
-    (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo")
-    (is (= '#{}
-           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "multiple used refers"
-    (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz")
-    (is (= '#{}
-           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "single unused refer"
-    (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))")
-    (is (= '#{x/foo}
-           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "multiple unused refer"
-    (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))")
-    (is (= '#{x/foo x/bar}
-           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "multiple unused refer and used"
-    (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar")
-    (is (= '#{x/foo x/baz}
-           (q/find-unused-refers (:findings @db/db) (h/file-path "/a.clj"))))))
+  (testing "clj"
+    (testing "used require via refer"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo")
+      (is (= '#{}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "multiple used refers"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz")
+      (is (= '#{}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "single unused refer"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))")
+      (is (= '#{x/foo}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "multiple unused refer"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))")
+      (is (= '#{x/foo x/bar}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "multiple unused refer and used"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar")
+      (is (= '#{x/foo x/baz}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj"))))))
+  (testing "cljc"
+    (testing "used require via refer"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo" (h/file-uri "file:///a.cljc"))
+      (is (= '#{}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "multiple used refers"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz" (h/file-uri "file:///a.cljc"))
+      (is (= '#{}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "single unused refer"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))" (h/file-uri "file:///a.cljc"))
+      (is (= '#{x/foo}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "multiple unused refer"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))" (h/file-uri "file:///a.cljc"))
+      (is (= '#{x/foo x/bar}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "multiple unused refer and used"
+      (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar" (h/file-uri "file:///a.cljc"))
+      (is (= '#{x/foo x/baz}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "used refer in a reader conditional"
+      (h/load-code-and-locs "(ns a (:require [y :refer [o]] [x :refer [f]])) #?(:clj f)" (h/file-uri "file:///a.cljc"))
+      (is (= '#{y/o}
+             (q/find-unused-refers (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))))
 
 (deftest find-unused-imports
-  (testing "single used full import"
-    (h/load-code-and-locs "(ns a (:import java.util.Date)) Date.")
-    (is (= '#{}
-           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "single unused full import"
-    (h/load-code-and-locs "(ns a (:import java.util.Date))")
-    (is (= '#{java.util.Date}
-           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "multiple unused full imports"
-    (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))")
-    (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "multiple unused package imports"
-    (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))")
-    (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj")))))
-  (testing "multiple unused and used imports"
-    (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime.")
-    (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-           (q/find-unused-imports (:findings @db/db) (h/file-path "/a.clj"))))))
+  (testing "clj"
+    (testing "single used full import"
+      (h/load-code-and-locs "(ns a (:import java.util.Date)) Date.")
+      (is (= '#{}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "single unused full import"
+      (h/load-code-and-locs "(ns a (:import java.util.Date))")
+      (is (= '#{java.util.Date}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "multiple unused full imports"
+      (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))")
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "multiple unused package imports"
+      (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))")
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj")))))
+    (testing "multiple unused and used imports"
+      (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime.")
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.clj"))))))
+  (testing "cljc"
+    (testing "single used full import"
+      (h/load-code-and-locs "(ns a (:import java.util.Date)) Date." (h/file-uri "file:///a.cljc"))
+      (is (= '#{}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "single unused full import"
+      (h/load-code-and-locs "(ns a (:import java.util.Date))" (h/file-uri "file:///a.cljc"))
+      (is (= '#{java.util.Date}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "multiple unused full imports"
+      (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))" (h/file-uri "file:///a.cljc"))
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "multiple unused package imports"
+      (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))" (h/file-uri "file:///a.cljc"))
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "multiple unused and used imports"
+      (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime." (h/file-uri "file:///a.cljc"))
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))
+    (testing "used import in a reader conditional"
+      (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) #?(:clj LocalTime.)" (h/file-uri "file:///a.cljc"))
+      (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
+             (q/find-unused-imports (:analysis @db/db) (:findings @db/db) (h/file-path "/a.cljc")))))))
 
 (deftest find-local-usages-under-cursor
   (testing "inside let"

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -388,6 +388,15 @@
                          " (:require"
                          "  [bar :refer [some] ]))"
                          "(some)")))
+  (testing "unused refer and alias"
+    (test-clean-ns {}
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "  [baz]"
+                         "  [bar :refer [some other] :as b]))")
+                   (code "(ns foo.bar"
+                         " (:require"
+                         "  [baz]))")))
   (testing "unused refer from single refer but used alias before"
     (test-clean-ns {}
                    (code "(ns foo.bar"

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -193,11 +193,13 @@
   ([db input-code expected-code]
    (test-clean-ns db input-code expected-code true))
   ([db input-code expected-code in-form]
+   (test-clean-ns db input-code expected-code in-form "file:///a.clj"))
+  ([db input-code expected-code in-form uri]
    (reset! db/db db)
-   (h/load-code-and-locs input-code (h/file-uri "file:///a.cljc"))
+   (h/load-code-and-locs input-code (h/file-uri uri))
    (let [zloc (when in-form
                 (-> (z/of-string input-code) z/down z/right z/right))
-         [{:keys [loc range]}] (transform/clean-ns zloc (h/file-uri "file:///a.cljc") db/db)]
+         [{:keys [loc range]}] (transform/clean-ns zloc (h/file-uri uri) db/db)]
      (is (some? range))
      (is (= expected-code
             (z/root-string loc))))))
@@ -685,13 +687,15 @@
                          "Date."
                          "List.")))
   (testing "cljc conditional readers"
-    (testing "remove reader macro after removing unused single require alias"
+    (testing "remove reader conditional after removing unused single require alias"
       (test-clean-ns {}
                      (code "(ns foo.bar"
                            " (:require"
                            "  #?(:clj [other.zeta :as z])))")
-                     (code "(ns foo.bar)")))
-    (testing "remove reader macro after removing unused require alias"
+                     (code "(ns foo.bar)")
+                     true
+                     "file:///a.cljc"))
+    (testing "remove reader conditional after removing unused require alias"
       (test-clean-ns {}
                      (code "(ns foo.bar"
                            " (:require"
@@ -706,8 +710,10 @@
                            "  #?(:cljs [other.foof :as f])"
                            "  [some.bar :as b]))"
                            "f/foo"
-                           "b/bar")))
-    (testing "remove reader macro after removing unused require refer"
+                           "b/bar")
+                     true
+                     "file:///a.cljc"))
+    (testing "remove reader conditional after removing unused require refer"
       (test-clean-ns {}
                      (code "(ns foo.bar"
                            " (:require"
@@ -722,8 +728,10 @@
                            "  #?(:cljs [other.foof :refer [f]])"
                            "  [some.bar :refer [b]]))"
                            "f"
-                           "b")))
-    (testing "remove reader macro after removing unused import"
+                           "b")
+                     true
+                     "file:///a.cljc"))
+    (testing "remove reader conditional after removing unused import"
       (test-clean-ns {}
                      (code "(ns foo.bar"
                            " (:import"
@@ -738,7 +746,86 @@
                            "  #?(:cljs [other.foof F])"
                            "  [some.bar B]))"
                            "F"
-                           "B")))))
+                           "B")
+                     true
+                     "file:///a.cljc"))
+    (testing "only used required alias in specific lang"
+      (test-clean-ns {}
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "  [other.foo :as f]"
+                           "  [other.beta :as b]"
+                           "  [other.zeta :as z]))"
+                           "#?(:clj f/foo)"
+                           "z/o")
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "  [other.foo :as f]"
+                           "  [other.zeta :as z]))"
+                           "#?(:clj f/foo)"
+                           "z/o")
+                     true
+                     "file:///a.cljc"))
+    (testing "only used required refer in specific lang"
+      (test-clean-ns {}
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "  [other.foo :refer [f]]"
+                           "  [other.beta :refer [b]]"
+                           "  [other.zeta :refer [z]]))"
+                           "#?(:clj f)"
+                           "z")
+                     (code "(ns foo.bar"
+                           " (:require"
+                           "  [other.foo :refer [f]]"
+                           "  [other.zeta :refer [z]]))"
+                           "#?(:clj f)"
+                           "z")
+                     true
+                     "file:///a.cljc"))
+    (testing "only used import in specific lang"
+      (test-clean-ns {}
+                     (code "(ns foo.bar"
+                           " (:import"
+                           "  [other.foo F]"
+                           "  [other.beta B]"
+                           "  [other.zeta Z]))"
+                           "#?(:clj F)"
+                           "Z")
+                     (code "(ns foo.bar"
+                           " (:import"
+                           "  [other.foo F]"
+                           "  [other.zeta Z]))"
+                           "#?(:clj F)"
+                           "Z")
+                     true
+                     "file:///a.cljc"))
+    (testing "Mixed cases"
+      (test-clean-ns {}
+                     (code "(ns a"
+                           "  (:require"
+                           "   [c.b]"
+                           "   [c.c :refer [x]]"
+                           "   [c.d :refer [f]]"
+                           "   [c.e :refer [b o]]"
+                           "   [c.f :as cf]"
+                           "   [c.g :as cg]))"
+                           "#?(:clj"
+                           "   (do (o)"
+                           "       (f)"
+                           "       cf/asd))")
+                     (code "(ns a"
+                           "  (:require"
+                           "   [c.b]"
+                           "   [c.d :refer [f]]"
+                           "   [c.e :refer [o]]"
+                           "   [c.f :as cf]))"
+                           "#?(:clj"
+                           "   (do (o)"
+                           "       (f)"
+                           "       cf/asd))")
+                     true
+                     "file:///a.cljc"))))
 
 (deftest paredit-test
   (let [zloc (edit/raise (z/find-value (z/of-string "(a (b))") z/next 'b))]


### PR DESCRIPTION
This should fix a bug on cljc files where the findings are splitter for langs, causing false-positive removes.