### PR TITLE
Extend move-coll-entry to elementwise movements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - Improve 'create function' refactor code action handling multiple cases. #682
   - Fix 'resolve macro as ...' code action not working.
   - Fix `showDocumentRequest` issues when triggered via some refactor code action.
-  - Add new code actions + commands `Move coll entry down` and `Move coll entry up` to move map/vectors pair entries. #684
+  - Add new code actions + commands `Move coll entry down` and `Move coll entry up` to move entries within collections. #684, #701
 
 - API/CLI
   - Make `format`, `clean-ns` and `rename` features not need to scan whole classpath, analyzing only project code improving performance a lot.

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -265,12 +265,12 @@
                         :arguments [uri line character]}}
 
              "refactor-move-coll-entry-up"
-             {:command {:title     "Move coll key-value entry up"
+             {:command {:title     "Move coll entry up"
                         :command   "move-coll-entry-up"
                         :arguments [uri line character]}}
 
              "refactor-move-coll-entry-down"
-             {:command {:title     "Move coll key-value entry down"
+             {:command {:title     "Move coll entry down"
                         :command   "move-coll-entry-down"
                         :arguments [uri line character]}}
 
@@ -427,7 +427,7 @@
           :character character}})
 
 (defn ^:private move-coll-entry-up-action [uri line character]
-  {:title "Move coll key-pair entry up"
+  {:title "Move coll entry up"
    :kind :refactor-rewrite
    :data {:id "refactor-move-coll-entry-up"
           :uri uri
@@ -435,7 +435,7 @@
           :character character}})
 
 (defn ^:private move-coll-entry-down-action [uri line character]
-  {:title "Move coll key-pair entry down"
+  {:title "Move coll entry down"
    :kind :refactor-rewrite
    :data {:id "refactor-move-coll-entry-down"
           :uri uri
@@ -507,8 +507,8 @@
         missing-imports* (future (find-missing-imports uri diagnostics db))
         require-suggestions* (future (find-all-require-suggestions uri diagnostics @missing-requires* db))
         allow-sort-map?* (future (f.sort-map/sortable-map-zloc zloc))
-        allow-move-entry-up?* (future (f.move-coll-entry/can-move-entry-up? zloc))
-        allow-move-entry-down?* (future (f.move-coll-entry/can-move-entry-down? zloc))
+        allow-move-entry-up?* (future (f.move-coll-entry/can-move-entry-up? zloc uri db))
+        allow-move-entry-down?* (future (f.move-coll-entry/can-move-entry-down? zloc uri db))
         definition (q/find-definition-from-cursor (:analysis @db) (shared/uri->filename uri) row col db)
         inline-symbol?* (future (r.transform/inline-symbol? definition db))]
     (cond-> []

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -213,6 +213,22 @@
              z/up))
        parent-zloc))))
 
+(defn ^:private can-swap?
+  "In a few cases, the simple can-move-*? heuristics return the wrong results.
+  This happens:
+  A) When on a comment following the first element/pair, and `move-up` is
+     invoked.
+  B) When on a padding line before the last element/pair, and `move-down` is
+     invoked.
+  Movement should not be allowed in either of these cases. Unfortunately,
+  there's no quick way to know we're in this situation until after we've
+  affiliated whitespace with elements. But now that we've done that, we can
+  detect it. It manifests as the origin-idx or dest-idx being out of bounds, in
+  which case either origin-elem or dest-elem will be missing. We bail out now to
+  avoid erroneous swaps."
+  [origin-elem dest-elem]
+  (and origin-elem dest-elem))
+
 (defn ^:private move-pair-zloc
   "Move a pair of elements around `zloc` in direction `dir` considering multiple
   comments cases."
@@ -230,16 +246,7 @@
 
         origin-elem (elem-by-index origin-idx elems)
         dest-elem   (elem-by-index dest-idx elems)]
-    ;; In a few cases, the simple can-move-*? heuristics return the wrong
-    ;; results. This happens:
-    ;; A) When on a comment after the first pair, and `move-up` is invoked.
-    ;; B) When on a padding line before the last pair, and `move-down` is invoked.
-    ;; Movement should not be allowed in either of these cases. Unfortunately,
-    ;; there's no quick way to know we're in this situation. But now that we've
-    ;; parsed the elems, we can detect it. It manifests as the origin-idx or
-    ;; dest-idx being out of bounds, in which case either origin-elem or
-    ;; dest-elem will be missing. We bail out now to avoid erroneous swaps.
-    (when (and origin-elem dest-elem)
+    (when (can-swap? origin-elem dest-elem)
       (let [earlier-idx  (min origin-idx dest-idx)
             [before rst] (split-elems-at-idx elems earlier-idx)
 
@@ -271,16 +278,7 @@
 
         origin-elem (elem-by-index origin-idx elems)
         dest-elem   (elem-by-index dest-idx elems)]
-    ;; In a few cases, the simple can-move-*? heuristics return the wrong
-    ;; results. This happens:
-    ;; A) When on a comment after the first element, and `move-up` is invoked.
-    ;; B) When on a padding line before the last element, and `move-down` is invoked.
-    ;; Movement should not be allowed in either of these cases. Unfortunately,
-    ;; there's no quick way to know we're in this situation. But now that we've
-    ;; parsed the elems, we can detect it. It manifests as the origin-idx or
-    ;; dest-idx being out of bounds, in which case either origin-elem or
-    ;; dest-elem will be missing. We bail out now to avoid erroneous swaps.
-    (when (and origin-elem dest-elem)
+    (when (can-swap? origin-elem dest-elem)
       (let [earlier-idx  (min origin-idx dest-idx)
             [before rst] (split-elems-at-idx elems earlier-idx)
 

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -106,15 +106,13 @@
         (recur zloc
                :on-elem
                elem-idx
-               (cond-> result
-                 (seq padding) (conj {:type :padding :locs padding}))))
+               (conj result {:type :padding :locs padding})))
 
       (= :on-elem state)
       (let [[prefix elem-loc] (z-split-with zloc z/whitespace-or-comment?)]
         (if-not elem-loc
           ;; We've processed all the elements and this is trailing whitespace.
-          (cond-> result
-            (seq prefix) (conj {:type :padding :locs prefix}))
+          (conj result {:type :padding :locs prefix})
           (let [;; affiliate elem with (optional) comment following it
                 postfix-start (z/right* elem-loc)
                 padding-start (->> postfix-start

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -1,5 +1,7 @@
 (ns clojure-lsp.feature.move-coll-entry
   (:require
+   [clojure-lsp.queries :as q]
+   [clojure-lsp.shared :as shared]
    [clojure.string :as string]
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]))
@@ -22,11 +24,11 @@
        (take-while (complement z/rightmost?))
        count))
 
-(defn newline-comment? [n]
+(defn ^:private newline-comment? [n]
   (and (n/comment? n)
        (string/ends-with? (:s n) "\n")))
 
-(defn z-take-while
+(defn ^:private z-take-while
   "Returns a sequence of locations in the direction of `f` from `zloc` that
   satisfy `p?`."
   [zloc f p?]
@@ -36,7 +38,7 @@
        (take-while (complement z/end?))
        (take-while p?)))
 
-(defn z-split-with
+(defn ^:private z-split-with
   "Like clojure.core/split-with, but for a clj-rewrite zipper. Returns two
   items, a sequence of locations to the z/right* of `zloc` that satisfy `p?`,
   and the first location that doesn't."
@@ -121,7 +123,7 @@
                              ;; TODO: handle case where comma precedes comment
                              ;; `a 1, ;; one comment`
                              ;; Conceptually, the comma should stay put while
-                             ;; the entry and comment move.
+                             ;; the pair and comment move.
                              (z/skip z/right* (comp #{:whitespace :comment}
                                                     z/tag))
                              ;; relinquish that node
@@ -142,67 +144,106 @@
                           :idx  elem-idx
                           :locs (concat prefix [elem-loc] postfix)}))))))))
 
