### PR TITLE
 Move coll entry

### DIFF
--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -2,10 +2,25 @@
   (:require
    [clojure.string :as string]
    [rewrite-clj.node :as n]
-   [rewrite-clj.zip :as z]
-   [taoensso.timbre :as log]))
+   [rewrite-clj.zip :as z]))
 
 (set! *warn-on-reflection* true)
+
+(defn- count-siblings-left
+  "Count the number of sibling nodes to the left of the child node `zloc`."
+  [zloc]
+  (->> zloc
+       (iterate z/left)
+       (take-while (complement z/leftmost?))
+       count))
+
+(defn- count-siblings-right
+  "Count the number of sibling nodes to the right of the child node `zloc`."
+  [zloc]
+  (->> zloc
+       (iterate z/right)
+       (take-while (complement z/rightmost?))
+       count))
 
 (defn ^:private expand-comment-newlines
   "Comment nodes often include their trailing newline. This splits such nodes
@@ -19,11 +34,9 @@
               [n]))
           children))
 
-(defn ^:private whitespace-comment-or-newline? [node]
-  (contains? #{:whitespace :comment :newline} (n/tag node)))
-
-(defn ^:private whitespace-or-comment? [node]
-  (contains? #{:whitespace :comment} (n/tag node)))
+(defn- trailing-whitespace? [node]
+  (and (n/whitespace-or-comment? node)
+       (not (n/linebreak? node))))
 
 (defn ^:private parse-entry-pairs
   "Parse the children of a map or binding `parent-zloc` into entry pairs
@@ -57,13 +70,13 @@
             ;; everything processed
             [result []]
 
-            (every? whitespace-comment-or-newline? children)
+            (every? n/whitespace-or-comment? children)
             ;; everything processed but extra lines
             [result children]
 
             (= :before-key state)
             ;; gather comments before key, and key itself
-            (let [[prefix [k & rst]] (split-with whitespace-comment-or-newline?
+            (let [[prefix [k & rst]] (split-with n/whitespace-or-comment?
                                                  children)]
               (recur rst
                      :before-val
@@ -72,9 +85,9 @@
             (= :before-val state)
             ;; gather comments before val, val itself, and optional comment
             ;; after val on same line
-            (let [[prefix [v & rst]] (split-with whitespace-comment-or-newline?
+            (let [[prefix [v & rst]] (split-with n/whitespace-or-comment?
                                                  children)
-                  [postfix rst]      (split-with whitespace-or-comment?
+                  [postfix rst]      (split-with trailing-whitespace?
                                                  rst)]
               (recur rst
                      :before-key
@@ -87,20 +100,18 @@
 (defn ^:private move-entry-zloc
   "Move `zloc` to direction `dir` considering multiple comments cases."
   [zloc dir]
-  (let [parent-zloc (z/up zloc)
+  (let [parent-zloc               (z/up zloc)
         [entry-pairs extra-lines] (parse-entry-pairs parent-zloc)
-        node-position     (->> zloc
-                               (iterate z/left)
-                               (take-while (complement z/leftmost?))
-                               count)
-        new-node-position (dir (dir node-position))
-        ;; position of the entry pair we're moving, whether the original
+
+        node-idx     (count-siblings-left zloc)
+        new-node-idx (dir (dir node-idx))
+        ;; index of the entry pair we're moving, whether the original
         ;; node was a key or value.
-        position          (-> node-position (/ 2) int)
-        new-position      (dir position)
-        entry-pairs (assoc entry-pairs
-                           position (get entry-pairs new-position)
-                           new-position (get entry-pairs position))
+        pair-idx     (-> node-idx (/ 2) int)
+        new-pair-idx (dir pair-idx)
+        entry-pairs  (assoc entry-pairs
+                            pair-idx (get entry-pairs new-pair-idx)
+                            new-pair-idx (get entry-pairs pair-idx))
         ;; Most entries can keep the whitespace that precedes them,
         ;; whether moving up or down. This assumption fails when
         ;; swapping the first and second entries. The entry that is
@@ -113,23 +124,28 @@
         ;; TODO: seems to work whether or not we're swapping the first
         ;; and second entries. But is that accounting for all whitespace
         ;; edge cases? Maybe better to do this only if (= #{0 1}
-        ;; (hash-set position new-position)).
-        entry-pairs (-> entry-pairs
-                        (update 0 #(drop-while n/whitespace? %))
-                        (update 1 #(concat (take-while n/whitespace? (get entry-pairs 0))
-                                           %)))
+        ;; (hash-set pair-idx new-pair-idx)).
+        [whitespace first-entry] (split-with n/whitespace? (get entry-pairs 0))
+        entry-pairs              (-> entry-pairs
+                                     (assoc 0 first-entry)
+                                     (update 1 #(concat whitespace %)))
 
         ;; Put revised entries back into parent.
         parent-zloc (z/subedit-> parent-zloc
                                  (z/replace (n/replace-children (z/node parent-zloc)
                                                                 (concat (flatten entry-pairs)
                                                                         extra-lines))))
-        parent-zloc (if (-> parent-zloc z/down z/rightmost* z/node n/comment?)
-                      ;; Do we really need to use z/position and add track-position to whole clojure-lsp zloc to make this work?
-                      (let [[_row col] (-> parent-zloc z/down z/rightmost z/left z/position)]
-                        (-> parent-zloc
-                            z/down
-                            z/rightmost*
+
+        ;; If after reordering, the last component has become a comment,
+        ;; we need to add a newline or else the closing bracket will be
+        ;; commented out.
+        last-zloc   (-> parent-zloc z/down z/rightmost*)
+        parent-zloc (if (-> last-zloc z/node n/comment?)
+                      ;; align bracket with last key
+                      (let [last-key   (-> parent-zloc z/down z/rightmost z/left)
+                            ;; Do we really need to use z/position and add track-position to whole clojure-lsp zloc to make this work?
+                            [_row col] (z/position last-key)]
+                        (-> last-zloc
                             (z/insert-space-right (dec col))
                             z/insert-newline-right
                             z/up))
@@ -139,7 +155,7 @@
     (->> parent-zloc
          z/down
          (iterate z/right)
-         (drop new-node-position)
+         (drop new-node-idx)
          first)))
 
 (defn ^:private can-move-entry? [zloc]
@@ -148,19 +164,11 @@
 
 (defn can-move-entry-up? [zloc]
   (and (can-move-entry? zloc)
-       (>= (->> zloc
-                (iterate z/left)
-                (take-while (complement z/leftmost?))
-                count)
-           2)))
+       (>= (count-siblings-left zloc) 2)))
 
 (defn can-move-entry-down? [zloc]
   (and (can-move-entry? zloc)
-       (>= (->> zloc
-                (iterate z/right)
-                (take-while (complement z/rightmost?))
-                count)
-           2)))
+       (>= (count-siblings-right zloc) 2)))
 
 (defn ^:private move-entry [zloc uri dir focus-zloc]
   (when-let [new-zloc (move-entry-zloc zloc dir)]

--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -142,9 +142,8 @@
         last-zloc   (-> parent-zloc z/down z/rightmost*)
         parent-zloc (if (-> last-zloc z/node n/comment?)
                       ;; align bracket with last key
-                      (let [last-key   (-> parent-zloc z/down z/rightmost z/left)
-                            ;; Do we really need to use z/position and add track-position to whole clojure-lsp zloc to make this work?
-                            [_row col] (z/position last-key)]
+                      (let [last-key (-> parent-zloc z/down z/rightmost z/left)
+                            col      (:col (meta (z/node last-key)))]
                         (-> last-zloc
                             (z/insert-space-right (dec col))
                             z/insert-newline-right

--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -119,8 +119,8 @@
         ;; whitespace, but it's moving to a location where it needs
         ;; some. And conversely, the entry that is initially second
         ;; typically has preceding whitespace but is moving somewhere
-        ;; where it shouldn't. We fix this by swapping preceding
-        ;; whitespace between the two.
+        ;; where it shouldn't. We fix this by moving preceding
+        ;; whitespace from one to the other.
         ;; TODO: seems to work whether or not we're swapping the first
         ;; and second entries. But is that accounting for all whitespace
         ;; edge cases? Maybe better to do this only if (= #{0 1}

--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -143,8 +143,7 @@
          first)))
 
 (defn ^:private can-move-entry? [zloc]
-  (and (not (contains? #{:map :vector :set} (z/tag zloc)))
-       (contains? #{:map :vector :set} (some-> zloc z/up z/tag))
+  (and (contains? #{:map :vector :set} (some-> zloc z/up z/tag))
        (even? (count (z/child-sexprs (z/up zloc))))))
 
 (defn can-move-entry-up? [zloc]

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -86,7 +86,7 @@
 
 (defn ^:private safe-zloc-of-string [text]
   (try
-    (z/of-string text {:track-position? true})
+    (z/of-string text)
     (catch clojure.lang.ExceptionInfo e
       (if-let [node (handle-end-slash-code text e)]
         node

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -211,6 +211,22 @@
                               " :b 2"
                               " ;; trailing comment"
                               " }") :b)
+      (assert-move-up (h/code "{;; a"
+                              " a 1"
+                              ""
+                              " ;; c"
+                              " c 3"
+                              ""
+                              " ;; b"
+                              " b 2}")
+                      (h/code "{;; a"
+                              " a 1"
+                              ""
+                              " ;; b"
+                              " b 2"
+                              ""
+                              " ;; c"
+                              " c 3}") 'c)
       ;; avoids commenting out closing bracket
       (assert-move-up (h/code "{:b 2"
                               " :a 1 ;; one comment"
@@ -285,6 +301,22 @@
                                 " :b 2"
                                 " ;; trailing comment"
                                 " }") :a)
+      (assert-move-down (h/code "{;; a"
+                                " a 1"
+                                ""
+                                " ;; c"
+                                " c 3"
+                                ""
+                                " ;; b"
+                                " b 2}")
+                        (h/code "{;; a"
+                                " a 1"
+                                ""
+                                " ;; b"
+                                " b 2"
+                                ""
+                                " ;; c"
+                                " c 3}") 'b)
       ;; avoids commenting out closing bracket
       (assert-move-down (h/code "{:b 2"
                                 " :a 1 ;; one comment"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -105,27 +105,33 @@
     (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "'[a 1 c 2]")
                                                          (z/find-next-value z/next 2)))))))
 
-(defn ^:private assert-move-up [expected subject cursor]
-  (is (= expected
-         (some-> (z/of-string subject {:track-position? true})
-                 (z/find-next-value z/next cursor)
-                 (f.move-coll-entry/move-up "file:///a.clj")
-                 :changes-by-uri
-                 (get "file:///a.clj")
-                 first
-                 :loc
-                 z/root-string))))
+(defn- string-move-up [subject cursor]
+  (some-> (z/of-string subject {:track-position? true})
+          (z/find-next-value z/next cursor)
+          (f.move-coll-entry/move-up "file:///a.clj")
+          :changes-by-uri
+          (get "file:///a.clj")
+          first
+          :loc
+          z/root-string))
 
-(defn ^:private assert-move-down [expected subject cursor]
-  (is (= expected
-         (some-> (z/of-string subject {:track-position? true})
-                 (z/find-next-value z/next cursor)
-                 (f.move-coll-entry/move-down "file:///a.clj")
-                 :changes-by-uri
-                 (get "file:///a.clj")
-                 first
-                 :loc
-                 z/root-string))))
+(defn- string-move-down [subject cursor]
+  (some-> (z/of-string subject {:track-position? true})
+          (z/find-next-value z/next cursor)
+          (f.move-coll-entry/move-down "file:///a.clj")
+          :changes-by-uri
+          (get "file:///a.clj")
+          first
+          :loc
+          z/root-string))
+
+(defmacro assert-move-up [expected subject cursor]
+  ;; This is a macro so test failures have the right line numbers
+  `(is (= ~expected (string-move-up ~subject ~cursor))))
+
+(defmacro assert-move-down [expected subject cursor]
+  ;; This is a macro so test failures have the right line numbers
+  `(is (= ~expected (string-move-down ~subject ~cursor))))
 
 (deftest move-up
   (testing "common cases"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -203,6 +203,14 @@
                               " :b (+ 1 1) ;; two comment"
                               " ;; c comment"
                               " :c 3} ;; three comment") :b)
+      (assert-move-up (h/code "{:b 2"
+                              " :a 1"
+                              " ;; trailing comment"
+                              " }")
+                      (h/code "{:a 1"
+                              " :b 2"
+                              " ;; trailing comment"
+                              " }") :b)
       ;; avoids commenting out closing bracket
       (assert-move-up (h/code "{:b 2"
                               " :a 1 ;; one comment"
@@ -269,6 +277,14 @@
                                 " :b (+ 1 1) ;; two comment"
                                 " ;; c comment"
                                 " :c 3} ;; three comment") :a)
+      (assert-move-down (h/code "{:b 2"
+                                " :a 1"
+                                " ;; trailing comment"
+                                " }")
+                        (h/code "{:a 1"
+                                " :b 2"
+                                " ;; trailing comment"
+                                " }") :a)
       ;; avoids commenting out closing bracket
       (assert-move-down (h/code "{:b 2"
                                 " :a 1 ;; one comment"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -261,6 +261,22 @@
                               ""
                               " ;; c"
                               " c 3}") 'c)
+      (assert-move-up (h/code "{;; b"
+                              " b 2"
+                              ""
+                              " ;; a"
+                              " a 1"
+                              ""
+                              " ;; c"
+                              " c 3}")
+                      (h/code "{;; a"
+                              " a 1"
+                              ""
+                              " ;; b"
+                              " b 2"
+                              ""
+                              " ;; c"
+                              " c 3}") 'b)
       ;; avoids commenting out closing bracket
       (assert-move-up (h/code "{:b 2"
                               " :a 1 ;; one comment"
@@ -425,6 +441,22 @@
                                 ""
                                 " ;; c"
                                 " c 3}") 'b)
+      (assert-move-down (h/code "{;; b"
+                                " b 2"
+                                ""
+                                " ;; a"
+                                " a 1"
+                                ""
+                                " ;; c"
+                                " c 3}")
+                        (h/code "{;; a"
+                                " a 1"
+                                ""
+                                " ;; b"
+                                " b 2"
+                                ""
+                                " ;; c"
+                                " c 3}") 'a)
       ;; avoids commenting out closing bracket
       (assert-move-down (h/code "{:b 2"
                                 " :a 1 ;; one comment"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -185,11 +185,11 @@
                               "      {:keys [c d]} {:c 1 :d 2}"
                               "      e 2])") {:keys ['c 'd]}))
     (testing "comments"
-      (assert-move-up (h/code "{:b (+ 1 1) ;; one comment"
-                              " :a 1 ;; two comment"
+      (assert-move-up (h/code "{:b (+ 1 1) ;; two comment"
+                              " :a 1 ;; one comment"
                               " :c 3} ;; three comment")
-                      (h/code "{:a 1 ;; two comment"
-                              " :b (+ 1 1) ;; one comment"
+                      (h/code "{:a 1 ;; one comment"
+                              " :b (+ 1 1) ;; two comment"
                               " :c 3} ;; three comment") :b)
       (assert-move-up (h/code ";; main comment"
                               "{;; b comment"
@@ -251,11 +251,11 @@
                                 "      {:keys [c d]} {:c 1 :d 2}"
                                 "      e 2])") {:keys ['c 'd]}))
     (testing "comments"
-      (assert-move-down (h/code "{:b (+ 1 1) ;; one comment"
-                                " :a 1 ;; two comment"
+      (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
+                                " :a 1 ;; one comment"
                                 " :c 3} ;; three comment")
-                        (h/code "{:a 1 ;; two comment"
-                                " :b (+ 1 1) ;; one comment"
+                        (h/code "{:a 1 ;; one comment"
+                                " :b (+ 1 1) ;; two comment"
                                 " :c 3} ;; three comment") :a)
       (assert-move-down (h/code ";; main comment"
                                 "{;; b comment"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -160,6 +160,10 @@
                             " 1 2}")
                     (h/code "{1 2"
                             " 3 4}") 3)
+    (assert-move-up (h/code "{3 4"
+                            " 1 2}")
+                    (h/code "{1 2"
+                            " 3 4}") 4)
     (assert-move-up (h/code "{:b (+ 1 1)"
                             " :a 1"
                             " :c 3}")
@@ -288,6 +292,10 @@
                               " 1 2}")
                       (h/code "{1 2"
                               " 3 4}") 1)
+    (assert-move-down (h/code "{3 4"
+                              " 1 2}")
+                      (h/code "{1 2"
+                              " 3 4}") 2)
     (assert-move-down (h/code "{:b (+ 1 1)"
                               " :a 1"
                               " :c 3}")

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -118,7 +118,7 @@
                                                          (z/find-next-value z/next 2)))))))
 
 (defn- string-move-up [subject cursor]
-  (some-> (z/of-string subject {:track-position? true})
+  (some-> (z/of-string subject)
           (z/find-next-depth-first #(= (z/sexpr %) cursor))
           (f.move-coll-entry/move-up "file:///a.clj")
           :changes-by-uri
@@ -128,7 +128,7 @@
           z/root-string))
 
 (defn- string-move-down [subject cursor]
-  (some-> (z/of-string subject {:track-position? true})
+  (some-> (z/of-string subject)
           (z/find-next-depth-first #(= (z/sexpr %) cursor))
           (f.move-coll-entry/move-down "file:///a.clj")
           :changes-by-uri

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -193,16 +193,22 @@
                               " :c 3} ;; three comment") :b)
       (assert-move-up (h/code ";; main comment"
                               "{;; b comment"
-                              " :b (+ 1 1) ;; one comment"
-                              " :a 1 ;; two comment"
+                              " :b (+ 1 1) ;; two comment"
+                              " :a 1 ;; one comment"
                               " ;; c comment"
                               " :c 3} ;; three comment")
                       (h/code ";; main comment"
-                              "{:a 1 ;; two comment"
+                              "{:a 1 ;; one comment"
                               " ;; b comment"
-                              " :b (+ 1 1) ;; one comment"
+                              " :b (+ 1 1) ;; two comment"
                               " ;; c comment"
-                              " :c 3} ;; three comment") :b))))
+                              " :c 3} ;; three comment") :b)
+      ;; avoids commenting out closing bracket
+      (assert-move-up (h/code "{:b 2"
+                              " :a 1 ;; one comment"
+                              " }")
+                      (h/code "{:a 1 ;; one comment"
+                              " :b 2}") :b))))
 
 (deftest move-down
   (testing "common cases"
@@ -253,13 +259,19 @@
                                 " :c 3} ;; three comment") :a)
       (assert-move-down (h/code ";; main comment"
                                 "{;; b comment"
-                                " :b (+ 1 1) ;; one comment"
-                                " :a 1 ;; two comment"
+                                " :b (+ 1 1) ;; two comment"
+                                " :a 1 ;; one comment"
                                 " ;; c comment"
                                 " :c 3} ;; three comment")
                         (h/code ";; main comment"
-                                "{:a 1 ;; two comment"
+                                "{:a 1 ;; one comment"
                                 " ;; b comment"
-                                " :b (+ 1 1) ;; one comment"
+                                " :b (+ 1 1) ;; two comment"
                                 " ;; c comment"
-                                " :c 3} ;; three comment") :a))))
+                                " :c 3} ;; three comment") :a)
+      ;; avoids commenting out closing bracket
+      (assert-move-down (h/code "{:b 2"
+                                " :a 1 ;; one comment"
+                                " }")
+                        (h/code "{:a 1 ;; one comment"
+                                " :b 2}") :a))))

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -292,9 +292,9 @@
                                           " ;; b comment"
                                           " :b 2 ;; two comment"
                                           " :c 3}"))
+                     ;; move cursor to <comment '; b comment'>
                      (z/down)
                      (z/find-next-value z/right :b)
-                     ;; b comment
                      (z/find z/left* (comp n/comment? z/node))
                      (f.move-coll-entry/move-up "file:///a.clj")
                      as-string)))
@@ -313,9 +313,9 @@
                (some-> (z/of-string (h/code "{:a 1 ;; one comment"
                                             " :b 2 ;; two comment"
                                             " :c 3}"))
+                       ;; move cursor to <comment '; two comment'>
                        (z/down)
                        (z/find-next-value z/right :b)
-                       ;; two comment
                        (z/find z/right* (comp n/comment? z/node))
                        (f.move-coll-entry/move-up "file:///a.clj")
                        as-string)))))
@@ -327,7 +327,7 @@
       ;; It moves to the right row, but not the right column.
       ;; Broken because the code uses :x's original position, not :y's
       ;; eventual position.
-      ;; It is possible do derive :y's eventual position from z/position-span,
+      ;; It is possible to derive :y's eventual position from z/position-span,
       ;; but that requires constructing the zipper with {:track-position? true}.
       ;; That's a global change that may affect performance. Needs to be
       ;; benchmarked.
@@ -474,7 +474,7 @@
                                           " ;; b comment"
                                           " :b 2 ;; two comment"
                                           " :c 3}"))
-                     ;; a comment
+                     ;; move cursor to <comment '; a comment'>
                      (z/down*)
                      (f.move-coll-entry/move-down "file:///a.clj")
                      as-string)))
@@ -488,6 +488,7 @@
                (some-> (z/of-string (h/code "{:a 1 ;; one comment"
                                             " :b 2 ;; two comment"
                                             " :c 3}"))
+                       ;; move cursor to <comment '; one comment'>
                        (z/down)
                        (z/find z/right* (comp n/comment? z/node))
                        (f.move-coll-entry/move-down "file:///a.clj")

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -159,10 +159,12 @@
     ;; |1 2 |3 4|
     ;; Which gets moved to {3 41 2 }. When there are newlines between nodes,
     ;; this isn't a problem. To fix this, the code needs to be smarter about
-    ;; relocating whitespace between nodes.
+    ;; reallocating whitespace between nodes.
     (comment
       (assert-move-up (h/code "{3 4 1 2}")
-                      (h/code "{1 2 3 4}") 3))
+                      (h/code "{1 2 3 4}") 3)
+      (assert-move-up (h/code "{3 4, 1 2}")
+                      (h/code "{1 2, 3 4}") 3))
     (assert-move-up (h/code "{3 4"
                             " 1 2}")
                     (h/code "{1 2"
@@ -171,6 +173,20 @@
                             " 1 2}")
                     (h/code "{1 2"
                             " 3 4}") 4)
+    ;; TODO fix this case
+    ;; Comma stays attached to `1 2,` entry. As with single line maps, the code
+    ;; needs to be smarter about reallocating whitespace between nodes.
+    (comment
+      (assert-move-up (h/code "{3 4,"
+                              " 1 2}")
+                      (h/code "{1 2,"
+                              " 3 4}") 3))
+    (assert-move-up (h/code "#{b 2,"
+                            "  a 1,"
+                            "  c 3}")
+                    (h/code "#{a 1,"
+                            "  b 2,"
+                            "  c 3}") 'b)
     (assert-move-up (h/code "{:b (+ 1 1)"
                             " :a 1"
                             " :c 3}")
@@ -310,7 +326,9 @@
     ;; see notes for similar failures when moving up
     (comment
       (assert-move-down (h/code "{3 4 1 2}")
-                        (h/code "{1 2 3 4}") 1))
+                        (h/code "{1 2 3 4}") 1)
+      (assert-move-down (h/code "{3 4, 1 2}")
+                        (h/code "{1 2, 3 4}") 1))
     (assert-move-down (h/code "{3 4"
                               " 1 2}")
                       (h/code "{1 2"
@@ -319,6 +337,19 @@
                               " 1 2}")
                       (h/code "{1 2"
                               " 3 4}") 2)
+    ;; TODO fix this case
+    ;; see notes for similar failures when moving up
+    (comment
+      (assert-move-down (h/code "{3 4,"
+                                " 1 2}")
+                        (h/code "{1 2,"
+                                " 3 4}") 1))
+    (assert-move-down (h/code "#{b 2,"
+                              "  a 1,"
+                              "  c 3}")
+                      (h/code "#{a 1,"
+                              "  b 2,"
+                              "  c 3}") 'a)
     (assert-move-down (h/code "{:b (+ 1 1)"
                               " :a 1"
                               " :c 3}")


### PR DESCRIPTION
- Allow movement of destructured bindings
- Treat commas as whitespace
- Add tests, including several commented out failing tests.

TODO
- [ ] Remove support for sets? 
   - @ericdallo you wrote `can-move-entry?` so I wanted to check with you on this. Since the elements of a set are never paired, I don't think this refactoring should be enabled for them. What do you think?
- [ ] Fix movement in single line maps. See failing tests.
- [ ] Fix movement when cursor starts on trailing comment. See failing tests.
- [ ] Fix movement of commas. See failing tests.
- [ ] Changelog
- [ ] Docs

I have a plan for several of the failing tests, but the fix I have in mind will be a reasonably large change to the central algorithm. I won't be surprised if that change makes some other tests fail, so it may take a while to get everything working again.