### PR TITLE
Avoid high CPU and lockup when kondo throws exceptions

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -3,7 +3,8 @@
  :remove-consecutive-blank-lines? true
  :insert-missing-whitespace? true
  :align-associative? false
- :indents {catch-kondo-errors [[:inner 0]]}
+ :indents {#re "^(?!catch-kondo-errors).*" [[:block 0]]
+           catch-kondo-errors [[:inner 0]]}
  :test-code
  (comment
    (:require

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -3,7 +3,7 @@
  :remove-consecutive-blank-lines? true
  :insert-missing-whitespace? true
  :align-associative? false
- :indents {#re ".*" [[:block 0]]}
+ :indents {catch-kondo-errors [[:inner 0]]}
  :test-code
  (comment
    (:require

--- a/src/clojure_lsp/feature/file_management.clj
+++ b/src/clojure_lsp/feature/file_management.clj
@@ -142,8 +142,8 @@
   (loop [state-db @db]
     (when (>= version (get-in state-db [:documents uri :v] -1))
       (if-let [kondo-result (shared/logging-time
-                                "Changes analyzed by clj-kondo took %s secs."
-                                (lsp.kondo/run-kondo-on-text! text uri db))]
+                              "Changes analyzed by clj-kondo took %s secs."
+                              (lsp.kondo/run-kondo-on-text! text uri db))]
         (let [filename (shared/uri->filename uri)
               old-local-analysis (get-in @db [:analysis filename])]
           (if (compare-and-set! db state-db (-> state-db

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -41,7 +41,9 @@
        (if (> (quot (- (System/nanoTime) ~'_time) 1000000) 60000) ; one minute timeout
          (log/warn "Timeout waiting for changes for body")
          (if (:processing-changes @db/db)
-           (recur)
+           (do
+             (Thread/sleep 100)
+             (recur))
            ~@body)))))
 
 (defn ^:private report-startup-progress

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -37,13 +37,13 @@
 
 (defmacro process-after-changes [& body]
   `(let [~'_time (System/nanoTime)]
-     (loop []
+     (loop [backoff# 1]
        (if (> (quot (- (System/nanoTime) ~'_time) 1000000) 60000) ; one minute timeout
          (log/warn "Timeout waiting for changes for body")
          (if (:processing-changes @db/db)
            (do
-             (Thread/sleep 100)
-             (recur))
+             (Thread/sleep backoff#)
+             (recur (min 200 (* 2 backoff#)))) ; 2^0, 2^1, ..., up to 200ms
            ~@body)))))
 
 (defn ^:private report-startup-progress


### PR DESCRIPTION
I have a snippet that would trigger an uncaught clj-kondo error and will further cause clojure-lsp to set my CPU on fire for a minute plus other functions (e.g. document highlighting) to stop working totally:

```clj
;; a.clj

(ns ^{:clj-kondo/config '{:linters
                          {:unresolved-symbol
                           {:exclude [(a/my-macro1 EXTRA [$])]}}}}  ;; Remove "EXTRA" and things will recover
  a)

(defmacro my-macro1 [a b c]
  (a b c))

(my-macro1 $ ? !)
```

LSP functions all stop working because the `:processing-changes` flag never gets set back to `false` when clj-kondo errors, and the `process-after-changes` macro spins to wait for that flag, causing high CPU until it times out. This PR fixes those problems. I've been away from the codebase for quite a while, so please point out if I'm not doing something right :)

I'll also make a patch for clj-kondo so the exception actually gets fixed.