### PR TITLE
Improve keyword completion

### DIFF
--- a/integration-test/integration/initialize_test.clj
+++ b/integration-test/integration/initialize_test.clj
@@ -67,7 +67,7 @@
                            :change 1
                            :save {:includeText true}}
         :completionProvider {:resolveProvider true
-                             :triggerCharacters []}
+                             :triggerCharacters [":" "/"]}
         :documentSymbolProvider true
         :definitionProvider true
         :documentHighlightProvider true}}

--- a/src/clojure_lsp/feature/completion.clj
+++ b/src/clojure_lsp/feature/completion.clj
@@ -325,6 +325,7 @@
                        (if cursor-loc
                          (z/sexpr cursor-loc)
                          ""))
+        keyword-value? (keyword? cursor-value)
         matches-fn (partial matches-cursor? cursor-value)
         inside-require? (edit/inside-require? cursor-loc)
         inside-refer? (edit/inside-refer? cursor-loc)
@@ -333,7 +334,7 @@
         cursor-value-or-ns (if (qualified-ident? cursor-value)
                              (namespace cursor-value)
                              (if (or (symbol? cursor-value)
-                                     (keyword? cursor-value))
+                                     keyword-value?)
                                (name cursor-value)
                                (str cursor-value)))
         cursor-full-ns? (when cursor-value-or-ns
@@ -359,7 +360,8 @@
         cursor-full-ns?
         (into (with-elements-from-full-ns cursor-value-or-ns analysis))
 
-        cursor-value-or-ns
+        (and cursor-value-or-ns
+             (not keyword-value?))
         (into (with-elements-from-alias cursor-loc cursor-value-or-ns cursor-value matches-fn db))
 
         simple-cursor?

--- a/src/clojure_lsp/feature/completion.clj
+++ b/src/clojure_lsp/feature/completion.clj
@@ -11,6 +11,7 @@
    [clojure-lsp.shared :as shared]
    [clojure.string :as string]
    [clojure.walk :as walk]
+   [medley.core :as medley]
    [rewrite-clj.zip :as z]
    [taoensso.timbre :as log]))
 
@@ -287,7 +288,7 @@
                          :detail (str "java.util." sym)
                          :priority :java})))))
 
-(defn ^:private with-snippets [cursor-loc text row col settings]
+(defn ^:private with-snippets [cursor-loc matches-fn text row col settings]
   (let [next-loc (parser/safe-loc-at-pos text row (inc col))]
     (->> (concat
            (f.completion-snippet/known-snippets settings)
@@ -295,10 +296,15 @@
          (map #(assoc %
                       :kind :snippet
                       :priority :snippet
-                      :insert-text-format :snippet)))))
+                      :insert-text-format :snippet))
+         (filter (comp matches-fn :label)))))
 
