### PR TITLE
fix incorrect results of `extract-function` when run on cljc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - General
   - Add `:classpath` to `serverInfo` command for downstream usages.
+  - Fix issues in `extract-function` that arise when operating over `.cljc` files.
 
 - Editor
   - Improve 'create function' refactor code action handling multiple cases. #682


### PR DESCRIPTION
I'm finding an issue when trying to extract `(+ 1 a)` to a new function in a `cljc` file that look like the following:
```clojure
(let [a 1 z 2]
  (+ 1 a))
```

The result is 
```clojure
(defn foo [a a]
  (+ 1 a))


  (+ 1 a))
  (foo a a))
```

After a quick investigation, it seems that the analysis, when run over `cljc` files, has results for both clj and cljs. This seems to confuse the `clojure-lsp.queries/find-local-usages-under-form` function.

I don't know if this is a long-standing issue that has a comprehensive plan to remedy, but I found the following quick-fix to this issue: when analysis data for both clj and cljs is present, filter out the cljs data.

This PR adds a test for this and implements this quick-fix