-(defn z-cursor-position [zloc]
+(defn ^:private z-cursor-position [zloc]
   (meta (z/node zloc)))
 
-(defn ^:private move-entry-zloc
-  "Move `zloc` to direction `dir` considering multiple comments cases."
+(defn ^:private elem-index-by-cursor-position
+  "Search for an element within `elems` that was at `cursor-position`.
+
+  We compare cursor position, not full loc, because comments have been separated
+  from their newlines by `seq-elems`.
+
+  This procedure is complicated by the possiblity that the cursor is on padding
+  between elements. If this was the case, we assume the intention was to move
+  the next element."
+  [cursor-position elems]
+  (reduce (fn [best-idx {:keys [idx type locs]}]
+            (let [origin? (->> locs
+                               (some (fn [elem-loc]
+                                       (= (z-cursor-position elem-loc)
+                                          cursor-position)))
+                               boolean)]
+              (case [type origin?]
+                [:elem true]     (reduced idx)
+                [:elem false]    idx
+                [:padding true]  (reduced (inc best-idx))
+                [:padding false] best-idx)))
+          -1
+          elems))
+
+(defn ^:private elem-by-index [origin-idx elems]
+  (->> elems
+       (filter (fn [{:keys [type idx]}]
+                 (and (= :elem type)
+                      (= idx origin-idx))))
+       first))
+
+(defn ^:private split-elems-at-idx [elems split-idx]
+  (split-with (fn [{:keys [type idx]}]
+                (or (= :padding type)
+                    (< idx split-idx)))
+              elems))
+
+(defn ^:private edit-collection
+  "Put revised entries back into parent."
+  [parent-zloc swapped]
+  (z/replace parent-zloc
+             (n/replace-children (z/node parent-zloc)
+                                 (->> swapped
+                                      (mapcat :locs)
+                                      (map z/node)))))
+
+(defn ^:private fix-trailing-comment
+  "After reordering, the last component may now be a comment. We need to add a
+  newline because otherwise the closing bracket will be commented out. By
+  default this aligns the bracket with rightmost element, but this can be
+  modified by providing a `movement` from the rightmost."
+  ([parent-zloc] (fix-trailing-comment parent-zloc identity))
+  ([parent-zloc movement]
+   (let [last-zloc (-> parent-zloc z/down z/rightmost*)]
+     (if (-> last-zloc z/node n/comment?)
+       (let [col (-> parent-zloc
+                     z/down
+                     z/rightmost
+                     movement
+                     z-cursor-position
+                     :col)]
+         (-> last-zloc
+             (z/insert-space-right (dec col))
+             z/insert-newline-right
+             z/up))
+       parent-zloc))))
+
+(defn ^:private move-pair-zloc
+  "Move a pair of elements around `zloc` in direction `dir` considering multiple
+  comments cases."
   [zloc dir]
-  (let [parent-zloc     (z/up zloc)
-        cursor-position (z-cursor-position zloc)
+  (let [parent-zloc (z/up zloc)
 
         elems (seq-elems parent-zloc)
 
-        ;; Search for original cursor location within elems.
-        ;; We compare cursor position, not full loc, because comments have been
-        ;; separated from their newlines by `seq-elems`.
-        ;; This algorithm is complicated by the possiblity that the cursor is on
-        ;; padding between elements. If this was the case, we assume the
-        ;; intention was to move the next element.
-        origin-idx (reduce (fn [best-idx {:keys [idx type locs]}]
-                             (let [origin? (->> locs
-                                                (some (fn [elem-loc]
-                                                        (= (z-cursor-position elem-loc)
-                                                           cursor-position)))
-                                                boolean)]
-                               (case [type origin?]
-                                 [:elem true]     (reduced idx)
-                                 [:elem false]    idx
-                                 [:padding true]  (reduced (inc best-idx))
-                                 [:padding false] best-idx)))
-                           -1
-                           elems)
+        origin-idx (elem-index-by-cursor-position (z-cursor-position zloc) elems)
         ;; Here we begin to treat elements like pairs.
-        origin-idx (if (odd? origin-idx) ;; on value
-                     (dec origin-idx)    ;; back to key
-                     origin-idx)
+        origin-idx (cond-> origin-idx
+                     ;; if on on value, go back to key
+                     (odd? origin-idx) dec)
         dest-idx   (dir (dir origin-idx))
 
-        origin-elem (->> elems
-                         (filter (fn [{:keys [type idx]}]
-                                   (and (= :elem type)
-                                        (= idx origin-idx))))
-                         first)
-        dest-elem   (->> elems
-                         (filter (fn [{:keys [type idx]}]
-                                   (and (= :elem type)
-                                        (= idx dest-idx))))
-                         first)]
+        origin-elem (elem-by-index origin-idx elems)
+        dest-elem   (elem-by-index dest-idx elems)]
     ;; In a few cases, the simple can-move-*? heuristics return the wrong
     ;; results. This happens:
-    ;; A) When on a padding line after the first pair, and `move-up` is invoked.
+    ;; A) When on a comment after the first pair, and `move-up` is invoked.
     ;; B) When on a padding line before the last pair, and `move-down` is invoked.
     ;; Movement should not be allowed in either of these cases. Unfortunately,
-    ;; there's no quick way to know we're in this situation. But now that we
-    ;; have parsed the elems, we can detect it. It manifests as the origin-idx
-    ;; or dest-idx being out of bounds, in which case either origin-elem or
+    ;; there's no quick way to know we're in this situation. But now that we've
+    ;; parsed the elems, we can detect it. It manifests as the origin-idx or
+    ;; dest-idx being out of bounds, in which case either origin-elem or
     ;; dest-elem will be missing. We bail out now to avoid erroneous swaps.
     (when (and origin-elem dest-elem)
-      (let [earlier-idx        (min origin-idx dest-idx)
-            [before rst]       (split-with (fn [{:keys [type idx]}]
-                                             (or (= :padding type)
-                                                 (< idx earlier-idx)))
-                                           elems)
+      (let [earlier-idx  (min origin-idx dest-idx)
+            [before rst] (split-elems-at-idx elems earlier-idx)
+
             [earlier-pair rst] (split-at 3 rst) ;; key, padding, value
             [interstitial rst] (split-at 1 rst) ;; padding
             [later-pair rst]   (split-at 3 rst) ;; key, padding, value
@@ -212,42 +253,132 @@
                                 interstitial
                                 earlier-pair
                                 rst)
-            ;; Put revised entries back into parent.
-            parent-zloc (z/replace parent-zloc
-                                   (n/replace-children (z/node parent-zloc)
-                                                       (->> swapped
-                                                            (mapcat :locs)
-                                                            (map z/node))))
-
-            ;; If after reordering, the last component has become a comment,
-            ;; we need to add a newline or else the closing bracket will be
-            ;; commented out.
-            last-zloc   (-> parent-zloc z/down z/rightmost*)
-            parent-zloc (if (-> last-zloc z/node n/comment?)
-                          ;; align bracket with last key
-                          (let [last-key (-> parent-zloc z/down z/rightmost z/left)
-                                col      (:col (meta (z/node last-key)))]
-                            (-> last-zloc
-                                (z/insert-space-right (dec col))
-                                z/insert-newline-right
-                                z/up))
-                          parent-zloc)]
+            parent-zloc (-> parent-zloc
+                            (edit-collection swapped)
+                            ;; align with last key, not value
+                            (fix-trailing-comment z/left))]
         [parent-zloc (first (:locs dest-elem))]))))
 
