### PR TITLE
Add naive sort to clean-ns, through settings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -65,5 +65,9 @@
                                    :jvm-opts ["-Xmx2g" "-server"]
                                    :main-class clojure-lsp.main
                                    :aliases [:debug]}}
+           :run-debug {:extra-deps {nrepl/nrepl {:mvn/version "0.8.3"}
+                                    cider/cider-nrepl {:mvn/version "0.27.2"}}
+                       :main-opts ["-m" "clojure-lsp.main"]
+                       :jvm-opts ["-Xmx2g" "-server"]}
            :run {:main-opts ["-m" "clojure-lsp.main"]
                  :jvm-opts ["-Xmx2g" "-server"]}}}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -227,7 +227,7 @@ Whether to enable sort of `ns` children like require,import forms following [Clo
 
 ##### require
 
-Whether to enable sort of `:require` form.
+Whether to enable sort of `:require` form. `true` to sort according to the Clojure Style Guide, `:naive` to sort as alphanumeric.
 
 ##### import
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -227,7 +227,7 @@ Whether to enable sort of `ns` children like require,import forms following [Clo
 
 ##### require
 
-Whether to enable sort of `:require` form. `true` to sort according to the Clojure Style Guide, `:naive` to sort as alphanumeric.
+Whether to enable sort of `:require` form. `true` to sort according to the Clojure Style Guide, `:lexicographically` to do a lexicographic sort that places unwrapped namespaces last.
 
 ##### import
 

--- a/src/clojure_lsp/feature/clean_ns.clj
+++ b/src/clojure_lsp/feature/clean_ns.clj
@@ -18,8 +18,10 @@
         :next-line)))
 
 (defn ^:private sort-by-if-enabled [fn type db coll]
-  (if (settings/get db [:clean :sort type] true)
-    (sort-by fn coll)
+  (if-let [sort-type (settings/get db [:clean :sort type] true)]
+    (if (= :naive sort-type)
+      (sort-by str coll)
+      (sort-by fn coll))
     coll))
 
 (defn ^:private refer-node-with-add-new-lines [nodes]

--- a/src/clojure_lsp/feature/clean_ns.clj
+++ b/src/clojure_lsp/feature/clean_ns.clj
@@ -19,7 +19,7 @@
 
 (defn ^:private sort-by-if-enabled [fn type db coll]
   (if-let [sort-type (settings/get db [:clean :sort type] true)]
-    (if (= :naive sort-type)
+    (if (= :lexicographically sort-type)
       (sort-by str coll)
       (sort-by fn coll))
     coll))

--- a/test/clojure_lsp/feature/clean_ns_test.clj
+++ b/test/clojure_lsp/feature/clean_ns_test.clj
@@ -387,6 +387,27 @@
                              "import1."
                              "apple."
                              "ball.")))
+    (testing "sort requires lexicographically"
+      (test-clean-ns {:settings {:clean {:sort {:require :lexicographically}}}}
+                     (h/code "(ns foo.bar"
+                             " (:require"
+                             "  apple"
+                             "  [ball import1]"
+                             "  ball"
+                             "  [zebra]"
+                             "  ))"
+                             "import1."
+                             "apple."
+                             "ball.")
+                     (h/code "(ns foo.bar"
+                             " (:require"
+                             "  [ball import1]"
+                             "  [zebra]"
+                             "  apple"
+                             "  ball))"
+                             "import1."
+                             "apple."
+                             "ball.")))
     (testing "unsorted used imports"
       (test-clean-ns {}
                      (h/code "(ns foo.bar"


### PR DESCRIPTION
A config setting to override the difficult to replicate clojure style guide `:require` sorting with a `:naive` sort that will follow tools like unix `sort` command or cursive's sort lines command.

`"clean" {:sort {:require :naive}`