### PR TITLE
Add support for classpath file lookup.

### DIFF
--- a/cli/resources/META-INF/native-image/clojure-lsp/clojure-lsp/reflect-config.json
+++ b/cli/resources/META-INF/native-image/clojure-lsp/clojure-lsp/reflect-config.json
@@ -33,6 +33,13 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"clojure_lsp.feature.classpath.ClasspathLookupParams",
+  "allDeclaredMethods":true,
+  "allPublicMethods": true,
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"clojure_lsp.feature.clojuredocs.ClojuredocsParams",
   "allDeclaredMethods":true,
   "allPublicMethods": true,

--- a/cli/src-java/clojure_lsp/ClojureLanguageServer.java
+++ b/cli/src-java/clojure_lsp/ClojureLanguageServer.java
@@ -11,6 +11,7 @@ import clojure.java.api.Clojure;
 import clojure.lang.IFn;
 
 import clojure_lsp.feature.cursor_info.CursorInfoParams;
+import clojure_lsp.feature.classpath.ClasspathLookupParams;
 import clojure_lsp.feature.clojuredocs.ClojuredocsParams;
 
 /**
@@ -44,5 +45,8 @@ public interface ClojureLanguageServer extends LanguageServer {
 
     @JsonRequest("clojure/clojuredocs/raw")
     CompletableFuture<Object> clojuredocsRaw(ClojuredocsParams clojuredocsParams);
+
+    @JsonRequest("clojure/classpath/lookup")
+    CompletableFuture<Object> lookupClasspath(ClasspathLookupParams params);
 
 }

--- a/cli/src-java/clojure_lsp/feature/classpath/ClasspathLookupParams.java
+++ b/cli/src-java/clojure_lsp/feature/classpath/ClasspathLookupParams.java
@@ -1,0 +1,20 @@
+package clojure_lsp.feature.classpath;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+
+public class ClasspathLookupParams {
+
+    @NonNull
+    private String filepath;
+
+    public String getFilepath() {
+        return filepath;
+    }
+
+    @Override
+    public String toString() {
+        return MessageJsonHandler.toString(this);
+    }
+
+}

--- a/cli/src/clojure_lsp/coercer.clj
+++ b/cli/src/clojure_lsp/coercer.clj
@@ -690,6 +690,7 @@
                                     (s/keys :opt-un [:capabilities/workspace :capabilities/text-document])))
 
 (s/def ::server-info-raw ::bean)
+(s/def ::classpath-lookup ::bean)
 (s/def ::cursor-info-raw ::bean)
 (s/def ::clojuredocs-raw ::bean)
 

--- a/lib/src/clojure_lsp/classpath_lookup.clj
+++ b/lib/src/clojure_lsp/classpath_lookup.clj
@@ -1,0 +1,121 @@
+(ns clojure-lsp.classpath-lookup
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :refer [ends-with?]]
+   [taoensso.timbre :as log])
+  (:import
+   [java.io ByteArrayOutputStream File InputStream]
+   [java.util.jar JarFile JarEntry]))
+
+(defn- file? [path]
+  (.isFile (io/as-file path)))
+
+(defn- path-to-jar-file? [path]
+  (and (file? path)
+       (ends-with? path ".jar")))
+
+(defn- jar-entry-is-file? [^JarEntry entry]
+  (not (.isDirectory entry)))
+
+(defn- slurp-bytes [^InputStream in]
+  (with-open [^ByteArrayOutputStream out (ByteArrayOutputStream.)]
+    (io/copy in out)
+    (.toByteArray out)))
+
+(defn- jar-entries [^String filepath]
+  (with-open [^JarFile jar (JarFile. filepath)]
+    (->> (enumeration-seq (.entries jar))
+         (filter (fn [^JarEntry entry] (not (.isDirectory entry))))
+         (mapv (fn [^JarEntry config-entry]
+                 (.getName config-entry))))))
+
+(defn- extract-files-from-jar
+  "Extracts files from a jar.
+   
+   Returns tuples in the form [filepath byte-array] where filepath is the path
+   of a file contained in a jar."
+  [jar-file-path]
+  (with-open [^JarFile jar (JarFile. ^String jar-file-path)]
+    (->> (enumeration-seq (.entries jar))
+         (filter jar-entry-is-file?)
+         (mapv (fn [^JarEntry entry]
+                 [(.getName entry)
+                  (with-open [in (.getInputStream jar entry)]
+                    (slurp-bytes in))])))))
+
+(defn- new-jar-index
+  "Builds an unexpanded jar index.
+   
+   A jar index is basically an index of files found in jars in a classpath.
+   It's a map where keys are file paths (found in jars) to their respective
+   contents (in bytes).
+
+   A new jar index, though, starts with file paths mapped to the path of the
+   containing jar file. We do that to speed up the first lookup by avoiding to
+   eagerly extract all jar files in the classpath at once. When a file is first
+   looked up in the index, and if its contents is a byte array, we return its
+   contents. But if it's a string, we 'expand' the file by reading it from the
+   jar and updating the index with the file bytes."
+  [classpath]
+  (->> classpath
+       (filter path-to-jar-file?)
+       (mapcat (fn [jar-path]
+                 (map #(vector % jar-path) (jar-entries jar-path))))
+       (into {})))
+
+(defn- expand-file-in-jar-index?
+  "When `filepath` at `jar-index` is a string it means the file has not yet
+   been expanded in the jar index. In such case the string is a path to the jar
+   file that contains the file. That path can be used to read the file bytes
+   from the jar and replace the jar file path in the index with the file bytes.
+   
+   Also returns false when `filepath` is not found in the jar index."
+  [jar-index filepath]
+  (string? (jar-index filepath)))
+
+(defn- expand-file-in-jar-index
+  "Expands a file in the jar index, if it's not been expanded yet."
+  [jar-index filepath]
+  (if-not (expand-file-in-jar-index? jar-index filepath)
+    jar-index
+    (->> (jar-index filepath)
+         (extract-files-from-jar)
+         (into jar-index))))
+
+(defn- dir-seq
+  "Like file-seq but for directories."
+  [dir]
+  (tree-seq
+   (fn [^File f] (. f (isDirectory)))
+   (fn [^File d] (filter (fn [^File f] (. f (isDirectory)))
+                         (. d (listFiles))))
+   (io/as-file dir)))
+
+(defn- lookup-source-file [filepath source-paths]
+  (some->> source-paths
+           (mapcat dir-seq)
+           (map #(io/file % filepath))
+           (filter file?)
+           (first)
+           (io/input-stream)
+           (slurp-bytes)))
+
+(defn- lookup-file [filepath source-paths jar-index]
+  (or (get jar-index filepath)
+      (lookup-source-file filepath source-paths)))
+
+(defn- expand-file-in-jar-index! [filepath db]
+  (->> (expand-file-in-jar-index (:jar-index @db) filepath)
+       (swap! db assoc :jar-index)
+       :jar-index))
+
+(defn- create-jar-index! [db]
+  (log/info "creating jar index")
+  (swap! db assoc :jar-index (new-jar-index (:classpath @db))))
+
+(defn lookup! [filepath db]
+  (when-not (:jar-index @db)
+    (create-jar-index! db))
+  (let [jar-index (expand-file-in-jar-index! filepath db)
+        source-paths (-> @db :settings :source-paths)]
+    (lookup-file filepath source-paths jar-index)))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -1,5 +1,6 @@
 (ns clojure-lsp.handlers
   (:require
+   [clojure-lsp.classpath-lookup :as classpath-lookup]
    [clojure-lsp.config :as config]
    [clojure-lsp.crawler :as crawler]
    [clojure-lsp.db :as db]
@@ -207,6 +208,10 @@
 
 (defn clojuredocs-raw [{:keys [symName symNs]}]
   (f.clojuredocs/find-docs-for symName symNs db/db))
+
+(defn lookup-classpath [filepath]
+  {:pre [(string? filepath)]}
+  (classpath-lookup/lookup! filepath db/db))
 
 (defn ^:private refactor [refactoring [doc-id line character & args] db]
   (let [row                        (inc (int line))


### PR DESCRIPTION
This is my first shot at implementing [nREPL sideloader support in Calva](https://github.com/BetterThanTomorrow/calva/issues/1451), although this might be used by any other editors and IDEs that want to follow this approach to sideloading. The idea here is that Calva (or any other editor) relies on clojure-lsp for loading files (classes or resources) from the classpath in order to send them across to the nREPL session. Please let me know if you think there's a better approach.

This PR adds a jsonrpc endpoint for looking up a file in the classpath. It accepts a file path as argument, tries to find the file in the classpath, and then returns its binary contents in base64 format, or nil if not found. First it looks into jar files, and then into the source paths if none of the jars contain the requested file. Perhaps this lookup order should be reversed because source paths appear before jar files in the classpath?

On the first time the endpoint is called, it builds an index containing all files found in jars from the classpath. Initially the indexed files point to their containing jar files, and then they get "expanded" with their actual binary contents as they are requested. This is a naive attempt to speed up lookups, so there might be better ways to accomplish that. Please see more details about the index at `classpath_lookup.clj`.
