### PR TITLE
Clojuredocs raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - Improve rename feature UX to output errors when it's not possible rename.
   - Add new `Unwind thread once` and `Unwind whole thread` code actions to undo a thread call.
   - Improve code actions performance request async all actions.
-  - Add new LSP custom method `clojure/cursordocs/raw` which takes a symbol and a namespace (both strings) and returns any Clojuredocs entry found, otherwise `null`.
+  - Add new LSP custom method `clojure/clojuredocs/raw` which takes a symbol and a namespace (both strings) and returns any Clojuredocs entry found, otherwise `null`.
 
 ## 2021.10.20-16.49.47
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Improve rename feature UX to output errors when it's not possible rename.
   - Add new `Unwind thread once` and `Unwind whole thread` code actions to undo a thread call.
   - Improve code actions performance request async all actions.
+  - Add new LSP custom method `clojure/cursordocs/raw` which takes a symbol and a namespace (both strings) and returns any Clojuredocs entry found, otherwise `null`.
 
 ## 2021.10.20-16.49.47
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -125,3 +125,4 @@ Other clients might provide a higher level interface to `workspace/executeComman
 | clojure/serverInfo/raw |                                | Use to retrieve from server the server configuration information      |
 | clojure/serverInfo/log |                                | Use to log to user the server configuration information               |
 | clojure/cursorInfo/log | `[document-uri, line, column]` | Use to log to user the debugging information for the symbol at cursor |
+| clojure/clojuredocs/raw | `[symbol-name, symbol-ns]` | Use to retreive any Clojuredocs entry. Will return `null` if no entry found.  |

--- a/resources/META-INF/native-image/clojure-lsp/clojure-lsp/reflect-config.json
+++ b/resources/META-INF/native-image/clojure-lsp/clojure-lsp/reflect-config.json
@@ -33,6 +33,13 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"org.eclipse.lsp4j.ClojuredocsParams",
+  "allDeclaredMethods":true,
+  "allPublicMethods": true,
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"com.google.gson.JsonObject",
   "allPublicMethods":true
 },

--- a/src-java/clojure_lsp/ClojuredocsParams.java
+++ b/src-java/clojure_lsp/ClojuredocsParams.java
@@ -1,0 +1,27 @@
+package clojure_lsp;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+
+public class ClojuredocsParams {
+
+    //@NonNull
+    private String symName;
+
+    //@NonNull
+    private String symNs;
+
+    public String getSymName() {
+        return symName;
+    }
+
+    public String getSymNs() {
+        return symNs;
+    }
+
+    @Override
+    public String toString() {
+        return MessageJsonHandler.toString(this);
+    }
+
+}

--- a/src-java/clojure_lsp/ClojuredocsParams.java
+++ b/src-java/clojure_lsp/ClojuredocsParams.java
@@ -5,10 +5,9 @@ import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 
 public class ClojuredocsParams {
 
-    //@NonNull
+    @NonNull
     private String symName;
 
-    //@NonNull
     private String symNs;
 
     public String getSymName() {

--- a/src-java/clojure_lsp/ExtraMethods.java
+++ b/src-java/clojure_lsp/ExtraMethods.java
@@ -22,4 +22,7 @@ public interface ExtraMethods {
     @JsonNotification("clojure/cursorInfo/log")
     void cursorInfoLog(CursorInfoParams cursorInfoParams);
 
+    @JsonRequest("clojure/clojuredocs/raw")
+    CompletableFuture<Object> clojuredocsRaw(ClojuredocsParams clojuredocsParams);
+
 }

--- a/src/clojure_lsp/feature/clojuredocs.clj
+++ b/src/clojure_lsp/feature/clojuredocs.clj
@@ -56,8 +56,7 @@
           (swap! db assoc-in [:clojuredocs :refreshing?] false))))))
 
 (defn find-docs-for [sym-name sym-ns db]
-  (when (and sym-ns
-             (settings/get db [:hover :clojuredocs] true))
+  (when sym-ns
     (let [full-keyword (keyword (str sym-ns) (str sym-name))]
       (if-let [cache (-> @db :clojuredocs :cache)]
         (get cache full-keyword)
@@ -65,3 +64,7 @@
           (async/go
             (refresh-cache! db))
           nil)))))
+
+(defn find-hover-docs-for [sym-name sym-ns db]
+  (when (settings/get db [:hover :clojuredocs] true)
+    (find-docs-for sym-name sym-ns db)))

--- a/src/clojure_lsp/feature/hover.clj
+++ b/src/clojure_lsp/feature/hover.clj
@@ -81,7 +81,7 @@
                    (if markdown?
                      (docstring->formatted-markdown doc)
                      doc))
-        clojuredocs (f.clojuredocs/find-docs-for sym-name sym-ns db)]
+        clojuredocs (f.clojuredocs/find-hover-docs-for sym-name sym-ns db)]
     (if markdown?
       {:kind "markdown"
        :value (cond-> (str opening-code sym-line closing-code)

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -206,14 +206,8 @@
 (defn cursor-info-log [{:keys [textDocument position]}]
   (producer/window-show-message (cursor-info [textDocument (:line position) (:character position)]) db/db))
 
-(defn ^:private clojuredocs [sym-name sym-ns]
-  (let [db-value @db/db]
-    (def db-value db-value)
-    (def sym-name sym-name)
-    (def sym-ns sym-ns)
-    (f.clojuredocs/find-docs-for sym-name sym-ns db-value)))
-
-(def clojuredocs-raw #'clojuredocs)
+(defn clojuredocs-raw [{:keys [symName symNs]}]
+  (f.clojuredocs/find-docs-for symName symNs db/db))
 
 (defn ^:private refactor [refactoring [doc-id line character args] db]
   (let [row                        (inc (int line))

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -239,10 +239,6 @@
     (cursor-info-log {:textDocument (nth arguments 0)
                       :position {:line (nth arguments 1)
                                  :character (nth arguments 2)}})
-    (= command "clojuredocs")
-    (clojuredocs-raw {:symName (nth arguments 0)
-                      :symNs {:line (nth arguments 1)
-                              :character (nth arguments 2)}})
 
     (= command "resolve-macro-as")
     (apply f.resolve-macro/resolve-macro-as! (concat arguments [db/db]))

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -625,6 +625,7 @@
                                     (s/keys :opt-un [:capabilities/workspace :capabilities/text-document])))
 
 (s/def ::server-info-raw ::bean)
+(s/def ::clojuredocs-raw ::bean)
 
 (defn conform-or-log [spec value]
   (when value

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -381,10 +381,10 @@
                (sync-notification params handlers/cursor-info-log))))
 
     (^CompletableFuture clojureDocsRaw [^ClojuredocsParams params]
-     (CompletableFuture/completedFuture
-      (->> (handlers/clojuredocs-raw)
-           (interop/conform-or-log ::interop/clojuredocs-raw))))
-    
+      (CompletableFuture/completedFuture
+        (->> (handlers/clojuredocs-raw)
+             (interop/conform-or-log ::interop/clojuredocs-raw))))
+
     (^CompletableFuture shutdown []
       (log/info "Shutting down")
       (reset! db/db {:documents {}})

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -17,7 +17,8 @@
    (clojure_lsp
      ClojureExtensions
      ExtraMethods
-     CursorInfoParams)
+     CursorInfoParams
+     ClojuredocsParams)
    (java.util.concurrent CompletableFuture
                          CompletionException)
    (java.util.function Supplier)
@@ -379,6 +380,11 @@
              (future
                (sync-notification params handlers/cursor-info-log))))
 
+    (^CompletableFuture clojureDocsRaw [^ClojuredocsParams params]
+     (CompletableFuture/completedFuture
+      (->> (handlers/clojuredocs-raw)
+           (interop/conform-or-log ::interop/clojuredocs-raw))))
+    
     (^CompletableFuture shutdown []
       (log/info "Shutting down")
       (reset! db/db {:documents {}})

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -380,10 +380,10 @@
              (future
                (sync-notification params handlers/cursor-info-log))))
 
-    (^CompletableFuture clojureDocsRaw [^ClojuredocsParams params]
-      (CompletableFuture/completedFuture
-        (->> (handlers/clojuredocs-raw)
-             (interop/conform-or-log ::interop/clojuredocs-raw))))
+    (^CompletableFuture clojuredocsRaw [^ClojuredocsParams params]
+      (start :clojuredocsRaw
+             (CompletableFuture/completedFuture
+               (sync-request params handlers/clojuredocs-raw ::interop/clojuredocs-raw))))
 
     (^CompletableFuture shutdown []
       (log/info "Shutting down")


### PR DESCRIPTION
I tried to follow the prior art. Thought of it as a mix of the server-info/raw command (which takes no argument and returns the results) and cursor-info (which takes arguments but doesn't return results).

When executed, it crashes with the following log:

```
[Trace - 10:08:48 AM] Sending request 'clojure/clojuredocs/raw - (149)'.
Oct 24, 2021 10:08:48 AM org.eclipse.lsp4j.jsonrpc.RemoteEndpoint fallbackResponseError
SEVERE: Internal error: java.lang.reflect.InvocationTargetException
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:67)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.request(GenericEndpoint.java:120)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleRequest(RemoteEndpoint.java:261)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:190)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:835)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:65)
	... 11 more
Caused by: java.lang.UnsupportedOperationException: clojuredocsRaw
	at clojure_lsp.server.proxy$clojure_lsp.ClojureExtensions$ExtraMethods$LanguageServer$4129860f.clojuredocsRaw(Unknown Source)
	... 16 more

[Trace - 10:08:48 AM] Received response 'clojure/clojuredocs/raw - (149)' in 2ms. Request failed: Internal error. (-32603).
```

My inline defs in the handler function never gets defined so it must crash before that, I am thinking. But I have no clue where. 