### PR TITLE
fix: make local/root paths relative to deps.edn

### DIFF
--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -351,3 +351,7 @@
   [^java.nio.file.Path path
    ^String child]
   (.toFile (.resolve path child)))
+
+(defn normalize-file
+  ^java.io.File [^java.io.File file]
+  (.toFile (.normalize (.toPath file))))

--- a/src/clojure_lsp/source_paths.clj
+++ b/src/clojure_lsp/source_paths.clj
@@ -49,6 +49,15 @@
          set
          (set/union root-source-paths))))
 
+(defn relative-to-deps-file [deps-file]
+  (let [p (.getParentFile (io/file deps-file))]
+    (fn [f]
+      (if (.isAbsolute (io/file f))
+        f
+        ;; NOTE; calling .getCanonicalFile on this would get of some "../" path
+        ;; components.
+        (io/file p f)))))
+
 (defn ^:private deps-file->local-roots
   [deps-file settings]
   (let [{:keys [deps extra-deps aliases]} (config/read-edn-file deps-file)
@@ -61,6 +70,7 @@
                    (concat (extract-local-roots deps)
                            (extract-local-roots extra-deps))))
          (concat deps-local-roots extra-deps-local-roots)
+         (map (relative-to-deps-file deps-file))
          (remove nil?))))
 
 (defn ^:private resolve-deps-source-paths

--- a/src/clojure_lsp/source_paths.clj
+++ b/src/clojure_lsp/source_paths.clj
@@ -54,7 +54,7 @@
     (fn [f]
       (if (.isAbsolute (io/file f))
         f
-        (io/file p f)))))
+        (shared/normalize-file (io/file p f))))))
 
 (defn ^:private deps-file->local-roots
   [deps-file settings]

--- a/src/clojure_lsp/source_paths.clj
+++ b/src/clojure_lsp/source_paths.clj
@@ -54,8 +54,6 @@
     (fn [f]
       (if (.isAbsolute (io/file f))
         f
-        ;; NOTE; calling .getCanonicalFile on this would get of some "../" path
-        ;; components.
         (io/file p f)))))
 
 (defn ^:private deps-file->local-roots

--- a/test/clojure_lsp/source_paths_test.clj
+++ b/test/clojure_lsp/source_paths_test.clj
@@ -160,10 +160,14 @@
                                              {:paths ["foo"]
                                               :deps '{other.lib {:local/root "../other"}}}
 
+                                             ;; this path seems platform dependent
                                              "/project/root/./some/lib/../other/deps.edn"
+                                             {:extra-paths ["bar"]}
+                                             "/project/root/some/lib/other/deps.edn"
                                              {:extra-paths ["bar"]}))
                     shared/file-exists? #(or (= "/project/root/./some/lib/deps.edn" (str %))
-                                             (= "/project/root/./some/lib/../other/deps.edn" (str %)))]
+                                             (= "/project/root/./some/lib/../other/deps.edn" (str %))
+                                             (= "/project/root/some/other/deps.edn" (str %)))]
         (is (= #{"./some/lib/foo" "src" "./some/lib/../other/bar"}
                (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))))
 

--- a/test/clojure_lsp/source_paths_test.clj
+++ b/test/clojure_lsp/source_paths_test.clj
@@ -162,9 +162,8 @@
 
                                              "/project/root/./some/lib/../other/deps.edn"
                                              {:extra-paths ["bar"]}))
-                    shared/file-exists? #(do (prn %)
-                                          (or (= "/project/root/./some/lib/deps.edn" (str %))
-                                              (= "/project/root/./some/lib/../other/deps.edn" (str %))))]
+                    shared/file-exists? #(or (= "/project/root/./some/lib/deps.edn" (str %))
+                                             (= "/project/root/./some/lib/../other/deps.edn" (str %)))]
         (is (= #{"./some/lib/foo" "src" "./some/lib/../other/bar"}
                (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))))
 

--- a/test/clojure_lsp/source_paths_test.clj
+++ b/test/clojure_lsp/source_paths_test.clj
@@ -110,8 +110,8 @@
                                              {:paths ["src"]
                                               :deps {'some.lib {:local/root "./some/lib"}}}
                                              {:paths ["foo" "bar"]}))
