### PR TITLE
Prevent potential macro expansion error

### DIFF
--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -20,7 +20,7 @@
   from body."
   [message & body]
   `(let [~'start-time (System/nanoTime)
-         ~'result ~@body]
+         ~'result (do ~@body)]
      (log/info (format ~message (start-time->end-time-seconds ~'start-time)))
      ~'result))
 


### PR DESCRIPTION
This patch prevents a potential error where passing more than two arguments to `logging-time` could result in a macro expansion error.

I spotted this while skimming through the code. All of the calls to `logging-time` currently pass no more than two arguments so this was never an issue.