### PR TITLE
Move coll entry tests

### DIFF
--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -254,13 +254,6 @@
                             " :b 2"
                             "|"
                             " :c 2}"))
-    (let [ws-zloc (load-code-and-zloc (h/code "{:a 1 |;; one comment"
-                                              ""
-                                              " :b 2}"))]
-      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
-      ;; erroneous swaps happen
-      (is (can-move-zloc-up? ws-zloc))
-      (is (nil? (move-zloc-up ws-zloc))))
     (let [ws-zloc (load-code-and-zloc (h/code "{:a 1"
                                               ""
                                               " :b 2"
@@ -355,7 +348,13 @@
                             " :c 3}")
                     (h/code "{:a 1 ;; one comment"
                             " :b 2 ;; |two comment"
-                            " :c 3}")))
+                            " :c 3}"))
+    (let [ws-zloc (load-code-and-zloc (h/code "{:a 1 |;; one comment"
+                                              " :b 2}"))]
+      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
+      ;; erroneous swaps happen
+      (is (can-move-zloc-up? ws-zloc))
+      (is (nil? (move-zloc-up ws-zloc)))))
   (testing "relocation"
     (assert-move-up-position [1 2]
                              (h/code "{:a 1 ;; one comment"

--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -22,13 +22,17 @@
   (let [[[row col]] (h/load-code-and-locs code uri)]
     (zloc-at row col)))
 
+(defn can-move-zloc-up? [zloc]
+  (f.move-coll-entry/can-move-entry-up? zloc uri @db/db))
+
+(defn can-move-zloc-down? [zloc]
+  (f.move-coll-entry/can-move-entry-down? zloc uri @db/db))
+
 (defn can-move-code-up? [code]
-  (let [zloc (load-code-and-zloc code)]
-    (f.move-coll-entry/can-move-entry-up? zloc uri @db/db)))
+  (can-move-zloc-up? (load-code-and-zloc code)))
 
 (defn can-move-code-down? [code]
-  (let [zloc (load-code-and-zloc code)]
-    (f.move-coll-entry/can-move-entry-down? zloc uri @db/db)))
+  (can-move-zloc-down? (load-code-and-zloc code)))
 
 (deftest can-move-entry-up?
   (testing "common cases"
@@ -249,18 +253,34 @@
                (z/right*)
                move-zloc-up
                as-string)))
-    (is (nil? (-> (h/code "{:a 1"
-                          ""
-                          " :b 2"
-                          "|"
-                          "}")
-                  load-code-and-zloc
-                  ;; load-code moves cursor in whitespace to outer form;
-                  ;; move cursor to blank line after b
-                  (z/down)
-                  (z/find-next-value z/right 2)
-                  z/right*
-                  move-zloc-up))))
+    (let [ws-zloc (-> (h/code "{:a 1 |;; one comment"
+                              ""
+                              " :b 2}")
+                      load-code-and-zloc
+                      ;; load-code moves cursor in whitespace to outer form;
+                      ;; move cursor to comment after 1
+                      (z/down)
+                      (z/find-next-value z/right 1)
+                      z/right*)]
+      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
+      ;; erroneous swaps happen
+      (is (can-move-zloc-up? ws-zloc))
+      (is (nil? (move-zloc-up ws-zloc))))
+    (let [ws-zloc (-> (h/code "{:a 1"
+                              ""
+                              " :b 2"
+                              "|"
+                              "}")
+                      load-code-and-zloc
+                      ;; load-code moves cursor in whitespace to outer form;
+                      ;; move cursor to blank line after b
+                      (z/down)
+                      (z/find-next-value z/right 2)
+                      z/right*)]
+      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
+      ;; erroneous swaps happen
+      (is (can-move-zloc-up? ws-zloc))
+      (is (nil? (move-zloc-up ws-zloc)))))
   (testing "comments"
     (assert-move-up (h/code "{:b (+ 1 1) ;; two comment"
                             " :a 1 ;; one comment"
@@ -482,17 +502,20 @@
                (z/down*)
                move-zloc-down
                as-string)))
