### PR TITLE
[docs] Freezing on MacOS

### DIFF
--- a/src/clojure_lsp/logging.clj
+++ b/src/clojure_lsp/logging.clj
@@ -7,7 +7,8 @@
 #_{:clj-kondo/ignore [:unresolved-var]}
 (defn setup-logging [db]
   (let [log-path (str (java.io.File/createTempFile "clojure-lsp." ".out"))]
-    (log/merge-config! {:appenders {:println {:enabled? false}
+    (log/merge-config! {:middleware [#(assoc % :hostname_ "")]
+                        :appenders {:println {:enabled? false}
                                     :spit (log/spit-appender {:fname log-path})}})
     (log/handle-uncaught-jvm-exceptions!)
     (swap! db assoc :log-path log-path)))


### PR DESCRIPTION
clojure-lsp uses com.taoensso/timbre for logging, and by default, timbre tries to add hostname into log entry. on my MacOS it wasn't able to resolve the hostname which caused freezes. 

Issue 
Every minute or so request to lsp takes 5 seconds.

Solution
Add MacOS hostname to /etc/hosts

sudo sed -i bak "s^127\.0\.0\.1.*^127.0.0.1 localhost $(hostname)^g" /etc/hosts
sudo sed -i bak "s^::1.*^::1 localhost $(hostname)^g" /etc/hosts

Reference
https://github.com/ptaoussanis/timbre/issues/323
https://stackoverflow.com/questions/39636792/jvm-takes-a-long-time-to-resolve-ip-address-for-localhost/39698914