### PR TITLE
Fix clj-kondo dep for native

### DIFF
--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -7,6 +7,7 @@
                                                                                  com.google.code.gson/gson]}
         com.google.code.gson/gson {:mvn/version "2.8.9"}
         borkdude/dynaload {:mvn/version "0.2.2"}
+        clj-kondo/clj-kondo {:mvn/version "2022.01.15"}
         nrepl/bencode {:mvn/version "1.1.0"}
 
         clojure-lsp/lib {:local/root "../lib"}}


### PR DESCRIPTION
Fixes #708

The current project structure of clojure-lsp is:
```clojure
deps.edn ;; a root one with only dev/test deps
lib/deps.edn ;; Dependencies for the API JVM usage only (the jar that goes to clojars)
cli/deps.edn ;; Dependencies for the CLI / graalvm (contains all LSP4j and native dependencies)
```

The cli one imports the lib via:
```clojure
clojure-lsp/lib {:local/root "../lib"}
```
So every base dependency is already on lib/deps.edn, like the `clj-kondo` dependency.

For some reason, not including clj-kondo on the **cli** deps.edn makes clj-kondo call freeze for some specific cases, As far as I can tell, it's related with missing classes during jar compilation that will be analyzed for the native image.
From my tests, not including clj-kondo make some missing classes compilation like `sci`.