-    (is (nil? (-> (h/code "{:a 1"
-                          "|"
-                          " :b 2}")
-                  load-code-and-zloc
-                  ;; load-code moves cursor in whitespace to outer form;
-                  ;; move cursor to blank line between a and b
-                  z/down
-                  z/right
-                  z/right*
-                  z/right*
-                  move-zloc-down))))
+    (let [ws-zloc (-> (h/code "{:a 1"
+                              "|"
+                              " :b 2}")
+                      load-code-and-zloc
+                      ;; load-code moves cursor in whitespace to outer form;
+                      ;; move cursor to blank line between a and b
+                      z/down
+                      z/right
+                      z/right*
+                      z/right*)]
+      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
+      ;; erroneous swaps happen
+      (is (can-move-zloc-down? ws-zloc))
+      (is (nil? (move-zloc-down ws-zloc)))))
   (testing "comments"
     (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
                               " :a 1 ;; one comment"

--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -364,12 +364,15 @@
       (is (nil? (move-zloc-up ws-zloc)))))
   (testing "relocation"
     (assert-move-up-position [1 2]
-                             (h/code "{:a 1 ;; one comment"
+                             (h/code "{:a 1"
                                      " |:b 2}"))
+    (assert-move-up-position [1 2]
+                             (h/code "[:a"
+                                     " |:b]"))
     ;; moves cursor to start of entry pair
     (assert-move-up-position [1 2]
-                             (h/code "{:a :x ;; one comment"
-                                     " :b    |:y}"))))
+                             (h/code "{:a 1"
+                                     " :b |2}"))))
 
 (deftest move-down
   (testing "common cases"
@@ -595,9 +598,12 @@
       (is (nil? (move-zloc-down ws-zloc)))))
   (testing "relocation"
     (assert-move-down-position [2 2]
-                               (h/code "{|:a 1 ;; one comment"
+                               (h/code "{|:a 1"
                                        " :b 2}"))
+    (assert-move-down-position [2 2]
+                               (h/code "[|:a"
+                                       " :b]"))
     ;; moves cursor to start of entry pair
     (assert-move-down-position [2 2]
-                               (h/code "{:a    |:x ;; one comment"
-                                       " :b :y}"))))
+                               (h/code "{:a |1"
+                                       " :b 2}"))))

--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -254,13 +254,16 @@
                             " :b 2"
                             "|"
                             " :c 2}"))
+    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
+    ;; don't at least no erroneous swaps happen
+    (let [ws-zloc (load-code-and-zloc (h/code "[:a"
+                                              "|"
+                                              "]"))]
+      (is (can-move-zloc-up? ws-zloc))
+      (is (nil? (move-zloc-up ws-zloc))))
     (let [ws-zloc (load-code-and-zloc (h/code "{:a 1"
-                                              ""
-                                              " :b 2"
                                               "|"
                                               "}"))]
-      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
-      ;; erroneous swaps happen
       (is (can-move-zloc-up? ws-zloc))
       (is (nil? (move-zloc-up ws-zloc)))))
   (testing "comments"
@@ -349,10 +352,14 @@
                     (h/code "{:a 1 ;; one comment"
                             " :b 2 ;; |two comment"
                             " :c 3}"))
+    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
+    ;; don't at least no erroneous swaps happen
+    (let [ws-zloc (load-code-and-zloc (h/code "[:a |;; a comment"
+                                              "]"))]
+      (is (can-move-zloc-up? ws-zloc))
+      (is (nil? (move-zloc-up ws-zloc))))
     (let [ws-zloc (load-code-and-zloc (h/code "{:a 1 |;; one comment"
-                                              " :b 2}"))]
-      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
-      ;; erroneous swaps happen
+                                              "}"))]
       (is (can-move-zloc-up? ws-zloc))
       (is (nil? (move-zloc-up ws-zloc)))))
   (testing "relocation"
@@ -478,11 +485,14 @@
                               " :b 2"
                               ""
                               " :c 2}"))
-    (let [ws-zloc (load-code-and-zloc (h/code "{:a 1"
-                                              "|"
-                                              " :b 2}"))]
-      ;; NOTE: ideally can-move-*? and move-* would agree, but at least no
-      ;; erroneous swaps happen
+    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
+    ;; don't at least no erroneous swaps happen
+    (let [ws-zloc (load-code-and-zloc (h/code "[|"
+                                              " :a]"))]
+      (is (can-move-zloc-down? ws-zloc))
+      (is (nil? (move-zloc-down ws-zloc))))
+    (let [ws-zloc (load-code-and-zloc (h/code "{|"
+                                              " :a 1}"))]
       (is (can-move-zloc-down? ws-zloc))
       (is (nil? (move-zloc-down ws-zloc)))))
   (testing "comments"
@@ -572,7 +582,17 @@
                               " :c 3}")
                       (h/code "{:a 1 ;; |one comment"
                               " :b 2 ;; two comment"
-                              " :c 3}")))
+                              " :c 3}"))
+    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
+    ;; don't at least no erroneous swaps happen
+    (let [ws-zloc (load-code-and-zloc (h/code "[|;; a comment"
+                                              " :a]"))]
+      (is (can-move-zloc-down? ws-zloc))
+      (is (nil? (move-zloc-down ws-zloc))))
+    (let [ws-zloc (load-code-and-zloc (h/code "{|;; a comment"
+                                              " :a 1}"))]
+      (is (can-move-zloc-down? ws-zloc))
+      (is (nil? (move-zloc-down ws-zloc)))))
   (testing "relocation"
     (assert-move-down-position [2 2]
                                (h/code "{|:a 1 ;; one comment"


### PR DESCRIPTION
This adds a few tests for element-wise movement and a few to document discrepancies between `can-move-*?` and `move-*`.

It also shortens the syntax for writing tests about movement from comments and whitespace.