### PR TITLE
Allow absolute paths in deps.edn :local/root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Bump clj-kondo to `2021.12.16`, supporting auto-load configs, improving potemkin support, adding more linters and more.
   - Merge `:cljfmt` settings with `:cljfmt-config-path` if file path exists.
   - Avoid high CPU and lockup when clj-kondo throws exceptions. #671
+  - Allow absolute paths in deps.edn :local/root #672
 
 - Editor
   - Change call hierarchy to return selection range of usage, not function definition.

--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -224,7 +224,10 @@
 
   The output representation path matches that of the operating system."
   [path root]
-  (.toString (.relativize (-> root io/file .toPath) (-> path io/file .toPath))))
+  (let [path-obj (-> path io/file .toPath)]
+    (if (.isAbsolute path-obj)
+      (.toString (.relativize (-> root io/file .toPath) path-obj))
+      path)))
 
 (defn join-filepaths
   [& components]

--- a/src/clojure_lsp/source_paths.clj
+++ b/src/clojure_lsp/source_paths.clj
@@ -80,7 +80,8 @@
                            (remove nil?))
           deps-files-by-local-root (->> local-roots
                                         (map (fn [local-root]
-                                               (let [sub-deps-file (io/file root-path local-root "deps.edn")]
+                                               (let [local-root (shared/relativize-filepath local-root root-path)
+                                                     sub-deps-file (io/file root-path local-root "deps.edn")]
                                                  (when (shared/file-exists? sub-deps-file)
                                                    [local-root sub-deps-file]))))
                                         (remove nil?))

--- a/test/clojure_lsp/source_paths_test.clj
+++ b/test/clojure_lsp/source_paths_test.clj
@@ -95,6 +95,15 @@
                  (#'source-paths/resolve-deps-source-paths "deps-root"
                                                            {:source-aliases nil} "/project/root")))))))
   (testing "local-root"
+    (testing "absolute path"
+      (with-redefs [config/read-edn-file (fn [file]
+                                           (if (= "deps-root" (str file))
+                                             {:paths ["src"]
+                                              :deps {'some.lib {:local/root "/some/lib"}}}
+                                             {:paths ["foo" "bar"]}))
+                    shared/file-exists? #(= "/project/root/../../some/lib/deps.edn" (str %))]
+        (is (= #{"../../some/lib/foo" "../../some/lib/bar" "src"}
+               (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))
     (testing "single root from :deps"
       (with-redefs [config/read-edn-file (fn [file]
                                            (if (= "deps-root" (str file))


### PR DESCRIPTION
Previously if I have something like

```clj
clj-kondo/clj-kondo {:local/root "/Users/me/git/clj-kondo"}
```

as a dependency in `deps.edn`, lsp will fail with

```
java.lang.IllegalArgumentException: /Users/me/git/clj-kondo is not a relative path
```

This PR fixes that issue.