-                    shared/file-exists? #(= "/project/root/./some/lib/deps.edn" (str %))]
-        (is (= #{"./some/lib/foo" "./some/lib/bar" "src"}
+                    shared/file-exists? #(= "/project/root/some/lib/deps.edn" (str %))]
+        (is (= #{"some/lib/foo" "some/lib/bar" "src"}
                (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))
     (testing "multiple root from :deps"
       (with-redefs [config/read-edn-file (fn [file]
@@ -122,14 +122,14 @@
                                                       other-lib {:mvn/version "1.2.3"}
                                                       another.lib/foo {:local/root "../another/lib"}}}
 
-                                             "/project/root/./some/lib/deps.edn"
+                                             "/project/root/some/lib/deps.edn"
                                              {:paths ["foo" "bar"]}
 
                                              "/project/root/../another/lib/deps.edn"
                                              {:extra-paths ["baz"]}))
-                    shared/file-exists? #(or (= "/project/root/./some/lib/deps.edn" (str %))
+                    shared/file-exists? #(or (= "/project/root/some/lib/deps.edn" (str %))
                                              (= "/project/root/../another/lib/deps.edn" (str %)))]
-        (is (= #{"./some/lib/foo" "./some/lib/bar" "src" "../another/lib/baz"}
+        (is (= #{"some/lib/foo" "some/lib/bar" "src" "../another/lib/baz"}
                (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))
     (testing "root on :dev alias"
       (with-redefs [config/read-edn-file (fn [file]
@@ -140,14 +140,14 @@
                                                       other-lib {:mvn/version "1.2.3"}}
                                               :aliases {:dev {:extra-deps '{another.lib/foo {:local/root "../another/lib"}}}}}
 
-                                             "/project/root/./some/lib/deps.edn"
+                                             "/project/root/some/lib/deps.edn"
                                              {:paths ["foo" "bar"]}
 
                                              "/project/root/../another/lib/deps.edn"
                                              {:extra-paths ["baz"]}))
-                    shared/file-exists? #(or (= "/project/root/./some/lib/deps.edn" (str %))
+                    shared/file-exists? #(or (= "/project/root/some/lib/deps.edn" (str %))
                                              (= "/project/root/../another/lib/deps.edn" (str %)))]
-        (is (= #{"./some/lib/foo" "./some/lib/bar" "src" "../another/lib/baz"}
+        (is (= #{"some/lib/foo" "some/lib/bar" "src" "../another/lib/baz"}
                (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))
     (testing "nested local/root"
       (with-redefs [config/read-edn-file (fn [file]
@@ -156,19 +156,16 @@
                                              {:paths ["src"]
                                               :deps '{some.lib {:local/root "./some/lib"}}}
 
-                                             "/project/root/./some/lib/deps.edn"
+                                             "/project/root/some/lib/deps.edn"
                                              {:paths ["foo"]
                                               :deps '{other.lib {:local/root "../other"}}}
 
-                                             ;; this path seems platform dependent
-                                             "/project/root/./some/lib/../other/deps.edn"
-                                             {:extra-paths ["bar"]}
-                                             "/project/root/some/lib/other/deps.edn"
+                                             "/project/root/some/other/deps.edn"
                                              {:extra-paths ["bar"]}))
-                    shared/file-exists? #(or (= "/project/root/./some/lib/deps.edn" (str %))
+                    shared/file-exists? #(or (= "/project/root/some/lib/deps.edn" (str %))
                                              (= "/project/root/./some/lib/../other/deps.edn" (str %))
                                              (= "/project/root/some/other/deps.edn" (str %)))]
-        (is (= #{"./some/lib/foo" "src" "./some/lib/../other/bar"}
+        (is (= #{"some/lib/foo" "src" "some/other/bar"}
                (#'source-paths/resolve-deps-source-paths "deps-root" {} "/project/root")))))))
 
 (deftest resolve-lein-source-paths


### PR DESCRIPTION
When resolving local/root dependencies, a realtive path needs to be with
respect to the deps.edn file that contains the dependency.