### PR TITLE
Turn off async custom linters in integration tests

### DIFF
--- a/cli/integration-test/integration/diagnostics_test.clj
+++ b/cli/integration-test/integration/diagnostics_test.clj
@@ -62,7 +62,8 @@
 (deftest report-duplicates-disabled
   (lsp/start-process!)
   (lsp/request! (fixture/initialize-request {:lint-project-files-after-startup? false
-                                             :linters {:clj-kondo {:report-duplicates false}}}))
+                                             :linters {:clj-kondo {:report-duplicates false
+                                                                   :async-custom-lint? false}}}))
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-notification "diagnostics/kondo.clj"))
 

--- a/cli/integration-test/integration/settings_change_test.clj
+++ b/cli/integration-test/integration/settings_change_test.clj
@@ -1,5 +1,6 @@
 (ns integration.settings-change-test
   (:require
+   [clojure.string :as string]
    [clojure.test :refer [deftest testing]]
    [integration.fixture :as fixture]
    [integration.helper :as h]
@@ -11,7 +12,10 @@
 (def current-lsp-config-content (slurp current-lsp-config-file))
 
 (def new-lsp-config-content
-  "{:linters {:clj-kondo {:level :off}}}\n")
+  (string/join "/n"
+               ["{:linters {:clj-kondo {:level :off"
+                "                       :async-custom-lint? false}}}"
+                ""]))
 
 (deftest unused-public-var
   (lsp/start-process!)

--- a/cli/integration-test/sample-test/.lsp/config.edn
+++ b/cli/integration-test/sample-test/.lsp/config.edn
@@ -1,2 +1,3 @@
-{:linters {:clj-kondo {:ns-exclude-regex ""}}
+{:linters {:clj-kondo {:ns-exclude-regex ""
+                       :async-custom-lint? false}}
  :api {:exit-on-errors? false}}


### PR DESCRIPTION
In an attempt to fix flaky tests #704.