### PR TITLE
Recognize `deftest` as a function definition form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Improve logging during startup for better troubleshooting.
   - Refactor allowing calls to `clojure-lsp.main/run!` for manually passing args, useful for `lein-clojure-lsp` for example.
   - Internal: Move graalvm configuration to sqlite-jdbc.
+  - Recognize `deftest` as function definition form
   
 - API/CLI
   - Use clj-kondo custom lint for API as well, required for correct diagnostics API feature. 

--- a/src/clojure_lsp/refactor/edit.clj
+++ b/src/clojure_lsp/refactor/edit.clj
@@ -31,7 +31,17 @@
       :else (recur (z/leftmost (z/up op-loc))))))
 
 (def function-definition-symbols
-  '#{defn defn- def defmacro defmulti defonce deftype defrecord s/def s/defn})
+  '#{defn
+     defn-
+     def
+     defmacro
+     defmulti
+     defonce
+     deftest
+     deftype
+     defrecord
+     s/def
+     s/defn})
 
 (defn find-function-definition-name-loc [loc]
   (let [function-loc (apply find-ops-up loc (mapv str function-definition-symbols))]

--- a/test/clojure_lsp/refactor/edit_test.clj
+++ b/test/clojure_lsp/refactor/edit_test.clj
@@ -114,7 +114,11 @@
     (testing "Implementing nothing" (assert-function-name "(defrecord foo [] (^void bar [] (let [a 1] d)))"))
     (testing "with map" (assert-function-name "(defrecord {:asd :ds} foo [] Some (^void bar [] (let [a 1] d)))"))
     (testing "with meta map" (assert-function-name "(defrecord ^{:asd :ds} foo [] Some (^void bar [] (let [a 1] d)))"))
-    (testing "with meta" (assert-function-name "(defrecord ^:private foo [] Some (^void bar [] (let [a 1] d)))"))))
+    (testing "with meta" (assert-function-name "(defrecord ^:private foo [] Some (^void bar [] (let [a 1] d)))")))
+  (testing "deftest"
+    (testing "simple" (assert-function-name "(deftest foo (is (let [a 1] d)))"))
+    (testing "with meta" (assert-function-name "(deftest ^:pending foo (is (let [a 1] d)))"))
+    (testing "with meta map" (assert-function-name "(deftest ^{:pending true} foo (is (let [a 1] d)))"))))
 
 (deftest find-function-usage-name
   (let [zloc (-> "(defn foo [] (let [a 1] d))" z/of-string (z/find-next-value z/next 'd))]


### PR DESCRIPTION
This allows refactorings like `extract-function` to work within
`deftest` forms.