### PR TITLE
Add features to move-coll-entry

### DIFF
--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -22,119 +22,168 @@
        (take-while (complement z/rightmost?))
        count))
 
-(defn ^:private expand-comment-newlines
-  "Comment nodes often include their trailing newline. This splits such nodes
-  into two, to allow more careful handling of newlines."
-  [children]
-  (mapcat (fn [{:keys [s prefix] :as n}]
-            (if (and (n/comment? n)
-                     (string/ends-with? s "\n"))
-              [(n/comment-node prefix (subs s 0 (dec (count s))))
-               (n/newline-node "\n")]
-              [n]))
-          children))
+(defn newline-comment? [n]
+  (and (n/comment? n)
+       (string/ends-with? (:s n) "\n")))
 
-(defn- trailing-whitespace? [node]
-  (and (n/whitespace-or-comment? node)
-       (not (n/linebreak? node))))
+(defn z-take-while [zloc f p?]
+  (->> zloc
+       (iterate f)
+       (take-while identity)
+       (take-while (complement z/end?))
+       (take-while p?)))
 
-(defn ^:private parse-entry-pairs
-  "Parse the children of a map or binding `parent-zloc` into entry pairs
-  (key/value pairs or binding/value pairs respectively).
+(defn z-split-with
+  [zloc p?]
+  [(z-take-while zloc z/right* p?)
+   (z/skip z/right* p? zloc)])
 
-  An entry pair is vector of nodes: the key and value themselves, with their
-  surrounding whitespace, comments and newlines.
+(defn ^:private seq-elems
+  "Returns the contents of `seq-zloc` as a a sequence of elements and padding
+  between them.
 
-  Logically, a pair's format is:
-  (whitespace | comment | newline)*
-  key
-  (whitespace | comment | newline)*
-  value
-  (whitespace | comment)*
+  What is an element? It's an item of the parent, plus any comments that are
+  associated with that item. For example, in the following vector there are two
+  elements:
 
-  NOTE: A pair does NOT include any trailing newlines... they are all allocated
-  to the next pair.
+  [;; comment before a
+   :a ;; comment after a
 
-  Returns two values: a vector of the entry pairs, and if there are lines
-  after the last value, a vector of those additional nodes."
-  [parent-zloc]
-  (let [[elements extra-lines]
-        (loop [children (->> parent-zloc
-                             z/node
-                             n/children
-                             expand-comment-newlines)
-               state    :before-key
-               result   []]
-          (cond
-            (not (seq children))
-            ;; everything processed
-            [result []]
+   ;; comment before b
+   :b ;; comment after b
+  ]
 
-            (every? n/whitespace-or-comment? children)
-            ;; everything processed but extra lines
-            [result children]
+  :a and its comments are one element, as are :b and its comments. The
+  whitespace between them is considered padding. To be precise, the padding
+  includes all whitespace, including newlines, between the :a and :b elements.
+  That is, the padding starts at the newline character following ';; comment
+  after a' and continues to the space character preceding ';; comment before b'.
+  In this case, there is also padding after the :b element: a newline and some
+  more whitespace.
 
-            (= :before-key state)
-            ;; gather comments before key, and key itself
-            (let [[prefix [k & rst]] (split-with n/whitespace-or-comment?
-                                                 children)]
-              (recur rst
-                     :before-val
-                     (conj result (concat prefix (when k [k])))))
+  The format of a returned elem is:
+  {:type :elem
+   :idx  <index of the element within seq-zloc>
+   :locs <sequence of zipper locations whose nodes make up the element>}
 
-            (= :before-val state)
-            ;; gather comments before val, val itself, and optional comment
-            ;; after val on same line
-            (let [[prefix [v & rst]] (split-with n/whitespace-or-comment?
-                                                 children)
-                  [postfix rst]      (split-with trailing-whitespace?
-                                                 rst)]
-              (recur rst
-                     :before-key
-                     (conj result (concat prefix (when v [v]) postfix))))))]
-    [(->> elements
-          (partition-all 2)
-          (mapv (fn [[k v]] (concat k v))))
-     extra-lines]))
+  The format of a returned padding is:
+  {:type :padding
+   :locs <sequence of zipper locations whose nodes make up the padding>}
+
+  The children of the original `seq-zloc` could be reconstructed by
+  concatenating all the `:locs` together.
+  "
+  [seq-zloc]
+  (loop [zloc (-> seq-zloc
+                  (z/edit* (fn [parent-node]
+                             (n/replace-children parent-node
+                                                 (mapcat (fn [node]
+                                                           (if (newline-comment? node)
+                                                             [(update node :s subs 0 (dec (count (:s node))))
+                                                              (n/newline-node "\n")]
+                                                             [node]))
+                                                         (n/children parent-node)))))
+                  z/down*)
+
+         state    :in-padding
+         elem-idx 0
+         result   []]
+    (cond
+      (nil? zloc) ;; rightmost?*
+      ;; everything processed
+      result
+
+      (= :in-padding state)
+      (let [[padding zloc] (z-split-with zloc z/whitespace?)]
+        (recur zloc
+               :on-elem
+               elem-idx
+               (cond-> result
+                 (seq padding) (conj {:type :padding :locs padding}))))
+
+      (= :on-elem state)
+      (let [[prefix elem-loc] (z-split-with zloc z/whitespace-or-comment?)]
+        (if-not elem-loc
+          ;; We've processed all the elements and this is trailing
+          ;; whitespace.
+          (cond-> result
+            (seq prefix) (conj {:type :padding :locs prefix}))
+          (let [;; find the start of the next padding
+                zloc    (->> elem-loc
+                             z/right*
+                             ;; move right until the first newline, comma or key
+                             ;; TODO: handle case where comma precedes comment
+                             ;; `a 1, ;; one comment`
+                             ;; Conceptually, the comma should stay put while
+                             ;; the entry and comment move.
+                             (z/skip z/right* (comp #{:whitespace :comment}
+                                                    z/tag))
+                             z/left*
+                             ;; then give up as much whitespace as possible,
+                             ;; back to the (optional) comment
+                             (z/skip z/left* z/whitespace?)
+                             z/right*)
+                ;; _ (prn (z/node zloc) (z/node (z/right* zloc)))
+                postfix (z-take-while (z/right* elem-loc)
+                                      z/right*
+                                      #(not= zloc %))]
+            (recur zloc
+                   :in-padding
+                   (inc elem-idx)
+                   (conj result
+                         {:type :elem
+                          :idx  elem-idx
+                          :locs (concat prefix [elem-loc] postfix)}))))))))
 
 (defn ^:private move-entry-zloc
   "Move `zloc` to direction `dir` considering multiple comments cases."
   [zloc dir]
-  (let [parent-zloc               (z/up zloc)
-        [entry-pairs extra-lines] (parse-entry-pairs parent-zloc)
+  (let [parent-zloc (z/up zloc)
+        elems       (seq-elems parent-zloc)
+        origin-elem (->> elems
+                         (filter (fn [{:keys [locs]}]
+                                   (some (fn [elem-loc]
+                                           ;; compare meta, not full loc, because
+                                           ;; comments have been separated from
+                                           ;; their newlines
+                                           (= (meta (z/node elem-loc))
+                                              (meta (z/node zloc))))
+                                         locs)))
+                         first)
 
-        node-idx     (count-siblings-left zloc)
-        new-node-idx (dir (dir node-idx))
-        ;; index of the entry pair we're moving, whether the original
-        ;; node was a key or value.
-        pair-idx     (-> node-idx (/ 2) int)
-        new-pair-idx (dir pair-idx)
-        entry-pairs  (assoc entry-pairs
-                            pair-idx (get entry-pairs new-pair-idx)
-                            new-pair-idx (get entry-pairs pair-idx))
-        ;; Most entries can keep the whitespace that precedes them,
-        ;; whether moving up or down. This assumption fails when
-        ;; swapping the first and second entries. The entry that is
-        ;; initially first typically doesn't have any preceding
-        ;; whitespace, but it's moving to a location where it needs
-        ;; some. And conversely, the entry that is initially second
-        ;; typically has preceding whitespace but is moving somewhere
-        ;; where it shouldn't. We fix this by moving preceding
-        ;; whitespace from one to the other.
-        ;; TODO: seems to work whether or not we're swapping the first
-        ;; and second entries. But is that accounting for all whitespace
-        ;; edge cases? Maybe better to do this only if (= #{0 1}
-        ;; (hash-set pair-idx new-pair-idx)).
-        [whitespace first-entry] (split-with n/whitespace? (get entry-pairs 0))
-        entry-pairs              (-> entry-pairs
-                                     (assoc 0 first-entry)
-                                     (update 1 #(concat whitespace %)))
+        ;; TODO we are assuming origin-elem is an elem. Handle case that
+        ;; origin-elem is padding
+        origin-idx (if (odd? (:idx origin-elem))
+                     (dec (:idx origin-elem))
+                     (:idx origin-elem))
+        dest-idx   (dir (dir origin-idx))
 
+        dest-elem (->> elems
+                       (filter (fn [{:keys [type idx]}]
+                                 (and (= :elem type)
+                                      (= idx dest-idx))))
+                       first)
+
+        earlier-idx        (min origin-idx dest-idx)
+        [before rst]       (split-with (fn [{:keys [type idx]}]
+                                         (or (= :padding type)
+                                             (< idx earlier-idx)))
+                                       elems)
+        [earlier-pair rst] (split-at 3 rst) ;; key, padding, value
+        [interstitial rst] (split-at 1 rst) ;; padding
+        [later-pair rst]   (split-at 3 rst) ;; key, padding, value
+
+        swapped     (concat before
+                            later-pair
+                            interstitial
+                            earlier-pair
+                            rst)
         ;; Put revised entries back into parent.
-        parent-zloc (z/subedit-> parent-zloc
-                                 (z/replace (n/replace-children (z/node parent-zloc)
-                                                                (concat (flatten entry-pairs)
-                                                                        extra-lines))))
+        parent-zloc (z/replace parent-zloc
+                               (n/replace-children (z/node parent-zloc)
+                                                   (->> swapped
+                                                        (mapcat :locs)
+                                                        (map z/node))))
 
         ;; If after reordering, the last component has become a comment,
         ;; we need to add a newline or else the closing bracket will be
@@ -149,13 +198,7 @@
                             z/insert-newline-right
                             z/up))
                       parent-zloc)]
-    ;; Move zipper back to original node, so repeated invocations keep
-    ;; moving the same entry.
-    (->> parent-zloc
-         z/down
-         (iterate z/right)
-         (drop new-node-idx)
-         first)))
+    [parent-zloc (first (:locs dest-elem))]))
 
 (defn ^:private can-move-entry? [zloc]
   (and (contains? #{:map :vector} (some-> zloc z/up z/tag))
@@ -169,19 +212,19 @@
   (and (can-move-entry? zloc)
        (>= (count-siblings-right zloc) 2)))
 
-(defn ^:private move-entry [zloc uri dir focus-zloc]
-  (when-let [new-zloc (move-entry-zloc zloc dir)]
-    {:show-document-after-edit {:uri uri
+(defn ^:private move-entry [zloc uri dir]
+  (when-let [[parent-loc dest-loc] (move-entry-zloc zloc dir)]
+    {:show-document-after-edit {:uri         uri
                                 :take-focus? true
-                                :range (meta (z/node focus-zloc))}
-     :changes-by-uri {uri
-                      [{:range (meta (z/node (z/up new-zloc)))
-                        :loc (z/up new-zloc)}]}}))
+                                :range       (meta (z/node dest-loc))}
+     :changes-by-uri           {uri
+                                [{:range (meta (z/node parent-loc))
+                                  :loc   parent-loc}]}}))
 
 (defn move-up [zloc uri]
   (when (can-move-entry-up? zloc)
-    (move-entry zloc uri dec (-> zloc z/left z/left))))
+    (move-entry zloc uri dec)))
 
 (defn move-down [zloc uri]
   (when (can-move-entry-down? zloc)
-    (move-entry zloc uri inc (-> zloc z/right z/right))))
+    (move-entry zloc uri inc)))