-(defn ^:private can-move-entry? [zloc]
-  (and (contains? #{:map :vector} (some-> zloc z/up z/tag))
-       (even? (count (z/child-sexprs (z/up zloc))))))
+(defn ^:private move-element-zloc
+  "Move an element around `zloc` in direction `dir` considering multiple
+  comments cases."
+  [zloc dir]
+  (let [parent-zloc (z/up zloc)
 
-(defn can-move-entry-up? [zloc]
-  (and (can-move-entry? zloc)
-       (>= (count-siblings-left zloc) 2)))
+        elems (seq-elems parent-zloc)
 
-(defn can-move-entry-down? [zloc]
-  (and (can-move-entry? zloc)
-       (>= (count-siblings-right zloc) 2)))
+        origin-idx (elem-index-by-cursor-position (z-cursor-position zloc) elems)
+        dest-idx   (dir origin-idx)
 
-(defn ^:private move-entry [zloc uri dir]
-  (when-let [[parent-loc dest-loc] (move-entry-zloc zloc dir)]
+        origin-elem (elem-by-index origin-idx elems)
+        dest-elem   (elem-by-index dest-idx elems)]
+    ;; In a few cases, the simple can-move-*? heuristics return the wrong
+    ;; results. This happens:
+    ;; A) When on a comment after the first element, and `move-up` is invoked.
+    ;; B) When on a padding line before the last element, and `move-down` is invoked.
+    ;; Movement should not be allowed in either of these cases. Unfortunately,
+    ;; there's no quick way to know we're in this situation. But now that we've
+    ;; parsed the elems, we can detect it. It manifests as the origin-idx or
+    ;; dest-idx being out of bounds, in which case either origin-elem or
+    ;; dest-elem will be missing. We bail out now to avoid erroneous swaps.
+    (when (and origin-elem dest-elem)
+      (let [earlier-idx  (min origin-idx dest-idx)
+            [before rst] (split-elems-at-idx elems earlier-idx)
+
+            [[earlier-elem padding later-elem] rst] (split-at 3 rst)
+
+            swapped (concat before
+                            [later-elem
+                             padding
+                             earlier-elem]
+                            rst)
+
+            parent-zloc (-> parent-zloc
+                            (edit-collection swapped)
+                            (fix-trailing-comment))]
+        [parent-zloc (first (:locs dest-elem))]))))
+
+(def ^:private common-binding-syms
+  "Symbols that are typically used to define bindings."
+  ;; We are not concerned with macros like `if-let` that establish one binding
+  ;; only. They can be treated like regular 'move-element' vectors.
+  #{'binding 'doseq 'for 'let 'loop 'with-local-vars 'with-open 'with-redefs})
+
+(defn ^:private establishes-bindings?
+  "Returns whether `zloc` (which should be a vector node) establishes bindings,
+  such as in `clojure.core/let`.
+
+  This uses a few heurisitics.
+
+  First, there are several clojure.core functions and macros which establish
+  bindings, such as `for`, `let`, `loop` and `binding`. It returns true if
+  `zloc` is in one of these expressions (even if the expression is actually
+  imported from some namespace besides clojure.core (TODO is it reasonable to
+  assume that any function with one of these names establishes bindings, even if
+  it isn't in clojure.core?)).
+
+  Otherwise, if the first child of `zloc` defines a local variable (according to
+  the clj-kondo diagnostics), then this also returns true. This allows library-
+  and user-defined code to declare that it establishes bindings, via `:lint-as`.
+  Originally this was the only heuristic, since it works for `let` and `for`.
+  But it fails for `bindings` and other forms where the clj-kondo analysis
+  reports that it merely references existing variables, rather than establishing
+  definitions."
+  [zloc uri {:keys [analysis]}]
+  (boolean
+    (or (when-let [outer-zloc (z/left zloc)]
+          (and (nil? (z/left outer-zloc)) ;; leftmost
+               (contains? common-binding-syms (z/sexpr outer-zloc))))
+        (let [z-pos   (z-cursor-position (z/down zloc))
+              z-scope {:name-row     (:row z-pos)
+                       :name-col     (:col z-pos)
+                       :name-end-row (:end-row z-pos)
+                       :name-end-col (:end-col z-pos)}]
+          (q/find-first (fn [element]
+                          (and (= :locals (:bucket element))
+                               (shared/inside? element z-scope)))
+                        (get analysis (shared/uri->filename uri)))))))
+
+(defn ^:private can-move-pair-up? [zloc]
+  (when (and (even? (count (z/child-sexprs (z/up zloc))))
+             (>= (count-siblings-left zloc) 2))
+    :pairwise))
+
+(defn ^:private can-move-element-up? [zloc]
+  (when (>= (count-siblings-left zloc) 1)
+    :elementwise))
+
+(defn ^:private can-move-pair-down? [zloc]
+  (when (and (even? (count (z/child-sexprs (z/up zloc))))
+             (>= (count-siblings-right zloc) 2))
+    :pairwise))
+
+(defn ^:private can-move-element-down? [zloc]
+  (when (>= (count-siblings-right zloc) 1)
+    :elementwise))
+
+(defn can-move-entry-up? [zloc uri db]
+  (let [parent-zloc (z/up zloc)]
+    (case (some-> parent-zloc z/tag)
+      :map         (can-move-pair-up? zloc)
+      :vector      (if (establishes-bindings? parent-zloc uri db)
+                     (can-move-pair-up? zloc)
+                     (can-move-element-up? zloc))
+      (:list :set) (can-move-element-up? zloc)
+      nil)))
+
+(defn can-move-entry-down? [zloc uri db]
+  (let [parent-zloc (z/up zloc)]
+    (case (some-> parent-zloc z/tag)
+      :map         (can-move-pair-down? zloc)
+      :vector      (if (establishes-bindings? parent-zloc uri db)
+                     (can-move-pair-down? zloc)
+                     (can-move-element-down? zloc))
+      (:list :set) (can-move-element-down? zloc)
+      nil)))
+
+(defn ^:private changes [uri [parent-loc dest-loc :as changed]]
+  (when changed
     {:show-document-after-edit {:uri         uri
                                 :take-focus? true
                                 :range       (z-cursor-position dest-loc)}
@@ -255,10 +386,14 @@
                                 [{:range (z-cursor-position parent-loc)
                                   :loc   parent-loc}]}}))
 
-(defn move-up [zloc uri]
-  (when (can-move-entry-up? zloc)
-    (move-entry zloc uri dec)))
+(defn move-up [zloc uri db]
+  (when-let [breadth (can-move-entry-up? zloc uri db)]
+    (changes uri (case breadth
+                   :pairwise    (move-pair-zloc zloc dec)
+                   :elementwise (move-element-zloc zloc dec)))))
 
-(defn move-down [zloc uri]
-  (when (can-move-entry-down? zloc)
-    (move-entry zloc uri inc)))
+(defn move-down [zloc uri db]
+  (when-let [breadth (can-move-entry-down? zloc uri db)]
+    (changes uri (case breadth
+                   :pairwise    (move-pair-zloc zloc inc)
+                   :elementwise (move-element-zloc zloc inc)))))

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -326,7 +326,7 @@
   [zloc uri {:keys [analysis]}]
   (boolean
     (or (when-let [outer-zloc (z/left zloc)]
-          (and (nil? (z/left outer-zloc)) ;; leftmost
+          (and (z/leftmost? outer-zloc)
                (contains? common-binding-syms (z/sexpr outer-zloc))))
         (let [z-pos   (z-cursor-position (z/down zloc))
               z-scope {:name-row     (:row z-pos)

--- a/lib/src/clojure_lsp/feature/refactor.clj
+++ b/lib/src/clojure_lsp/feature/refactor.clj
@@ -78,11 +78,11 @@
 (defmethod refactor :sort-map [{:keys [loc]}]
   (f.sort-map/sort-map loc))
 
-(defmethod refactor :move-coll-entry-up [{:keys [loc uri]}]
-  (f.move-coll-entry/move-up loc uri))
+(defmethod refactor :move-coll-entry-up [{:keys [loc uri db]}]
+  (f.move-coll-entry/move-up loc uri db))
 
-(defmethod refactor :move-coll-entry-down [{:keys [loc uri]}]
-  (f.move-coll-entry/move-down loc uri))
+(defmethod refactor :move-coll-entry-down [{:keys [loc uri db]}]
+  (f.move-coll-entry/move-down loc uri db))
 
 (defmethod refactor :suppress-diagnostic [{:keys [loc args]}]
   (apply r.transform/suppress-diagnostic loc args))

--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -1,137 +1,124 @@
 (ns clojure-lsp.feature.move-coll-entry-test
   (:require
+   [clojure-lsp.db :as db]
    [clojure-lsp.feature.move-coll-entry :as f.move-coll-entry]
+   [clojure-lsp.parser :as parser]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]))
 
+(h/reset-db-after-test)
+
+(def ^:private uri (h/file-uri "file:///a.cljc"))
+
+(defn zloc-at [row col]
+  (-> @db/db
+      (get-in [:documents uri])
+      :text
+      (parser/loc-at-pos row col)))
+
+(defn load-code-and-zloc [code]
+  (let [[[row col]] (h/load-code-and-locs code uri)]
+    (zloc-at row col)))
+
+(defn can-move-code-up? [code]
+  (let [zloc (load-code-and-zloc code)]
+    (f.move-coll-entry/can-move-entry-up? zloc uri @db/db)))
+
+(defn can-move-code-down? [code]
+  (let [zloc (load-code-and-zloc code)]
+    (f.move-coll-entry/can-move-entry-down? zloc uri @db/db)))
+
 (deftest can-move-entry-up?
   (testing "common cases"
-    (is (not (f.move-coll-entry/can-move-entry-up? (z/of-string "[]"))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "[1]")
-                                                       (z/find-next-value z/next 1)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "#{1 2 3}")
-                                                       (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "[1 2 3]")
-                                                       (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{1 2 3}")
-                                                       (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (z/of-string "{:a :b :c :d}"))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (z/of-string "#{:a :b :c :d}"))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (z/of-string "[:a :b :c :d]"))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (z/of-string "'(:a :b :c :d)"))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{1 2}")
-                                                       (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "#{1 2 3 4}")
-                                                       (z/find-next-value z/next 3)))))
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{1 2 3 4}")
-                                                  (z/find-next-value z/next 3))))
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{:a :b :c :d}")
-                                                  (z/find-next-value z/next :c))))
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "[1 2 3 4]")
-                                                  (z/find-next-value z/next 3))))
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "'[a 1 c 2]")
-                                                  (z/find-next-value z/next 'c)))))
+    (is (not (can-move-code-up? "|[]")))
+    (is (not (can-move-code-up? "[|1]")))
+    (is (not (can-move-code-up? "{1 |2 3}")))
+    (is (not (can-move-code-up? "|{:a :b :c :d}")))
+    (is (not (can-move-code-up? "|#{:a :b :c :d}")))
+    (is (not (can-move-code-up? "|[:a :b :c :d]")))
+    (is (not (can-move-code-up? "|'(:a :b :c :d)")))
+    (is (not (can-move-code-up? "{|1 2}")))
+    (is (not (can-move-code-up? "{1 |2}")))
+    (is (can-move-code-up? "#{1 |2 3}"))
+    (is (can-move-code-up? "[1 |2 3]"))
+    (is (can-move-code-up? "'(1 |2 3)"))
+    (is (can-move-code-up? "{1 2 |3 4}"))
+    (is (can-move-code-up? "(let [a 1 |c 2])"))
+    (is (can-move-code-up? "(binding [a 1 |c 2])")))
   (testing "comments"
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string (h/code "{1 2 ;; some comment"
-                                                                       " 3 4}"))
-                                                  (z/find-next-value z/next 3))))
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string (h/code "{1 2"
-                                                                       " ;; some comment"
-                                                                       " 3 4}"))
-                                                  (z/find-next-value z/next 3)))))
+    (is (can-move-code-up? (h/code "{1 2 ;; some comment"
+                                   " |3 4}")))
+    (is (can-move-code-up? (h/code "{1 2"
+                                   " ;; some comment"
+                                   " |3 4}"))))
   (testing "with destructuring"
-    (is (f.move-coll-entry/can-move-entry-up? (-> (z/of-string (h/code "[[a b] [1 2]"
-                                                                       " {:keys [c d]} {:c 1 :d 2}"
-                                                                       " e 2]"))
-                                                  (z/find-next-depth-first #(= (z/sexpr %)
-                                                                               {:keys '[c d]}))))))
+    (is (can-move-code-up? (h/code "(let [[a b] [1 2]"
+                                   "      |{:keys [c d]} {:c 1 :d 2}"
+                                   "      e 2])"))))
   (testing "when on first entry"
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "#{1 2 3 4}")
-                                                       (z/find-next-value z/next 1)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "#{1 2 3 4}")
-                                                       (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{:a :b :c :d}")
-                                                       (z/find-next-value z/next :a)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "{:a :b :c :d}")
-                                                       (z/find-next-value z/next :b)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "'[a 1 c 2]")
-                                                       (z/find-next-value z/next 'a)))))
-    (is (not (f.move-coll-entry/can-move-entry-up? (-> (z/of-string "'[a 1 c 2]")
-                                                       (z/find-next-value z/next 1)))))))
+    (is (not (can-move-code-up? "#{|1 2 3}")))
+    (is (not (can-move-code-up? "[|1 2 3]")))
+    (is (not (can-move-code-up? "'(|1 2 3)")))
+    (is (not (can-move-code-up? "{|:a :b :c :d}")))
+    (is (not (can-move-code-up? "{:a |:b :c :d}")))
+    (is (not (can-move-code-up? "(let [|a 1 c 2])")))
+    (is (not (can-move-code-up? "(let [a |1 c 2])")))))
 
 (deftest can-move-entry-down?
   (testing "common cases"
-    (is (not (f.move-coll-entry/can-move-entry-down? (z/of-string "[]"))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "[1]")
-                                                         (z/find-next-value z/next 1)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "#{1 2 3}")
-                                                         (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "[1 2 3]")
-                                                         (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{1 2 3}")
-                                                         (z/find-next-value z/next 2)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (z/of-string "{:a :b :c :d}"))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (z/of-string "#{:a :b :c :d}"))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (z/of-string "[:a :b :c :d]"))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (z/of-string "'(:a :b :c :d)"))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{1 2}")
-                                                         (z/find-next-value z/next 1)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "#{1 2 3 4}")
-                                                         (z/find-next-value z/next 1)))))
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{1 2 3 4}")
-                                                    (z/find-next-value z/next 1))))
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{:a :b :c :d}")
-                                                    (z/find-next-value z/next :a))))
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "[1 2 3 4]")
-                                                    (z/find-next-value z/next 1))))
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "'[a 1 c 2]")
-                                                    (z/find-next-value z/next 'a)))))
+    (is (not (can-move-code-down? "|[]")))
+    (is (not (can-move-code-down? "[|1]")))
+    (is (not (can-move-code-down? "{1 |2 3}")))
+    (is (not (can-move-code-down? "|{:a :b :c :d}")))
+    (is (not (can-move-code-down? "|#{:a :b :c :d}")))
+    (is (not (can-move-code-down? "|[:a :b :c :d]")))
+    (is (not (can-move-code-down? "|'(:a :b :c :d)")))
+    (is (not (can-move-code-down? "{|1 2}")))
+    (is (can-move-code-down? "#{1 |2 3}"))
+    (is (can-move-code-down? "[1 |2 3]"))
+    (is (can-move-code-down? "'(1 |2 3)"))
+    (is (can-move-code-down? "{|1 2 3 4}"))
+    (is (can-move-code-down? "(let [|a 1 c 2])"))
+    (is (can-move-code-down? "(binding [|a 1 c 2])")))
   (testing "comments"
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string (h/code "{1 2 ;; some comment"
-                                                                         " 3 4 ;; other coment"
-                                                                         " 5 6}"))
-                                                    (z/find-next-value z/next 3))))
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string (h/code "{1 2"
-                                                                         " ;; some comment"
-                                                                         " 3 4"
-                                                                         " 5 6}"))
-                                                    (z/find-next-value z/next 3)))))
+    (is (can-move-code-down? (h/code "{1 2 ;; some comment"
+                                     " |3 4 ;; other coment"
+                                     " 5 6}")))
+    (is (can-move-code-down? (h/code "{1 2"
+                                     " ;; some comment"
+                                     " |3 4"
+                                     " 5 6}"))))
   (testing "with destructuring"
-    (is (f.move-coll-entry/can-move-entry-down? (-> (z/of-string (h/code "[[a b] [1 2]"
-                                                                         " {:keys [c d]} {:c 1 :d 2}"
-                                                                         " e 2]"))
-                                                    (z/find-next-depth-first #(= (z/sexpr %)
-                                                                                 {:keys '[c d]}))))))
+    (is (can-move-code-down? (h/code "(let [[a b] [1 2]"
+                                     "      |{:keys [c d]} {:c 1 :d 2}"
+                                     "      e 2])"))))
   (testing "when on last entry"
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "#{1 2 3 4}")
-                                                         (z/find-next-value z/next 3)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "#{1 2 3 4}")
-                                                         (z/find-next-value z/next 4)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{:a :b :c :d}")
-                                                         (z/find-next-value z/next :c)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "{:a :b :c :d}")
-                                                         (z/find-next-value z/next :d)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "'[a 1 c 2]")
-                                                         (z/find-next-value z/next 'c)))))
-    (is (not (f.move-coll-entry/can-move-entry-down? (-> (z/of-string "'[a 1 c 2]")
-                                                         (z/find-next-value z/next 2)))))))
+    (is (not (can-move-code-down? "#{1 2 |3}")))
+    (is (not (can-move-code-down? "[1 2 |3]")))
+    (is (not (can-move-code-down? "'(1 2 |3)")))
+    (is (not (can-move-code-down? "{:a :b |:c :d}")))
+    (is (not (can-move-code-down? "{:a :b :c |:d}")))
+    (is (not (can-move-code-down? "(let [a 1 |c 2])")))
+    (is (not (can-move-code-down? "(let [a 1 c |2])")))))
 