-(defn- sort-completion-results [results]
-  (sort-by (juxt #(get priority-kw->number (:priority %) 0) :label :detail) results))
+(defn ^:private sorting-and-distincting-items [items]
+  (->> items
+       (medley/distinct-by (juxt :label :kind :detail))
+       (sort-by (juxt #(get priority-kw->number (:priority %) 0) :label :detail))
+       (map #(dissoc % :priority))
+       not-empty))
 
 (defn completion [uri row col db]
   (let [filename (shared/uri->filename uri)
@@ -338,52 +344,40 @@
                                (name cursor-value)
                                (str cursor-value)))
         cursor-full-ns? (when cursor-value-or-ns
-                          (contains? (q/find-all-ns-definition-names analysis) (symbol cursor-value-or-ns)))]
-    (cond
-      inside-refer?
-      (->> (with-refer-elements matches-fn cursor-loc (concat other-ns-elements external-ns-elements))
-           (into #{})
-           set
-           sort-completion-results
-           not-empty)
+                          (contains? (q/find-all-ns-definition-names analysis) (symbol cursor-value-or-ns)))
+        items (cond
+                inside-refer?
+                (with-refer-elements matches-fn cursor-loc (concat other-ns-elements external-ns-elements))
 
-      inside-require?
-      (->> (with-ns-definition-elements matches-fn (concat other-ns-elements external-ns-elements))
-           (into #{})
-           set
-           sort-completion-results
-           (map #(dissoc % :priority))
-           not-empty)
+                inside-require?
+                (with-ns-definition-elements matches-fn (concat other-ns-elements external-ns-elements))
 
-      :else
-      (cond-> #{}
-        cursor-full-ns?
-        (into (with-elements-from-full-ns cursor-value-or-ns analysis))
+                :else
+                (cond-> []
+                  cursor-full-ns?
+                  (into (with-elements-from-full-ns cursor-value-or-ns analysis))
 
-        (and cursor-value-or-ns
-             (not keyword-value?))
-        (into (with-elements-from-alias cursor-loc cursor-value-or-ns cursor-value matches-fn db))
+                  (and cursor-value-or-ns
+                       (not keyword-value?))
+                  (into (with-elements-from-alias cursor-loc cursor-value-or-ns cursor-value matches-fn db))
 
-        simple-cursor?
-        (-> (into (with-element-items matches-fn uri cursor-element current-ns-elements row col))
-            (into (with-clojure-core-items matches-fn analysis)))
+                  (or simple-cursor?
+                      keyword-value?)
+                  (-> (into (with-element-items matches-fn uri cursor-element current-ns-elements row col))
+                      (into (with-clojure-core-items matches-fn analysis)))
 
-        (and simple-cursor?
-             (supports-cljs? uri))
-        (into (with-clojurescript-items matches-fn analysis))
+                  (and simple-cursor?
+                       (supports-cljs? uri))
+                  (into (with-clojurescript-items matches-fn analysis))
 
-        (and simple-cursor?
-             (supports-clj-core? uri))
-        (into (with-java-items matches-fn))
+                  (and simple-cursor?
+                       (supports-clj-core? uri))
+                  (into (with-java-items matches-fn))
 
-        support-snippets?
-        (into (with-snippets cursor-loc text row col settings))
-
-        :always
-        (->> set
-             sort-completion-results
-             (map #(dissoc % :priority))
-             not-empty)))))
+                  (and support-snippets?
+                       simple-cursor?)
+                  (into (with-snippets cursor-loc matches-fn text row col settings))))]
+    (sorting-and-distincting-items items)))
 
 (defn ^:private resolve-item-by-ns
   [{{:keys [name ns filename]} :data :as item} db]

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -1167,9 +1167,7 @@
 
         (< 1 (count test-source-paths))
         (let [actions (mapv #(hash-map :title %) source-paths)
-              _ (log/info "===>" actions)
               chosen-source-path (producer/window-show-message-request "Which source-path?" :info actions db)]
-          (log/info "-->" chosen-source-path)
           (create-test-for-source-path uri function-name-loc chosen-source-path db))
 
             ;; No source paths besides current one

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -352,7 +352,7 @@
                                                                                 :incremental TextDocumentSyncKind/Incremental
                                                                                 TextDocumentSyncKind/Full))
                                                                   (.setSave (SaveOptions. true))))
-                                          (.setCompletionProvider (CompletionOptions. true []))))))))))
+                                          (.setCompletionProvider (CompletionOptions. true [":" "/"]))))))))))
 
     (^void initialized [^InitializedParams params]
       (start :initialized

--- a/test/clojure_lsp/features/completion_test.clj
+++ b/test/clojure_lsp/features/completion_test.clj
@@ -82,13 +82,11 @@
     (is (= nil (f.completion/completion (h/file-uri "file:///e.clj") 5 3 db/db))))
   (testing "complete all available namespace definitions when inside require"
     (h/assert-submaps
-      [{:label "alpaca.ns" :kind :module}
-       {:label "alpaca.ns" :kind :module}]
+      [{:label "alpaca.ns" :kind :module}]
       (f.completion/completion (h/file-uri "file:///f.clj") 2 21 db/db)))
   (testing "complete locals"
     (h/assert-submaps
-      [{:label "ba" :kind :property}
-       {:label "bar" :kind :function}
+      [{:label "bar" :kind :function}
        {:label "baz" :kind :variable}
        {:label "ba" :kind :property}
        {:label "ba/baff" :kind :variable}
@@ -286,8 +284,8 @@
             "fo"))
   (testing "completing replacing $current-form"
     (h/assert-submaps
-      [{:label "foo", :kind :variable}
-       {:label "foo", :kind :module}
+      [{:label "foo", :kind :module}
+       {:label "foo", :kind :variable}
        {:label ":foo", :kind :keyword, :detail ""}
        {:label "for", :kind :reference, :detail "clojure.core/for"}
        {:label "force", :kind :reference, :detail "clojure.core/force"}

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -28,7 +28,11 @@
   (is (= "(ns foo) foo/bar" (z/string (z/up (#'parser/safe-zloc-of-string "(ns foo) foo/bar")))))
   (is (= "(ns foo) foo/ (+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) foo/ (+ 1 2)"))))
   (is (= "(ns foo) foo/\n(+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) foo/\n(+ 1 2)"))))
-  (is (= "(ns foo) (foo/)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (foo/)")))))
+  (is (= "(ns foo) (foo/)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (foo/)"))))
+  (is (= "(ns foo) :\n" (z/string (#'parser/safe-zloc-of-string "(ns foo) :\n"))))
+  (is (= "(ns foo) : " (z/string (#'parser/safe-zloc-of-string "(ns foo) : "))))
+  (is (= "(ns foo) (:)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (:)"))))
+  (is (= "(ns foo)\n:\n" (z/string (#'parser/safe-zloc-of-string "(ns foo)\n:\n")))))
 
 (deftest find-loc-at-pos-test
   (testing "valid code"

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -32,7 +32,10 @@
   (is (= "(ns foo) :\n" (z/string (#'parser/safe-zloc-of-string "(ns foo) :\n"))))
   (is (= "(ns foo) : " (z/string (#'parser/safe-zloc-of-string "(ns foo) : "))))
   (is (= "(ns foo) (:)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (:)"))))
-  (is (= "(ns foo)\n:\n" (z/string (#'parser/safe-zloc-of-string "(ns foo)\n:\n")))))
+  (is (= "(ns foo)\n:\n" (z/string (#'parser/safe-zloc-of-string "(ns foo)\n:\n"))))
+  (is (= "(ns foo) :foo/ (+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) :foo/ (+ 1 2)"))))
+  (is (= "(ns foo) (:foo/) (+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (:foo/) (+ 1 2)"))))
+  (is (= ":user/username\n:user/\n123" (z/string (#'parser/safe-zloc-of-string ":user/username\n:user/\n123")))))
 
 (deftest find-loc-at-pos-test
   (testing "valid code"


### PR DESCRIPTION
Fixes #630

* Remove duplicated keywords items
* Check prefix to return snippets when only applicable
* Fix parsing of invalid keywords like `:foo/` to allow completion for those cases
* Fix completion items for namespaced keywords