--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -26,7 +26,10 @@
   (and (n/comment? n)
        (string/ends-with? (:s n) "\n")))
 
-(defn z-take-while [zloc f p?]
+(defn z-take-while
+  "Returns a sequence of locations in the direction of `f` from `zloc` that
+  satisfy `p?`."
+  [zloc f p?]
   (->> zloc
        (iterate f)
        (take-while identity)
@@ -34,6 +37,9 @@
        (take-while p?)))
 
 (defn z-split-with
+  "Like clojure.core/split-with, but for a clj-rewrite zipper. Returns two
+  items, a sequence of locations to the z/right* of `zloc` that satisfy `p?`,
+  and the first location that doesn't."
   [zloc p?]
   [(z-take-while zloc z/right* p?)
    (z/skip z/right* p? zloc)])
@@ -166,8 +172,9 @@
                                  [:padding false] best-idx)))
                            -1
                            elems)
-        origin-idx (if (odd? origin-idx)
-                     (dec origin-idx)
+        ;; Here we begin to treat elements like pairs.
+        origin-idx (if (odd? origin-idx) ;; on value
+                     (dec origin-idx)    ;; back to key
                      origin-idx)
         dest-idx   (dir (dir origin-idx))
 

--- a/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/src/clojure_lsp/feature/move_coll_entry.clj
@@ -158,7 +158,7 @@
          first)))
 
 (defn ^:private can-move-entry? [zloc]
-  (and (contains? #{:map :vector :set} (some-> zloc z/up z/tag))
+  (and (contains? #{:map :vector} (some-> zloc z/up z/tag))
        (even? (count (z/child-sexprs (z/up zloc))))))
 
 (defn can-move-entry-up? [zloc]

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -195,6 +195,30 @@
                       (h/code "(let [[a b] [1 2]"
                               "      {:keys [c d]} {:c 1 :d 2}"
                               "      e 2])") {:keys ['c 'd]}))
+    (testing "blank lines"
+      (is (= (h/code "{:b 2"
+                     ""
+                     " :a 1}")
+             (some-> (z/of-string (h/code "{:a 1"
+                                          ""
+                                          " :b 2}"))
+                     ;; move cursor to blank line between a and b
+                     (z/down)
+                     (z/find-next-value z/right 1)
+                     (z/right*)
+                     (f.move-coll-entry/move-up "file:///a.clj")
+                     as-string)))
+      (is (nil?
+           (some-> (z/of-string (h/code "{:a 1"
+                                        ""
+                                        " :b 2"
+                                        ""
+                                        "}"))
+                   ;; move cursor to blank line after b
+                   (z/down)
+                   (z/find-next-value z/right 2)
+                   (z/right*)
+                   (f.move-coll-entry/move-up "file:///a.clj")))))
     (testing "comments"
       (assert-move-up (h/code "{:b (+ 1 1) ;; two comment"
                               " :a 1 ;; one comment"
@@ -341,6 +365,29 @@
                         (h/code "(let [[a b] [1 2]"
                                 "      {:keys [c d]} {:c 1 :d 2}"
                                 "      e 2])") {:keys ['c 'd]}))
+    (testing "blank lines"
+      (is (= (h/code "{"
+                     " :b 2"
+                     ""
+                     " :a 1}")
+             (some-> (z/of-string (h/code "{"
+                                          " :a 1"
+                                          ""
+                                          " :b 2}"))
+                     ;; move cursor to blank line above a
+                     (z/down*)
+                     (f.move-coll-entry/move-down "file:///a.clj")
+                     as-string)))
+      (is (nil?
+           (some-> (z/of-string (h/code "{:a 1"
+                                        ""
+                                        " :b 2}"))
+                   ;; move cursor to blank line between a and b
+                   (z/down)
+                   (z/find-next-value z/right 1)
+                   (z/right*)
+                   (f.move-coll-entry/move-down "file:///a.clj")
+                   as-string))))
     (testing "comments"
       (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
                                 " :a 1 ;; one comment"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -23,13 +23,13 @@
     (is (not (f.move-coll-entry/can-move-entry-up? (z/of-string "'(:a :b :c :d)"))))
     (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{1 2}")
                                                        (z/find-next-value z/next 2)))))
+    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "#{1 2 3 4}")
+                                                       (z/find-next-value z/next 3)))))
     (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{1 2 3 4}")
                                                   (z/find-next-value z/next 3))))
     (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{:a :b :c :d}")
                                                   (z/find-next-value z/next :c))))
     (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "[1 2 3 4]")