-(defn- move-up* [subject cursor]
-  (some-> (z/of-string subject)
-          (z/find-next-depth-first #(= (z/sexpr %) cursor))
-          (f.move-coll-entry/move-up "file:///a.clj")))
+(defn move-zloc-up [zloc]
+  (f.move-coll-entry/move-up zloc uri @db/db))
 
-(defn- move-down* [subject cursor]
-  (some-> (z/of-string subject)
-          (z/find-next-depth-first #(= (z/sexpr %) cursor))
-          (f.move-coll-entry/move-down "file:///a.clj")))
+(defn move-zloc-down [zloc]
+  (f.move-coll-entry/move-down zloc uri @db/db))
+
+(defn move-code-up [code]
+  (move-zloc-up (load-code-and-zloc code)))
+
+(defn move-code-down [code]
+  (move-zloc-down (load-code-and-zloc code)))
 
 (defn- as-string [change]
   (some-> change
           :changes-by-uri
-          (get "file:///a.clj")
+          (get uri)
           first
           :loc
           z/root-string))
@@ -143,109 +130,397 @@
     [row col]))
 
 ;; These are macros so test failures have the right line numbers
-(defmacro assert-move-up [expected subject cursor]
-  `(is (= ~expected (as-string (move-up* ~subject ~cursor)))))
-(defmacro assert-move-down [expected subject cursor]
-  `(is (= ~expected (as-string (move-down* ~subject ~cursor)))))
-(defmacro assert-move-up-position [expected subject cursor]
-  `(is (= ~expected (as-position (move-up* ~subject ~cursor)))))
-(defmacro assert-move-down-position [expected subject cursor]
-  `(is (= ~expected (as-position (move-down* ~subject ~cursor)))))
+(defmacro assert-move-up [expected code]
+  `(is (= ~expected (as-string (move-code-up ~code)))))
+(defmacro assert-move-down [expected code]
+  `(is (= ~expected (as-string (move-code-down ~code)))))
+(defmacro assert-move-up-position [expected code]
+  `(is (= ~expected (as-position (move-code-up ~code)))))
+(defmacro assert-move-down-position [expected code]
+  `(is (= ~expected (as-position (move-code-down ~code)))))
 
 (deftest move-up
   (testing "common cases"
     (assert-move-up (h/code "{3 4 1 2}")
-                    (h/code "{1 2 3 4}") 3)
+                    (h/code "{1 2 |3 4}"))
     (assert-move-up (h/code "{3 4, 1 2}")
-                    (h/code "{1 2, 3 4}") 3)
+                    (h/code "{1 2, |3 4}"))
     (assert-move-up (h/code "{3 4"
                             " 1 2}")
                     (h/code "{1 2"
-                            " 3 4}") 3)
+                            " |3 4}"))
     (assert-move-up (h/code "{3 4"
                             " 1 2}")
                     (h/code "{1 2"
-                            " 3 4}") 4)
+                            " 3 |4}"))
     (assert-move-up (h/code "{3 4,"
                             " 1 2}")
                     (h/code "{1 2,"
-                            " 3 4}") 3)
+                            " |3 4}"))
     (assert-move-up (h/code "{:b (+ 1 1)"
                             " :a 1"
                             " :c 3}")
                     (h/code "{:a 1"
-                            " :b (+ 1 1)"
-                            " :c 3}") :b)
-    (assert-move-up (h/code "[a [1 2]"
+                            " |:b (+ 1 1)"
+                            " :c 3}"))
+    (assert-move-up (h/code "[2 1]")
+                    (h/code "[1 |2]"))
+    (assert-move-up (h/code "[1 3 2]")
+                    (h/code "[1 2 |3]"))
+    (assert-move-up (h/code "(def a 1)"
+                            "[2 a]")
+                    (h/code "(def a 1)"
+                            "[a |2]"))
+    (assert-move-up (h/code "(let [a [1 2]"
+                            "      c 3"
+                            "      b 2])")
+                    (h/code "(let [a [1 2]"
+                            "      b 2"
+                            "      |c 3])"))
+    (assert-move-up (h/code "(binding [b 2"
+                            "          a 1]"
+                            "  (+ a b))")
+                    (h/code "(binding [a 1"
+                            "          |b 2]"
+                            "  (+ a b))"))
+    (assert-move-up (h/code "(for [b [3 4]"
+                            "      a [1 2]"
+                            "      :let [c (inc a)]]"
+                            "  (+ a b c))")
+                    (h/code "(for [a [1 2]"
+                            "      |b [3 4]"
+                            "      :let [c (inc a)]]"
+                            "  (+ a b c))"))
+    (assert-move-up (h/code "(for [a [1 2]"
+                            "      :let [c (inc b)"
+                            "            b (inc a)]]"
+                            "  (+ a b c))")
+                    (h/code "(for [a [1 2]"
+                            "      :let [b (inc a)"
+                            "            |c (inc b)]]"
+                            "  (+ a b c))"))
+    (assert-move-up (h/code "(ns foo"
+                            "  {:clj-kondo/config '{:lint-as {foo/foo clojure.core/let}}})"
+                            "(defmacro foo [bs & form]"
+                            "  `(let [~@bs]"
+                            "     ~@form))"
+                            "(foo [b 2"
+                            "      a 1]"
+                            "  (inc a))")
+                    (h/code "(ns foo"
+                            "  {:clj-kondo/config '{:lint-as {foo/foo clojure.core/let}}})"
+                            "(defmacro foo [bs & form]"
+                            "  `(let [~@bs]"
+                            "     ~@form))"
+                            "(foo [a 1"
+                            "      |b 2]"
+                            "  (inc a))")))
+  (testing "with destructuring"
+    (assert-move-up (h/code "(let [[a b] [1 2]"
+                            "      e 2"
+                            "      {:keys [c d]} {:c 1 :d 2}])")
+                    (h/code "(let [[a b] [1 2]"
+                            "      {:keys [c d]} {:c 1 :d 2}"
+                            "      |e 2])"))
+    (assert-move-up (h/code "(let [{:keys [c d]} {:c 1 :d 2}"
+                            "      [a b] [1 2]"
+                            "      e 2])")
+                    (h/code "(let [[a b] [1 2]"
+                            "      |{:keys [c d]} {:c 1 :d 2}"
+                            "      e 2])"))
+    (assert-move-up (h/code "(for [a [1 2]"
+                            "      :let [{:keys [c]} {:c 1}"
+                            "            {:keys [b]} {:b 1}]])")
+                    (h/code "(for [a [1 2]"
+                            "      :let [{:keys [b]} {:b 1}"
+                            "            |{:keys [c]} {:c 1}]])")))
+  (testing "blank lines"
+    (is (= (h/code "{:b 2"
+                   ""
+                   " :a 1}")
+           (-> (h/code "{:a 1"
+                       "|"
+                       " :b 2}")
+               load-code-and-zloc
+               ;; load-code moves cursor in whitespace to outer form;
+               ;; move cursor to blank line between a and b
+               (z/down)
+               (z/find-next-value z/right 1)
+               (z/right*)
+               move-zloc-up
+               as-string)))
+    (is (nil? (-> (h/code "{:a 1"
+                          ""
+                          " :b 2"
+                          "|"
+                          "}")
+                  load-code-and-zloc
+                  ;; load-code moves cursor in whitespace to outer form;
+                  ;; move cursor to blank line after b
+                  (z/down)
+                  (z/find-next-value z/right 2)
+                  z/right*
+                  move-zloc-up))))
+  (testing "comments"
+    (assert-move-up (h/code "{:b (+ 1 1) ;; two comment"
+                            " :a 1 ;; one comment"
+                            " :c 3} ;; three comment")
+                    (h/code "{:a 1 ;; one comment"
+                            " |:b (+ 1 1) ;; two comment"
+                            " :c 3} ;; three comment"))
+    (assert-move-up (h/code ";; main comment"
+                            "{;; b comment"
+                            " :b (+ 1 1) ;; two comment"
+                            " :a 1 ;; one comment"
+                            " ;; c comment"
+                            " :c 3} ;; three comment")
+                    (h/code ";; main comment"
+                            "{:a 1 ;; one comment"
+                            " ;; b comment"
+                            " |:b (+ 1 1) ;; two comment"
+                            " ;; c comment"
+                            " :c 3} ;; three comment"))
+    (assert-move-up (h/code "{:b 2"
+                            " :a 1"
+                            " ;; trailing comment"
+                            " }")
+                    (h/code "{:a 1"
+                            " |:b 2"
+                            " ;; trailing comment"
+                            " }"))
+    (assert-move-up (h/code "{;; a"
+                            " a 1"
+                            ""
+                            " ;; c"
                             " c 3"
-                            " b 2]")
-                    (h/code "[a [1 2]"
+                            ""
+                            " ;; b"
+                            " b 2}")
+                    (h/code "{;; a"
+                            " a 1"
+                            ""
+                            " ;; b"
                             " b 2"
-                            " c 3]") 'c)
-    (testing "with destructuring"
-      (assert-move-up (h/code "(let [[a b] [1 2]"
+                            ""
+                            " ;; c"
+                            " |c 3}"))
+    (assert-move-up (h/code "{;; b"
+                            " b 2"
+                            ""
+                            " ;; a"
+                            " a 1"
+                            ""
+                            " ;; c"
+                            " c 3}")
+                    (h/code "{;; a"
+                            " a 1"
+                            ""
+                            " ;; b"
+                            " |b 2"
+                            ""
+                            " ;; c"
+                            " c 3}"))
+    ;; avoids commenting out closing bracket
+    (assert-move-up (h/code "[b"
+                            " a ;; a comment"
+                            " ]")
+                    (h/code "[a ;; a comment"
+                            " |b]"))
+    (assert-move-up (h/code "{:b 2"
+                            " :a 1 ;; one comment"
+                            " }")
+                    (h/code "{:a 1 ;; one comment"
+                            " |:b 2}"))
+    ;; moves from leading comment / whitespace
+    (is (= (h/code "{;; b comment"
+                   " :b 2 ;; two comment"
+                   " :a 1 ;; one comment"
+                   " :c 3}")
+           (-> (h/code "{:a 1 ;; one comment"
+                       " ;; |b comment"
+                       " :b 2 ;; two comment"
+                       " :c 3}")
+               load-code-and-zloc
+               ;; load-code moves cursor in whitespace to outer form;
+               ;; move cursor to <comment '; b comment'>
+               (z/down)
+               (z/find-next-value z/right :b)
+               (z/find z/left* (comp n/comment? z/node))
+               move-zloc-up
+               as-string)))
+    ;; moves from trailing comment / whitespace
+    (is (= (h/code "{:b 2 ;; two comment"
+                   " :a 1 ;; one comment"
+                   " :c 3}")
+           (-> (h/code "{:a 1 ;; one comment"
+                       " :b 2 ;; |two comment"
+                       " :c 3}")
+               load-code-and-zloc
+               ;; load-code moves cursor in whitespace to outer form;
+               ;; move cursor to <comment '; two comment'>
+               (z/down)
+               (z/find-next-value z/right :b)
+               (z/find z/right* (comp n/comment? z/node))
+               move-zloc-up
+               as-string))))
+  (testing "relocation"
+    (assert-move-up-position [1 2]
+                             (h/code "{:a 1 ;; one comment"
+                                     " |:b 2}"))
+    ;; moves cursor to start of entry pair
+    (assert-move-up-position [1 2]
+                             (h/code "{:a :x ;; one comment"
+                                     " :b    |:y}"))))
+
+(deftest move-down
+  (testing "common cases"
+    (assert-move-down (h/code "{3 4 1 2}")
+                      (h/code "{|1 2 3 4}"))
+    (assert-move-down (h/code "{3 4, 1 2}")
+                      (h/code "{|1 2, 3 4}"))
+    (assert-move-down (h/code "{3 4"
+                              " 1 2}")
+                      (h/code "{|1 2"
+                              " 3 4}"))
+    (assert-move-down (h/code "{3 4"
+                              " 1 2}")
+                      (h/code "{1 |2"
+                              " 3 4}"))
+    (assert-move-down (h/code "{3 4,"
+                              " 1 2}")
+                      (h/code "{|1 2,"
+                              " 3 4}"))
+    (assert-move-down (h/code "{:b (+ 1 1)"
+                              " :a 1"
+                              " :c 3}")
+                      (h/code "{|:a 1"
+                              " :b (+ 1 1)"
+                              " :c 3}"))
+    (assert-move-down (h/code "[2 1]")
+                      (h/code "[|1 2]"))
+    (assert-move-down (h/code "[2 1 3]")
+                      (h/code "[|1 2 3]"))
+    (assert-move-down (h/code "(def a 1)"
+                              "[2 a]")
+                      (h/code "(def a 1)"
+                              "[|a 2]"))
+    (assert-move-down (h/code "(let [a [1 2]"
+                              "      c 3"
+                              "      b 2])")
+                      (h/code "(let [a [1 2]"
+                              "      |b 2"
+                              "      c 3])"))
+    (assert-move-down (h/code "(binding [b 2"
+                              "          a 1]"
+                              "  (+ a b))")
+                      (h/code "(binding [|a 1"
+                              "          b 2]"
+                              "  (+ a b))"))
+    (assert-move-down (h/code "(for [b [3 4]"
+                              "      a [1 2]"
+                              "      :let [c (inc a)]]"
+                              "  (+ a b c))")
+                      (h/code "(for [|a [1 2]"
+                              "      b [3 4]"
+                              "      :let [c (inc a)]]"
+                              "  (+ a b c))"))
+    (assert-move-down (h/code "(for [a [1 2]"
+                              "      :let [c (inc b)"
+                              "            b (inc a)]]"
+                              "  (+ a b c))")
+                      (h/code "(for [a [1 2]"
+                              "      :let [|b (inc a)"
+                              "            c (inc b)]]"
+                              "  (+ a b c))"))
+    (assert-move-down (h/code "(ns foo"
+                              "  {:clj-kondo/config '{:lint-as {foo/foo clojure.core/let}}})"
+                              "(defmacro foo [bs & form]"
+                              "  `(let [~@bs]"
+                              "     ~@form))"
+                              "(foo [b 2"
+                              "      a 1]"
+                              "  (inc a))")
+                      (h/code "(ns foo"
+                              "  {:clj-kondo/config '{:lint-as {foo/foo clojure.core/let}}})"
+                              "(defmacro foo [bs & form]"
+                              "  `(let [~@bs]"
+                              "     ~@form))"
+                              "(foo [|a 1"
+                              "      b 2]"
+                              "  (inc a))")))
+  (testing "with destructuring"
+    (assert-move-down (h/code "(let [[a b] [1 2]"
+                              "      {:keys [c d]} {:c 1 :d 2}"
+                              "      e 2])")
+                      (h/code "(let [[a b] [1 2]"
+                              "      |e 2"
+                              "      {:keys [c d]} {:c 1 :d 2}])"))
+    (assert-move-down (h/code "(let [[a b] [1 2]"
                               "      e 2"
                               "      {:keys [c d]} {:c 1 :d 2}])")
                       (h/code "(let [[a b] [1 2]"
-                              "      {:keys [c d]} {:c 1 :d 2}"
-                              "      e 2])") 'e)
-      (assert-move-up (h/code "(let [{:keys [c d]} {:c 1 :d 2}"
-                              "      [a b] [1 2]"
-                              "      e 2])")
-                      (h/code "(let [[a b] [1 2]"
-                              "      {:keys [c d]} {:c 1 :d 2}"
-                              "      e 2])") {:keys ['c 'd]}))
-    (testing "blank lines"
-      (is (= (h/code "{:b 2"
-                     ""
-                     " :a 1}")
-             (some-> (z/of-string (h/code "{:a 1"
-                                          ""
-                                          " :b 2}"))
-                     ;; move cursor to blank line between a and b
-                     (z/down)
-                     (z/find-next-value z/right 1)
-                     (z/right*)
-                     (f.move-coll-entry/move-up "file:///a.clj")
-                     as-string)))
-      (is (nil? (some-> (z/of-string (h/code "{:a 1"
-                                             ""
-                                             " :b 2"
-                                             ""
-                                             "}"))
-                        ;; move cursor to blank line after b
-                        (z/down)
-                        (z/find-next-value z/right 2)
-                        (z/right*)
-                        (f.move-coll-entry/move-up "file:///a.clj")))))
-    (testing "comments"
-      (assert-move-up (h/code "{:b (+ 1 1) ;; two comment"
+                              "      |{:keys [c d]} {:c 1 :d 2}"
+                              "      e 2])"))
+    (assert-move-down (h/code "(for [a [1 2]"
+                              "      :let [{:keys [c]} {:c 1}"
+                              "            {:keys [b]} {:b 1}]])")
+                      (h/code "(for [a [1 2]"
+                              "      :let [|{:keys [b]} {:b 1}"
+                              "            {:keys [c]} {:c 1}]])")))
+  (testing "blank lines"
+    (is (= (h/code "{"
+                   " :b 2"
+                   ""
+                   " :a 1}")
+           (-> (h/code "{|"
+                       " :a 1"
+                       ""
+                       " :b 2}")
+               load-code-and-zloc
+               ;; load-code moves cursor in whitespace to outer form;
+               ;; move cursor to blank line above a
+               (z/down*)
+               move-zloc-down
+               as-string)))
+    (is (nil? (-> (h/code "{:a 1"
+                          "|"
+                          " :b 2}")
+                  load-code-and-zloc
+                  ;; load-code moves cursor in whitespace to outer form;
+                  ;; move cursor to blank line between a and b
+                  z/down
+                  z/right
+                  z/right*
+                  z/right*
+                  move-zloc-down))))
+  (testing "comments"
+    (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
                               " :a 1 ;; one comment"
                               " :c 3} ;; three comment")
-                      (h/code "{:a 1 ;; one comment"
+                      (h/code "{|:a 1 ;; one comment"
                               " :b (+ 1 1) ;; two comment"
-                              " :c 3} ;; three comment") :b)
-      (assert-move-up (h/code ";; main comment"
+                              " :c 3} ;; three comment"))
+    (assert-move-down (h/code ";; main comment"
                               "{;; b comment"
                               " :b (+ 1 1) ;; two comment"
                               " :a 1 ;; one comment"
                               " ;; c comment"
                               " :c 3} ;; three comment")
                       (h/code ";; main comment"
-                              "{:a 1 ;; one comment"
+                              "{|:a 1 ;; one comment"
                               " ;; b comment"
                               " :b (+ 1 1) ;; two comment"
                               " ;; c comment"
-                              " :c 3} ;; three comment") :b)
-      (assert-move-up (h/code "{:b 2"
+                              " :c 3} ;; three comment"))
+    (assert-move-down (h/code "{:b 2"
                               " :a 1"
                               " ;; trailing comment"
                               " }")
-                      (h/code "{:a 1"
+                      (h/code "{|:a 1"
                               " :b 2"
                               " ;; trailing comment"
-                              " }") :b)
-      (assert-move-up (h/code "{;; a"
+                              " }"))
+    (assert-move-down (h/code "{;; a"
                               " a 1"
                               ""
                               " ;; c"
@@ -257,11 +532,11 @@
                               " a 1"
                               ""
                               " ;; b"
-                              " b 2"
+                              " |b 2"
                               ""
                               " ;; c"
-                              " c 3}") 'c)
-      (assert-move-up (h/code "{;; b"
+                              " c 3}"))
+    (assert-move-down (h/code "{;; b"
                               " b 2"
                               ""
                               " ;; a"
@@ -270,218 +545,60 @@
                               " ;; c"
                               " c 3}")
                       (h/code "{;; a"
-                              " a 1"
+                              " |a 1"
                               ""
                               " ;; b"
                               " b 2"
                               ""
                               " ;; c"
-                              " c 3}") 'b)
-      ;; avoids commenting out closing bracket
-      (assert-move-up (h/code "{:b 2"
+                              " c 3}"))
+    ;; avoids commenting out closing bracket
+    (assert-move-down (h/code "[b"
+                              " a ;; a comment"
+                              " ]")
+                      (h/code "[|a ;; a comment"
+                              " b]"))
+    (assert-move-down (h/code "{:b 2"
                               " :a 1 ;; one comment"
                               " }")
-                      (h/code "{:a 1 ;; one comment"
-                              " :b 2}") :b)
-      ;; moves from leading comment / whitespace
-      (is (= (h/code "{;; b comment"
-                     " :b 2 ;; two comment"
-                     " :a 1 ;; one comment"
-                     " :c 3}")
-             (some-> (z/of-string (h/code "{:a 1 ;; one comment"
-                                          " ;; b comment"
-                                          " :b 2 ;; two comment"
-                                          " :c 3}"))
-                     ;; move cursor to <comment '; b comment'>
-                     (z/down)
-                     (z/find-next-value z/right :b)
-                     (z/find z/left* (comp n/comment? z/node))
-                     (f.move-coll-entry/move-up "file:///a.clj")
-                     as-string)))
-      ;; moves from trailing comment / whitespace
-      (is (= (h/code "{:b 2 ;; two comment"
-                     " :a 1 ;; one comment"
-                     " :c 3}")
-             (some-> (z/of-string (h/code "{:a 1 ;; one comment"
-                                          " :b 2 ;; two comment"
-                                          " :c 3}"))
-                     ;; move cursor to <comment '; two comment'>
-                     (z/down)
-                     (z/find-next-value z/right :b)
-                     (z/find z/right* (comp n/comment? z/node))
-                     (f.move-coll-entry/move-up "file:///a.clj")
-                     as-string))))
-    (testing "relocation"
-      (assert-move-up-position [1 2]
-                               (h/code "{:a 1 ;; one comment"
-                                       " :b 2}") :b)
-      ;; moves cursor to start of entry pair
-      (assert-move-up-position [1 2]
-                               (h/code "{:a :x ;; one comment"
-                                       " :b    :y}") :y))))
-
-(deftest move-down
-  (testing "common cases"
-    (assert-move-down (h/code "{3 4 1 2}")
-                      (h/code "{1 2 3 4}") 1)
-    (assert-move-down (h/code "{3 4, 1 2}")
-                      (h/code "{1 2, 3 4}") 1)
-    (assert-move-down (h/code "{3 4"
-                              " 1 2}")
-                      (h/code "{1 2"
-                              " 3 4}") 1)
-    (assert-move-down (h/code "{3 4"
-                              " 1 2}")
-                      (h/code "{1 2"
-                              " 3 4}") 2)
-    (assert-move-down (h/code "{3 4,"
-                              " 1 2}")
-                      (h/code "{1 2,"
-                              " 3 4}") 1)
-    (assert-move-down (h/code "{:b (+ 1 1)"
-                              " :a 1"
-                              " :c 3}")
-                      (h/code "{:a 1"
-                              " :b (+ 1 1)"
-                              " :c 3}") :a)
-    (assert-move-down (h/code "[a [1 2]"
-                              " c 3"
-                              " b 2]")
-                      (h/code "[a [1 2]"
-                              " b 2"
-                              " c 3]") 'b)
-    (testing "with destructuring"
-      (assert-move-down (h/code "(let [[a b] [1 2]"
-                                "      {:keys [c d]} {:c 1 :d 2}"
-                                "      e 2])")
-                        (h/code "(let [[a b] [1 2]"
-                                "      e 2"
-                                "      {:keys [c d]} {:c 1 :d 2}])")
-                        'e)
-      (assert-move-down (h/code "(let [[a b] [1 2]"
-                                "      e 2"
-                                "      {:keys [c d]} {:c 1 :d 2}])")
-                        (h/code "(let [[a b] [1 2]"
-                                "      {:keys [c d]} {:c 1 :d 2}"
-                                "      e 2])") {:keys ['c 'd]}))
-    (testing "blank lines"
-      (is (= (h/code "{"
-                     " :b 2"
-                     ""
-                     " :a 1}")
-             (some-> (z/of-string (h/code "{"
-                                          " :a 1"
-                                          ""
-                                          " :b 2}"))
-                     ;; move cursor to blank line above a
-                     (z/down*)
-                     (f.move-coll-entry/move-down "file:///a.clj")
-                     as-string)))
-      (is (nil? (some-> (z/of-string (h/code "{:a 1"
-                                             ""
-                                             " :b 2}"))
-                        ;; move cursor to blank line between a and b
-                        (z/down)
-                        (z/find-next-value z/right 1)
-                        (z/right*)
-                        (f.move-coll-entry/move-down "file:///a.clj")
-                        as-string))))
-    (testing "comments"
-      (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
-                                " :a 1 ;; one comment"
-                                " :c 3} ;; three comment")
-                        (h/code "{:a 1 ;; one comment"
-                                " :b (+ 1 1) ;; two comment"
-                                " :c 3} ;; three comment") :a)
-      (assert-move-down (h/code ";; main comment"
-                                "{;; b comment"
-                                " :b (+ 1 1) ;; two comment"
-                                " :a 1 ;; one comment"
-                                " ;; c comment"
-                                " :c 3} ;; three comment")
-                        (h/code ";; main comment"
-                                "{:a 1 ;; one comment"
-                                " ;; b comment"
-                                " :b (+ 1 1) ;; two comment"
-                                " ;; c comment"
-                                " :c 3} ;; three comment") :a)
-      (assert-move-down (h/code "{:b 2"
-                                " :a 1"
-                                " ;; trailing comment"
-                                " }")
-                        (h/code "{:a 1"
-                                " :b 2"
-                                " ;; trailing comment"
-                                " }") :a)
-      (assert-move-down (h/code "{;; a"
-                                " a 1"
-                                ""
-                                " ;; c"
-                                " c 3"
-                                ""
-                                " ;; b"
-                                " b 2}")
-                        (h/code "{;; a"
-                                " a 1"
-                                ""
-                                " ;; b"
-                                " b 2"
-                                ""
-                                " ;; c"
-                                " c 3}") 'b)
-      (assert-move-down (h/code "{;; b"
-                                " b 2"
-                                ""
-                                " ;; a"
-                                " a 1"
-                                ""
-                                " ;; c"
-                                " c 3}")
-                        (h/code "{;; a"
-                                " a 1"
-                                ""
-                                " ;; b"
-                                " b 2"
-                                ""
-                                " ;; c"
-                                " c 3}") 'a)
-      ;; avoids commenting out closing bracket
-      (assert-move-down (h/code "{:b 2"
-                                " :a 1 ;; one comment"
-                                " }")
-                        (h/code "{:a 1 ;; one comment"
-                                " :b 2}") :a)
-      ;; moves from leading comment / whitespace
-      (is (= (h/code "{;; b comment"
-                     " :b 2 ;; two comment"
-                     " ;; a comment"
-                     " :a 1 ;; one comment"
-                     " :c 3}")
-             (some-> (z/of-string (h/code "{;; a comment"
-                                          " :a 1 ;; one comment"
-                                          " ;; b comment"
-                                          " :b 2 ;; two comment"
-                                          " :c 3}"))
-                     ;; move cursor to <comment '; a comment'>
-                     (z/down*)
-                     (f.move-coll-entry/move-down "file:///a.clj")
-                     as-string)))
-      (is (= (h/code "{:b 2 ;; two comment"
-                     " :a 1 ;; one comment"
-                     " :c 3}")
-             (some-> (z/of-string (h/code "{:a 1 ;; one comment"
-                                          " :b 2 ;; two comment"
-                                          " :c 3}"))
-                     ;; move cursor to <comment '; one comment'>
-                     (z/down)
-                     (z/find z/right* (comp n/comment? z/node))
-                     (f.move-coll-entry/move-down "file:///a.clj")
-                     as-string))))
-    (testing "relocation"
-      (assert-move-down-position [2 2]
-                                 (h/code "{:a 1 ;; one comment"
-                                         " :b 2}") :a)
-      ;; moves cursor to start of entry pair
-      (assert-move-down-position [2 2]
-                                 (h/code "{:a :x ;; one comment"
-                                         " :b    :y}") :x))))
+                      (h/code "{|:a 1 ;; one comment"
+                              " :b 2}"))
+    ;; moves from leading comment / whitespace
+    (is (= (h/code "{;; b comment"
+                   " :b 2 ;; two comment"
+                   " ;; a comment"
+                   " :a 1 ;; one comment"
+                   " :c 3}")
+           (-> (h/code "{;; |a comment"
+                       " :a 1 ;; one comment"
+                       " ;; b comment"
+                       " :b 2 ;; two comment"
+                       " :c 3}")
+               load-code-and-zloc
+               ;; load-code moves cursor in whitespace to outer form;
+               ;; move cursor to <comment '; a comment'>
+               (z/down*)
+               move-zloc-down
+               as-string)))
+    ;; moves from trailing comment / whitespace
+    (is (= (h/code "{:b 2 ;; two comment"
+                   " :a 1 ;; one comment"
+                   " :c 3}")
+           (-> (h/code "{:a 1 ;; |one comment"
+                       " :b 2 ;; two comment"
+                       " :c 3}")
+               load-code-and-zloc
+               ;; load-code moves cursor in whitespace to outer form;
+               ;; move cursor to <comment '; one comment'>
+               (z/down)
+               (z/find z/right* (comp n/comment? z/node))
+               move-zloc-down
+               as-string))))
+  (testing "relocation"
+    (assert-move-down-position [2 2]
+                               (h/code "{|:a 1 ;; one comment"
+                                       " :b 2}"))
+    ;; moves cursor to start of entry pair
+    (assert-move-down-position [2 2]
+                               (h/code "{:a    |:x ;; one comment"
+                                       " :b :y}"))))


### PR DESCRIPTION
Originally `move-coll-entry` moved elements in vectors and maps in a pairwise fashion. This extends `move-coll-entry` so that it will move element-wise instead.  That is, it will move a pair of elements in some situations but a single element in others. It tries to be smart about which situation it is being called in. It will move pairwise in maps and vectors that establish bindings, and element-wise in sets, lists and regular vectors.

As before, it does its best to preserve comment affiliation. Comments will be kept near the element as it moves, including comments that appear on the lines before an element or a comment at the end of the same line as the element.

/cc @snoe, who originally suggested this addition to move-coll-entry in #684.