### PR TITLE
Expose cursor info raw API

### DIFF
--- a/integration-test/entrypoint.clj
+++ b/integration-test/entrypoint.clj
@@ -16,7 +16,8 @@
     integration.api.clean-ns-test
     integration.api.diagnostics-test
     integration.api.format-test
-    integration.api.rename-test])
+    integration.api.rename-test
+    integration.cursor-info-test])
 
 (defn timeout [timeout-ms callback]
   (let [fut (future (callback))

--- a/integration-test/integration/cursor_info_test.clj
+++ b/integration-test/integration/cursor_info_test.clj
@@ -1,13 +1,13 @@
 (ns integration.cursor-info-test
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is testing]]
    [integration.fixture :as fixture]
    [integration.helper :as h]
    [integration.lsp :as lsp]))
 
 (lsp/clean-after-test)
 
-(deftest definition
+(deftest cursor-info
   (lsp/start-process!)
   (lsp/request! (fixture/initialize-request))
   (lsp/notify! (fixture/initialized-notification))
@@ -15,8 +15,8 @@
 
   (testing "cursor info on empty line"
     (h/assert-submap
-     {:elements []}
-     (lsp/request! (fixture/cursor-info-raw-request "cursor_info/a.clj" 1 2))))
+      {:elements []}
+      (lsp/request! (fixture/cursor-info-raw-request "cursor_info/a.clj" 1 2))))
 
   (testing "cursor info on local var"
     (let [definition-bucket (-> (fixture/cursor-info-raw-request "cursor_info/a.clj" 3 2)

--- a/integration-test/integration/cursor_info_test.clj
+++ b/integration-test/integration/cursor_info_test.clj
@@ -1,0 +1,36 @@
+(ns integration.cursor-info-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [integration.fixture :as fixture]
+   [integration.helper :as h]
+   [integration.lsp :as lsp]))
+
+(lsp/clean-after-test)
+
+(deftest definition
+  (lsp/start-process!)
+  (lsp/request! (fixture/initialize-request))
+  (lsp/notify! (fixture/initialized-notification))
+  (lsp/notify! (fixture/did-open-notification "cursor_info/a.clj"))
+
+  (testing "cursor info on empty line"
+    (h/assert-submap
+     {:elements []}
+     (lsp/request! (fixture/cursor-info-raw-request "cursor_info/a.clj" 1 2))))
+
+  (testing "cursor info on local var"
+    (let [definition-bucket (-> (fixture/cursor-info-raw-request "cursor_info/a.clj" 3 2)
+                                (lsp/request!)
+                                (get-in [:elements 0 :definition :bucket]))]
+      (is (= "locals" definition-bucket))))
+
+  (testing "cursor info on definition"
+    (let [first-element (-> (fixture/cursor-info-raw-request "cursor_info/a.clj" 2 8)
+                            (lsp/request!)
+                            (get-in [:elements 0]))
+          element (:element first-element)
+          definition (:definition first-element)]
+      (is (not (nil? first-element)))
+      (is (= (:filename element) (:filename definition)))
+      (is (= (:name-row element) (:name-row definition)))
+      (is (= (:name-col element) (:name-col definition))))))

--- a/integration-test/integration/fixture.clj
+++ b/integration-test/integration/fixture.clj
@@ -59,6 +59,11 @@
                 {:textDocument {:uri (h/file->uri (h/source-path->file path))}
                  :position {:line row :character col}}))
 
+(defn cursor-info-raw-request [path row col]
+  (lsp-json-rpc "clojure/cursorInfo/raw"
+                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                 :position {:line row :character col}}))
+
 (defn initialized-notification []
   (lsp-json-rpc :initialized {}))
 

--- a/integration-test/sample-test/src/sample_test/cursor_info/a.clj
+++ b/integration-test/sample-test/src/sample_test/cursor_info/a.clj
@@ -1,0 +1,6 @@
+(ns sample-test.src.sample-test.cursor-info.a)
+
+(defn some-public-func [a]
+  a)
+
+

--- a/integration-test/sample-test/src/sample_test/cursor_info/a.clj
+++ b/integration-test/sample-test/src/sample_test/cursor_info/a.clj
@@ -3,4 +3,3 @@
 (defn some-public-func [a]
   a)
 
-

--- a/src-java/clojure_lsp/ExtraMethods.java
+++ b/src-java/clojure_lsp/ExtraMethods.java
@@ -19,6 +19,9 @@ public interface ExtraMethods {
     @JsonNotification("clojure/serverInfo/log")
     void serverInfoLog();
 
+    @JsonRequest("clojure/cursorInfo/raw")
+    CompletableFuture<Object> cursorInfoRaw(CursorInfoParams cursorInfoParams);
+    
     @JsonNotification("clojure/cursorInfo/log")
     void cursorInfoLog(CursorInfoParams cursorInfoParams);
 

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -637,6 +637,7 @@
                                     (s/keys :opt-un [:capabilities/workspace :capabilities/text-document])))
 
 (s/def ::server-info-raw ::bean)
+(s/def ::cursor-info-raw ::bean)
 (s/def ::clojuredocs-raw ::bean)
 
 (defn conform-or-log [spec value]

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -381,6 +381,11 @@
                (end
                  (handlers/server-info-log)))))
 
+    (^CompletableFuture cursorInfoRaw [^CursorInfoParams params]
+      (start :cursorInfoRaw
+             (CompletableFuture/completedFuture
+               (sync-request params handlers/cursor-info-raw ::interop/cursor-info-raw))))
+    
     (^void cursorInfoLog [^CursorInfoParams params]
       (start :cursor-info-log
              (future

--- a/src/clojure_lsp/server.clj
+++ b/src/clojure_lsp/server.clj
@@ -385,7 +385,7 @@
       (start :cursorInfoRaw
              (CompletableFuture/completedFuture
                (sync-request params handlers/cursor-info-raw ::interop/cursor-info-raw))))
-    
+
     (^void cursorInfoLog [^CursorInfoParams params]
       (start :cursor-info-log
              (future


### PR DESCRIPTION
Expose cursor info raw API to be used in the editors.

Sample use case - in emacs lsp-mode:
`lsp-clojure-dwim`
1. find a definition for the symbol
2. find references if the cursor is already on the definition
3. fallback to cider for finding runtime definitions
4. open code actions if no symbol under cursor (useful for threading actions when the cursor is on parentheses)

here is a naive implementation of 'lsp-clojure-dwim` that uses a new API method:
https://gist.github.com/ikhaldeev/eb82213ff3233158112ff29160b16283

I haven't found a way to utilize clojure/cursorInfo/log for this use case.