-                                                  (z/find-next-value z/next 3))))
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "#{1 2 3 4}")
                                                   (z/find-next-value z/next 3))))
     (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "'[a 1 c 2]")
                                                   (z/find-next-value z/next 'c)))))
@@ -78,13 +78,13 @@
     (is (not (f.move-coll-entry/can-move-entry-down? (z/of-string "'(:a :b :c :d)"))))
     (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{1 2}")
                                                          (z/find-next-value z/next 1)))))
+    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "#{1 2 3 4}")
+                                                         (z/find-next-value z/next 1)))))
     (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{1 2 3 4}")
                                                     (z/find-next-value z/next 1))))
     (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{:a :b :c :d}")
                                                     (z/find-next-value z/next :a))))
     (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "[1 2 3 4]")
-                                                    (z/find-next-value z/next 1))))
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "#{1 2 3 4}")
                                                     (z/find-next-value z/next 1))))
     (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "'[a 1 c 2]")
                                                     (z/find-next-value z/next 'a)))))
@@ -181,12 +181,6 @@
                               " 1 2}")
                       (h/code "{1 2,"
                               " 3 4}") 3))
-    (assert-move-up (h/code "#{b 2,"
-                            "  a 1,"
-                            "  c 3}")
-                    (h/code "#{a 1,"
-                            "  b 2,"
-                            "  c 3}") 'b)
     (assert-move-up (h/code "{:b (+ 1 1)"
                             " :a 1"
                             " :c 3}")
@@ -199,12 +193,6 @@
                     (h/code "[a [1 2]"
                             " b 2"
                             " c 3]") 'c)
-    (assert-move-up (h/code "#{a 1"
-                            "  c 3"
-                            "  b 2}")
-                    (h/code "#{a 1"
-                            "  b 2"
-                            "  c 3}") 'c)
     (testing "with destructuring"
       (assert-move-up (h/code "(let [[a b] [1 2]"
                               "      e 2"
@@ -360,12 +348,6 @@
                                 " 1 2}")
                         (h/code "{1 2,"
                                 " 3 4}") 1))
-    (assert-move-down (h/code "#{b 2,"
-                              "  a 1,"
-                              "  c 3}")
-                      (h/code "#{a 1,"
-                              "  b 2,"
-                              "  c 3}") 'a)
     (assert-move-down (h/code "{:b (+ 1 1)"
                               " :a 1"
                               " :c 3}")
@@ -378,12 +360,6 @@
                       (h/code "[a [1 2]"
                               " b 2"
                               " c 3]") 'b)
-    (assert-move-down (h/code "#{a 1"
-                              "  c 3"
-                              "  b 2}")
-                      (h/code "#{a 1"
-                              "  b 2"
-                              "  c 3}") 'b)
     (testing "with destructuring"
       (assert-move-down (h/code "(let [[a b] [1 2]"
                                 "      {:keys [c d]} {:c 1 :d 2}"

--- a/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -208,17 +208,16 @@
                      (z/right*)
                      (f.move-coll-entry/move-up "file:///a.clj")
                      as-string)))
-      (is (nil?
-           (some-> (z/of-string (h/code "{:a 1"
-                                        ""
-                                        " :b 2"
-                                        ""
-                                        "}"))
-                   ;; move cursor to blank line after b
-                   (z/down)
-                   (z/find-next-value z/right 2)
-                   (z/right*)
-                   (f.move-coll-entry/move-up "file:///a.clj")))))
+      (is (nil? (some-> (z/of-string (h/code "{:a 1"
+                                             ""
+                                             " :b 2"
+                                             ""
+                                             "}"))
+                        ;; move cursor to blank line after b
+                        (z/down)
+                        (z/find-next-value z/right 2)
+                        (z/right*)
+                        (f.move-coll-entry/move-up "file:///a.clj")))))
     (testing "comments"
       (assert-move-up (h/code "{:b (+ 1 1) ;; two comment"
                               " :a 1 ;; one comment"
@@ -378,16 +377,15 @@
                      (z/down*)
                      (f.move-coll-entry/move-down "file:///a.clj")
                      as-string)))
-      (is (nil?
-           (some-> (z/of-string (h/code "{:a 1"
-                                        ""
-                                        " :b 2}"))
-                   ;; move cursor to blank line between a and b
-                   (z/down)
-                   (z/find-next-value z/right 1)
-                   (z/right*)
-                   (f.move-coll-entry/move-down "file:///a.clj")
-                   as-string))))
+      (is (nil? (some-> (z/of-string (h/code "{:a 1"
+                                             ""
+                                             " :b 2}"))
+                        ;; move cursor to blank line between a and b
+                        (z/down)
+                        (z/find-next-value z/right 1)
+                        (z/right*)
+                        (f.move-coll-entry/move-down "file:///a.clj")
+                        as-string))))
     (testing "comments"
       (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
                                 " :a 1 ;; one comment"


### PR DESCRIPTION
This PR is a re-write of move-coll-entry to use a different method of allocating comments to entries. It now supports several features that were not possible before:
1. Move entries terminated by commas
        {1 2,
         3 4}
         ->
        {3 4,
         1 2}
2. Move entries within single line maps
   * `{1 2 3 4} -> {3 4 1 2}`
   * `{1 2, 3 4} -> {3 4, 1 2}`
3. Move entry when starting on trailing whitespace
        {1 2 ;; two |comment
         3 4}
         ->
        {3 4
         |1 2 ;; two comment}

It also does a better job of moving the cursor, which is now reliably placed at the beginning of the entry in its new location.

As a separate matter, this PR removes support for moving entries within sets. In the future it may be possible to add support for moving items one at a time (as opposed to in pairs) within sets, vectors and lists. And the comment allocation in this PR should facilitate that. But, for now, it is not supported.

@ericdallo I found a few cases where can-move-*? returns the wrong results. This happens:

* When on a padding line after the first pair, and `move-up` is invoked.
* When on a padding line before the last pair, and `move-down` is invoked.

Movement should not be allowed in either of these situations, but can-move-*? reports differently. Unfortunately, there's no quick way to know we're in one of these situations without doing most of the work of allocating whitespace. I changed the code to return nil in these cases. Is that the right thing to do to make the action a no-op? Or should I return the original unchanged zloc somehow?