### PR TITLE
Remove "resolve code action"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /.lsp/.cache
 /.clj-kondo/.cache
 /out
-/target
+target/
 /classes
 /.DS_Store
 /.cpcache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - Fix removal of file analysis on didClose for external files like jars. #717
   - Fix cursor not moving when using code actions that move the cursor automatically.
   - Fix additional-snippets to work on top-level forms as well.
+  - Remove support for LSP `codeAction/resolve`. It added complexity and was not
+    used in a way that improved performance of the action menu. #722, #725, #726
 
 ## 2022.01.22-01.31.09
 

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -4,6 +4,7 @@
 
 (def namespaces
   '[integration.initialize-test
+    integration.code-action-test
     integration.definition-test
     integration.declaration-test
     integration.diagnostics-test

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -13,7 +13,8 @@
   (lsp/start-process!)
   (lsp/request! (fixture/initialize-request
                   {:initializationOptions fixture/default-init-options
-                   :capabilities          fixture/full-client-capabilities}))
+                   :capabilities          {:window    {:showDocument {:support true}}
+                                           :workspace {:workspaceEdit {:documentChanges true}}}}))
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-notification sample-file-name))
 

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -56,8 +56,7 @@
                                     "   ;; b comment"
                                     "   :b 2 ;; 2 comment"
                                     "   :d 4}")}]}]
-        (:documentChanges (:edit (lsp/await-request :workspace/applyEdit)))))
-
+        (:documentChanges (:edit (lsp/await-client-request :workspace/applyEdit)))))
     (testing "the cursor is repositioned"
       (h/assert-submap
        ;; FIXME: 5/3 is the correct positioning. But the associated fix is on
@@ -75,4 +74,4 @@
                              :character 3}
                      :end   {:line      6
                              :character 5}}}
-        (lsp/await-request :window/showDocument)))))
+        (lsp/await-client-request :window/showDocument)))))

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -1,0 +1,78 @@
+(ns integration.code-action-test
+  (:require
+   [clojure.test :refer [deftest testing]]
+   [integration.fixture :as fixture]
+   [integration.helper :as h]
+   [integration.lsp :as lsp]))
+
+(def sample-file-name "code_action/a.clj")
+
+(lsp/clean-after-test)
+
+(deftest view-and-execute-code-action
+  (lsp/start-process!)
+  (lsp/request! (fixture/initialize-emacs-request))
+  (lsp/notify! (fixture/initialized-notification))
+  (lsp/notify! (fixture/did-open-notification sample-file-name))
+
+  (testing "When a code action is available"
+    (h/assert-submaps
+      [{:title "Inline symbol"
+        :kind "refactor.inline"}
+       {:title "Cycle privacy"
+        :kind "refactor.rewrite"}
+       {:title "Extract function"
+        :kind "refactor.extract"}
+       {:title "Sort map"
+        :kind "refactor.rewrite"}
+       {:title "Move coll entry up"
+        :kind "refactor.rewrite"
+        :command {:title "Move coll entry up"
+                  :command "move-coll-entry-up"
+                  :arguments [(h/source-path->uri sample-file-name)
+                              5
+                              4]}}
+       {:title "Move coll entry down"
+        :kind "refactor.rewrite"
+        :command {:title "Move coll entry down"
+                  :command "move-coll-entry-down"
+                  :arguments [(h/source-path->uri sample-file-name)
+                              5
+                              4]}}
+       {:title "Clean namespace"
+        :kind "source.organizeImports"}]
+      (lsp/request! (fixture/code-action-request sample-file-name 5 4)))
+
+    (lsp/request! (fixture/execute-command-request "move-coll-entry-down"
+                                                   (h/source-path->uri sample-file-name)
+                                                   5 4))
+
+    (testing "the code action edit is applied asynchronously"
+      (h/assert-submaps
+        [{:edits [{:range   {:start {:line 3, :character 2},
+                             :end   {:line 7, :character 8}},
+                   :newText (h/code "{:a 1"
+                                    "   :c 3"
+                                    "   ;; b comment"
+                                    "   :b 2 ;; 2 comment"
+                                    "   :d 4}")}]}]
+        (:documentChanges (:edit (lsp/await-request :workspace/applyEdit)))))
+
+    (testing "the cursor is repositioned"
+      (h/assert-submap
+       ;; FIXME: 5/3 is the correct positioning. But the associated fix is on
+       ;; another branch. I'm committing the actual-but-incorrect 6/3-6/5 in the
+       ;; interim so that A) this integration test exists, and B) it proves that
+       ;; we're calling window/showDocument, which we weren't before.
+        #_{:takeFocus true
+        ;; 5/3 is the start of <comment ";; b comment">, after the move
+           :selection {:start {:line      5
+                               :character 3}
+                       :end   {:line      5
+                               :character 3}}}
+        {:takeFocus true
+         :selection {:start {:line      6
+                             :character 3}
+                     :end   {:line      6
+                             :character 5}}}
+        (lsp/await-request :window/showDocument)))))

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -11,7 +11,9 @@
 
 (deftest view-and-execute-code-action
   (lsp/start-process!)
-  (lsp/request! (fixture/initialize-emacs-request))
+  (lsp/request! (fixture/initialize-request
+                  {:initializationOptions fixture/default-init-options
+                   :capabilities          fixture/full-client-capabilities}))
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-notification sample-file-name))
 

--- a/cli/integration-test/integration/diagnostics_test.clj
+++ b/cli/integration-test/integration/diagnostics_test.clj
@@ -61,9 +61,9 @@
 
 (deftest report-duplicates-disabled
   (lsp/start-process!)
-  (lsp/request! (fixture/initialize-request {:lint-project-files-after-startup? false
-                                             :linters {:clj-kondo {:report-duplicates false
-                                                                   :async-custom-lint? false}}}))
+  (lsp/request! (fixture/initialize-request (assoc fixture/default-init-options
+                                                   :linters {:clj-kondo {:report-duplicates  false
+                                                                         :async-custom-lint? false}})))
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-notification "diagnostics/kondo.clj"))
 

--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -12,22 +12,44 @@
      :params params
      :id (lsp/inc-request-id)}))
 
+(def default-init-options {:lint-project-files-after-startup? false})
+
 (defn initialize-request
   ([]
-   (initialize-request {:lint-project-files-after-startup? false}))
+   (initialize-request default-init-options))
   ([settings]
+   (initialize-request settings nil))
+  ([settings capabilities]
    (lsp-json-rpc :initialize
-                 {:rootUri (h/file->uri (io/file h/root-project-path))
-                  :initializationOptions settings})))
+                 (cond-> {:rootUri (h/file->uri (io/file h/root-project-path))
+                          :initializationOptions settings}
+                   capabilities (assoc :capabilities capabilities)))))
+
+(defn initialize-emacs-request []
+  (initialize-request
+   default-init-options
+   ;; Emacs' advertised client capabilities
+   ;; LSP :: lsp-mode 20220115.1742, Emacs 27.2, darwin
+   ;; Derived from a printout of client capabilities that was halfway through
+   ;; the json -> java -> coerce process. It was messy. I hope this is accurate.
+   ;; Emacs advertises many other capabilities, but this includes only the ones
+   ;; that clojure-lsp cares about as of 2022-01-28.
+   {:experimental {:testTree true}
+    :textDocument {:hover      {:contentFormat ["markdown" "plaintext"]}
+                   :completion {:completionItem {:snippetSupport true}}}
+    :window       {:showDocument {:support true}}
+    :workspace    {:workspaceEdit {:documentChanges true}
+                   ;; does not advertise code lens refresh support, though clojure-lsp would use it
+                   #_#_:codeLens  {:refreshSupport true}}}))
 
 (defn definition-request [path row col]
   (lsp-json-rpc :textDocument/definition
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                {:textDocument {:uri (h/source-path->uri path)}
                  :position {:line row :character col}}))
 
 (defn declaration-request [path row col]
   (lsp-json-rpc :textDocument/declaration
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                {:textDocument {:uri (h/source-path->uri path)}
                  :position {:line row :character col}}))
 
 (defn formatting-full-request [path]
@@ -38,7 +60,7 @@
 
 (defn rename-request [path new-name row col]
   (lsp-json-rpc :textDocument/rename
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                {:textDocument {:uri (h/source-path->uri path)}
                  :position {:line row :character col}
                  :newName new-name}))
 
@@ -52,21 +74,32 @@
 
 (defn document-symbol-request [path]
   (lsp-json-rpc :textDocument/documentSymbol
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}}))
+                {:textDocument {:uri (h/source-path->uri path)}}))
 
 (defn document-highlight-request [path row col]
   (lsp-json-rpc :textDocument/documentHighlight
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                {:textDocument {:uri (h/source-path->uri path)}
                  :position {:line row :character col}}))
 
 (defn linked-editing-range-request [path row col]
   (lsp-json-rpc :textDocument/linkedEditingRange
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                {:textDocument {:uri (h/source-path->uri path)}
                  :position {:line row :character col}}))
+
+(defn code-action-request [path row col]
+  (lsp-json-rpc :textDocument/codeAction
+                {:textDocument {:uri (h/source-path->uri path)}
+                 :context      {:diagnostics []}
+                 :range        {:start {:line row :character col}}}))
+
+(defn execute-command-request [command & args]
+  (lsp-json-rpc :workspace/executeCommand
+                {:command   command
+                 :arguments args}))
 
 (defn cursor-info-raw-request [path row col]
   (lsp-json-rpc "clojure/cursorInfo/raw"
-                {:textDocument {:uri (h/file->uri (h/source-path->file path))}
+                {:textDocument {:uri (h/source-path->uri path)}
                  :position {:line row :character col}}))
 
 (defn initialized-notification []

--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -13,20 +13,21 @@
      :id (lsp/inc-request-id)}))
 
 (def default-init-options {:lint-project-files-after-startup? false})
-(def emacs-capabilities
-  ;; Emacs' advertised client capabilities
-  ;; LSP :: lsp-mode 20220115.1742, Emacs 27.2, darwin
-  ;; Derived from a printout of client capabilities that was halfway through
-  ;; the json -> java -> coerce process. It was messy. I hope this is accurate.
-  ;; Emacs advertises many other capabilities, but this includes only the ones
-  ;; that clojure-lsp cares about as of 2022-01-28.
+(def full-client-capabilities
+  "Turn on all the client capabilities that clojure-lsp cares about.
+
+  ```
+  (intiailize-request {:initializationOptions default-init-opts
+                       :capabilities full-client-capabilities})
+  ```
+
+  Last updated 2022-01-28."
   {:experimental {:testTree true}
    :textDocument {:hover      {:contentFormat ["markdown" "plaintext"]}
                   :completion {:completionItem {:snippetSupport true}}}
    :window       {:showDocument {:support true}}
    :workspace    {:workspaceEdit {:documentChanges true}
-                  ;; does not advertise code lens refresh support, though clojure-lsp would use it
-                  #_#_:codeLens  {:refreshSupport true}}})
+                  :codeLens {:refreshSupport true}}})
 
 (defn initialize-request
   ([]
@@ -35,10 +36,6 @@
    (lsp-json-rpc :initialize
                  (merge {:rootUri (h/file->uri (io/file h/root-project-path))}
                         params))))
-
-(defn initialize-emacs-request []
-  (initialize-request {:initializationOptions default-init-options
-                       :capabilities          emacs-capabilities}))
 
 (defn completion-request [path row col]
   (lsp-json-rpc :textDocument/completion

--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -13,21 +13,6 @@
      :id (lsp/inc-request-id)}))
 
 (def default-init-options {:lint-project-files-after-startup? false})
-(def full-client-capabilities
-  "Turn on all the client capabilities that clojure-lsp cares about.
-
-  ```
-  (intiailize-request {:initializationOptions default-init-opts
-                       :capabilities full-client-capabilities})
-  ```
-
-  Last updated 2022-01-28."
-  {:experimental {:testTree true}
-   :textDocument {:hover      {:contentFormat ["markdown" "plaintext"]}
-                  :completion {:completionItem {:snippetSupport true}}}
-   :window       {:showDocument {:support true}}
-   :workspace    {:workspaceEdit {:documentChanges true}
-                  :codeLens {:refreshSupport true}}})
 
 (defn initialize-request
   ([]

--- a/cli/integration-test/integration/helper.clj
+++ b/cli/integration-test/integration/helper.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
+   [clojure.string :as string]
    [clojure.test :refer [is]]))
 
 (def root-project-path
@@ -64,3 +65,6 @@
        (str "integration-test/sample-test/src/sample_test/")
        io/as-relative-path
        delete-folder))
+
+(defn code [& strings]
+  (string/join \newline strings))

--- a/cli/integration-test/integration/initialize_test.clj
+++ b/cli/integration-test/integration/initialize_test.clj
@@ -52,8 +52,7 @@
                                                "refactor.inline"
                                                "refactor.rewrite"
                                                "source"
-                                               "source.organizeImports"]
-                             :resolveProvider true}
+                                               "source.organizeImports"]}
         :hoverProvider true
         :semanticTokensProvider {:legend {:tokenTypes ["namespace"
                                                        "type"

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -154,7 +154,7 @@
           (Thread/sleep 500)
           (recur))))))
 
-(defn await-request [method]
+(defn await-client-request [method]
   (loop []
     (let [method-str (keyname method)
           msg        (first (filter #(= method-str (:method %)) @server-requests))]

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -13,7 +13,7 @@
 (def ^:dynamic *stdout* nil)
 
 (defonce server-responses (atom {}))
-(defonce server-requests (atom {}))
+(defonce server-requests (atom []))
 (defonce server-notifications (atom []))
 (defonce client-request-id (atom 0))
 
@@ -54,7 +54,7 @@
               (and id method)
               (do
                 (println (colored :magenta "Received request:") (colored :yellow json))
-                (swap! server-requests assoc id json))
+                (swap! server-requests conj json))
 
               id
               (do
@@ -81,7 +81,7 @@
     (io/reader (:out *clojure-lsp-process*))))
 
 (defn clean! []
-  (reset! server-requests {})
+  (reset! server-requests [])
   (reset! server-responses {})
   (reset! server-notifications [])
   (reset! client-request-id 0)
@@ -150,6 +150,22 @@
                         (remove #(= method-str (:method %)))
                         vec)))
           (:params notification))
+        (do
+          (Thread/sleep 500)
+          (recur))))))
+
+(defn await-request [method]
+  (loop []
+    (let [method-str (keyname method)
+          msg        (first (filter #(= method-str (:method %)) @server-requests))]
+      (if msg
+        (do
+          (swap! server-requests
+                 (fn [n]
+                   (->> n
+                        (remove #(= method-str (:method %)))
+                        vec)))
+          (:params msg))
         (do
           (Thread/sleep 500)
           (recur))))))

--- a/cli/integration-test/integration/settings_change_test.clj
+++ b/cli/integration-test/integration/settings_change_test.clj
@@ -20,10 +20,9 @@
         (spit lsp-config-file old-content)))))
 
 (def new-lsp-config-content
-  (string/join "/n"
-               ["{:linters {:clj-kondo {:level :off"
-                "                       :async-custom-lint? false}}}"
-                ""]))
+  (h/code "{:linters {:clj-kondo {:level :off"
+          "                       :async-custom-lint? false}}}"
+          ""))
 
 (deftest unused-public-var
   (lsp/start-process!)

--- a/cli/integration-test/integration/settings_change_test.clj
+++ b/cli/integration-test/integration/settings_change_test.clj
@@ -1,6 +1,5 @@
 (ns integration.settings-change-test
   (:require
-   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [integration.fixture :as fixture]
    [integration.helper :as h]

--- a/cli/integration-test/integration/stubs_test.clj
+++ b/cli/integration-test/integration/stubs_test.clj
@@ -11,8 +11,8 @@
   (h/delete-project-file "../../.lsp/.cache")
   (h/delete-project-file "../../.clj-kondo/.cache")
   (lsp/start-process!)
-  (lsp/request! (fixture/initialize-request {:lint-project-files-after-startup? false
-                                             :stubs {:generation {:namespaces #{"datomic.api"}}}}))
+  (lsp/request! (fixture/initialize-request (assoc fixture/default-init-options
+                                                   :stubs {:generation {:namespaces #{"datomic.api"}}})))
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-notification "stubs/a.clj"))
 

--- a/cli/integration-test/sample-test/src/sample_test/code_action/a.clj
+++ b/cli/integration-test/sample-test/src/sample_test/code_action/a.clj
@@ -1,0 +1,8 @@
+(ns sample-test.code-action.a)
+
+(def m
+  {:a 1
+   ;; b comment
+   :b 2 ;; 2 comment
+   :c 3
+   :d 4})

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -30,7 +30,6 @@
      CallHierarchyOutgoingCallsParams
      CallHierarchyPrepareParams
      CodeActionParams
-     CodeAction
      CodeActionOptions
      CodeLens
      CodeLensParams
@@ -214,10 +213,6 @@
     (start :codeAction
            (async-request params handlers/code-actions ::coercer/code-actions)))
 
-  (^CompletableFuture resolveCodeAction [_ ^CodeAction unresolved]
-    (start :resolveCodeAction
-           (async-request unresolved handlers/resolve-code-action ::coercer/code-action)))
-
   (^CompletableFuture codeLens [_ ^CodeLensParams params]
     (start :codeLens
            (async-request params handlers/code-lens ::coercer/code-lenses)))
@@ -343,8 +338,7 @@
                                         (.setSignatureHelpProvider (SignatureHelpOptions. []))
                                         (.setCallHierarchyProvider true)
                                         (.setLinkedEditingRangeProvider true)
-                                        (.setCodeActionProvider (doto (CodeActionOptions. (vec (vals coercer/code-action-kind)))
-                                                                  (.setResolveProvider true)))
+                                        (.setCodeActionProvider (CodeActionOptions. (vec (vals coercer/code-action-kind))))
                                         (.setCodeLensProvider (CodeLensOptions. true))
                                         (.setReferencesProvider true)
                                         (.setRenameProvider (RenameOptions. true))
@@ -488,8 +482,7 @@
     (->> edit
          (coercer/conform-or-log ::coercer/workspace-edit-or-error)
          ApplyWorkspaceEditParams.
-         (.applyEdit client)
-         .get))
+         (.applyEdit client)))
 
   (show-document-request [_this document-request]
     (log/info "Requesting to show on editor the document" document-request)

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure-lsp.feature.add-missing-libspec :as f.add-missing-libspec]
    [clojure-lsp.feature.move-coll-entry :as f.move-coll-entry]
-   [clojure-lsp.feature.refactor :as f.refactor]
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.feature.sort-map :as f.sort-map]
    [clojure-lsp.parser :as parser]
@@ -95,221 +94,15 @@
            :name name
            :position position})))))
 
-(defn ^:private refactor-code-action
-  [refactoring zloc uri line character db & extra-args]
-  (f.refactor/call-refactor {:loc         zloc
-                             :refactoring refactoring
-                             :uri         uri
-                             :version     0
-                             :args        extra-args
-                             :row         (inc line)
-                             :col         (inc character)}
-                            db))
-
-(defn resolve-code-action-edits
-  [{{:keys [id uri line character chosen-alias chosen-ns chosen-refer coll diagnostic-code]} :data :as code-action}
-   zloc
-   db]
-  (->
-    (merge code-action
-           (case id
-             "add-missing-require"
-             (refactor-code-action :add-missing-libspec zloc uri line character db)
-
-             "add-missing-import"
-             (refactor-code-action :add-missing-import zloc uri line character db)
-
-             "add-require-suggestion"
-             (refactor-code-action :add-require-suggestion zloc uri line character db chosen-ns chosen-alias chosen-refer)
-
-             ("refactor-create-private-function"
-              "refactor-create-public-function")
-             (refactor-code-action :create-function zloc uri line character db)
-
-             "refactor-inline-symbol"
-             (refactor-code-action :inline-symbol zloc uri line character db)
-
-             "refactor-change-coll"
-             (refactor-code-action :change-coll zloc uri line character db coll)
-
-             "refactor-move-to-let"
-             (refactor-code-action :move-to-let zloc uri line character db "new-binding")
-
-             "refactor-cycle-privacy"
-             (refactor-code-action :cycle-privacy zloc uri line character db)
-
-             "refactor-extract-function"
-             (refactor-code-action :extract-function zloc uri line character db "new-function")
-
-             "refactor-thread-first-all"
-             (refactor-code-action :thread-first-all zloc uri line character db)
-
-             "refactor-thread-last-all"
-             (refactor-code-action :thread-last-all zloc uri line character db)
-
-             "refactor-unwind-thread"
-             (refactor-code-action :unwind-thread zloc uri line character db)
-
-             "refactor-unwind-all"
-             (refactor-code-action :unwind-all zloc uri line character db)
-
-             "refactor-sort-map"
-             (refactor-code-action :sort-map zloc uri line character db)
-
-             "refactor-move-coll-entry-down"
-             (refactor-code-action :move-coll-entry-down zloc uri line character db)
-
-             "refactor-move-coll-entry-up"
-             (refactor-code-action :move-coll-entry-up zloc uri line character db)
-
-             "refactor-suppress-diagnostic"
-             (refactor-code-action :suppress-diagnostic zloc uri line character db diagnostic-code)
-
-             "refactor-create-test"
-             (refactor-code-action :create-test zloc uri line character db)
-
-             "clean-ns"
-             (refactor-code-action :clean-ns zloc uri line character db)
-
-             "resolve-macro-as"
-             (refactor-code-action :resolve-macro-as zloc uri line character db)
-
-             {}))
-    (dissoc :data)))
-
-(defn ^:private resolve-code-action-commands
-  [{{:keys [id uri line character chosen-alias chosen-ns chosen-refer coll diagnostic-code]} :data :as code-action}
-   zloc
-   db]
-  (->
-    (merge code-action
-           (case id
-
-             "add-missing-require"
-             (f.refactor/call-refactor {:loc         zloc
-                                        :refactoring :add-missing-libspec
-                                        :uri         uri
-                                        :version     0
-                                        :row         (inc line)
-                                        :col         (inc character)}
-                                       db)
-
-             "add-missing-import"
-             {:command {:title     "Add missing import"
-                        :command   "add-missing-import"
-                        :arguments [uri line character]}}
-
-             "add-require-suggestion"
-             {:command {:title     "Add require suggestion"
-                        :command   "add-require-suggestion"
-                        :arguments [uri line character chosen-alias chosen-ns chosen-refer]}}
-
-             "refactor-create-private-function"
-             {:command {:title     "Create function"
-                        :command   "create-function"
-                        :arguments [uri line character]}}
-
-             "refactor-create-public-function"
-             {:command {:title     "Create function"
-                        :command   "create-function"
-                        :arguments [uri line character]}}
-
-             "refactor-inline-symbol"
-             {:command {:title     "Inline symbol"
-                        :command   "inline-symbol"
-                        :arguments [uri line character]}}
-
-             "refactor-change-coll"
-             {:command {:title "Change coll"
-                        :command "change-coll"
-                        :arguments [uri line character coll]}}
-
-             "refactor-move-to-let"
-             {:command {:title     "Move to let"
-                        :command   "move-to-let"
-                        :arguments [uri line character "new-binding"]}}
-
-             "refactor-cycle-privacy"
-             {:command {:title     "Cycle privacy"
-                        :command   "cycle-privacy"
-                        :arguments [uri line character]}}
-
-             "refactor-extract-function"
-             {:command {:title     "Extract function"
-                        :command   "extract-function"
-                        :arguments [uri line character "new-function"]}}
-
-             "refactor-thread-first-all"
-             {:command {:title     "Thread first all"
-                        :command   "thread-first-all"
-                        :arguments [uri line character]}}
-
-             "refactor-thread-last-all"
-             {:command {:title     "Thread last all"
-                        :command   "thread-last-all"
-                        :arguments [uri line character]}}
-
-             "refactor-unwind-thread"
-             {:command {:title     "Unwind thread once"
-                        :command   "unwind-thread"
-                        :arguments [uri line character]}}
-
-             "refactor-unwind-all"
-             {:command {:title     "Unwind whole thread"
-                        :command   "unwind-all"
-                        :arguments [uri line character]}}
-
-             "refactor-sort-map"
-             {:command {:title     "Sort map"
-                        :command   "sort-map"
-                        :arguments [uri line character]}}
-
-             "refactor-move-coll-entry-up"
-             {:command {:title     "Move coll entry up"
-                        :command   "move-coll-entry-up"
-                        :arguments [uri line character]}}
-
-             "refactor-move-coll-entry-down"
-             {:command {:title     "Move coll entry down"
-                        :command   "move-coll-entry-down"
-                        :arguments [uri line character]}}
-
-             "refactor-suppress-diagnostic"
-             {:command {:title "Suppress diagnostic"
-                        :command "suppress-diagnostic"
-                        :arguments [uri line character diagnostic-code]}}
-
-             "refactor-create-test"
-             {:command {:title     "Create test"
-                        :command   "create-test"
-                        :arguments [uri line character]}}
-
-             "clean-ns"
-             {:command {:title     "Clean namespace"
-                        :command   "clean-ns"
-                        :arguments [uri line character]}}
-
-             "resolve-macro-as"
-             {:command {:title "Resolve macro as..."
-                        :command "resolve-macro-as"
-                        :arguments [uri line character]}}
-
-             {}))
-    (dissoc :data)))
-
 (defn ^:private require-suggestion-actions
   [uri alias-suggestions]
   (map (fn [{:keys [ns alias refer position]}]
-         {:data       {:character (:character position)
-                       :chosen-alias alias
-                       :chosen-ns ns
-                       :chosen-refer refer
-                       :id "add-require-suggestion"
-                       :line (:line position)
-                       :uri uri}
+         {:title      (format "Add require '[%s %s %s]'" ns (if alias ":as" ":refer") (or alias (str "[" refer "]")))
           :kind       :quick-fix
           :preferred? true
-          :title      (format "Add require '[%s %s %s]'" ns (if alias ":as" ":refer") (or alias (str "[" refer "]")))})
+          :command    {:title     "Add require suggestion"
+                       :command   "add-require-suggestion"
+                       :arguments [uri (:line position) (:character position) ns alias refer]}})
        alias-suggestions))
 
 (defn ^:private missing-require-actions
@@ -318,10 +111,9 @@
          {:title      (format "Add require '[%s %s %s]'" ns (if alias ":as" ":refer") (or alias (str "[" refer "]")))
           :kind       :quick-fix
           :preferred? true
-          :data       {:id        "add-missing-require"
-                       :uri       uri
-                       :line      (:line position)
-                       :character (:character position)}})
+          :command    {:title     "Add missing require"
+                       :command   "add-missing-require"
+                       :arguments [uri (:line position) (:character position)]}})
        missing-requires))
 
 (defn ^:private missing-import-actions [uri missing-imports]
@@ -329,171 +121,149 @@
          {:title      (str "Add import '" missing-import "'")
           :kind       :quick-fix
           :preferred? true
-          :data       {:id        "add-missing-import"
-                       :uri       uri
-                       :line      (:line position)
-                       :character (:character position)}})
+          :command    {:title     "Add missing import"
+                       :command   "add-missing-import"
+                       :arguments [uri (:line position) (:character position)]}})
        missing-imports))
 
 (defn ^:private change-colls-actions [uri line character other-colls]
   (map (fn [coll]
-         {:title      (str "Change coll to " (name coll))
-          :kind       :refactor
-          :data       {:id        "refactor-change-coll"
-                       :uri       uri
-                       :line      line
-                       :character character
-                       :coll (name coll)}})
+         {:title   (str "Change coll to " (name coll))
+          :kind    :refactor
+          :command {:title     "Change coll"
+                    :command   "change-coll"
+                    :arguments [uri line character (name coll)]}})
        other-colls))
 
 (defn ^:private inline-symbol-action [uri line character]
-  {:title "Inline symbol"
-   :kind  :refactor-inline
-   :data  {:id        "refactor-inline-symbol"
-           :uri       uri
-           :line      line
-           :character character}})
+  {:title   "Inline symbol"
+   :kind    :refactor-inline
+   :command {:title     "Inline symbol"
+             :command   "inline-symbol"
+             :arguments [uri line character]}})
 
 (defn ^:private move-to-let-action [uri line character]
-  {:title "Move to let"
-   :kind  :refactor-extract
-   :data  {:id        "refactor-move-to-let"
-           :uri       uri
-           :line      line
-           :character character}})
+  {:title   "Move to let"
+   :kind    :refactor-extract
+   :command {:title     "Move to let"
+             :command   "move-to-let"
+             :arguments [uri line character "new-binding"]}})
 
 (defn ^:private cycle-privacy-action [uri line character]
-  {:title "Cycle privacy"
-   :kind  :refactor-rewrite
-   :data  {:id        "refactor-cycle-privacy"
-           :uri       uri
-           :line      line
-           :character character}})
+  {:title   "Cycle privacy"
+   :kind    :refactor-rewrite
+   :command {:title     "Cycle privacy"
+             :command   "cycle-privacy"
+             :arguments [uri line character]}})
 
 (defn ^:private extract-function-action [uri line character]
-  {:title "Extract function"
-   :kind  :refactor-extract
-   :data  {:id        "refactor-extract-function"
-           :uri       uri
-           :line      line
-           :character character}})
+  {:title   "Extract function"
+   :kind    :refactor-extract
+   :command {:title     "Extract function"
+             :command   "extract-function"
+             :arguments [uri line character "new-function"]}})
 
 (defn ^:private clean-ns-action [uri line character]
-  {:title "Clean namespace"
-   :kind  :source-organize-imports
-   :data  {:id        "clean-ns"
-           :uri       uri
-           :line      line
-           :character character}})
+  {:title   "Clean namespace"
+   :kind    :source-organize-imports
+   :command {:title     "Clean namespace"
+             :command   "clean-ns"
+             :arguments [uri line character]}})
 
 (defn ^:private thread-first-all-action [uri line character]
-  {:title "Thread first all"
-   :kind :refactor-rewrite
-   :data {:id "refactor-thread-first-all"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Thread first all"
+   :kind    :refactor-rewrite
+   :command {:title     "Thread first all"
+             :command   "thread-first-all"
+             :arguments [uri line character]}})
 
 (defn ^:private thread-last-all-action [uri line character]
-  {:title "Thread last all"
-   :kind :refactor-rewrite
-   :data {:id "refactor-thread-last-all"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Thread last all"
+   :kind    :refactor-rewrite
+   :command {:title     "Thread last all"
+             :command   "thread-last-all"
+             :arguments [uri line character]}})
 
 (defn ^:private unwind-thread-action [uri line character]
-  {:title "Unwind thread once"
-   :kind :refactor-rewrite
-   :data {:id "refactor-unwind-thread"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Unwind thread once"
+   :kind    :refactor-rewrite
+   :command {:title     "Unwind thread once"
+             :command   "unwind-thread"
+             :arguments [uri line character]}})
 
 (defn ^:private unwind-all-action [uri line character]
-  {:title "Unwind whole thread"
-   :kind :refactor-rewrite
-   :data {:id "refactor-unwind-all"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Unwind whole thread"
+   :kind    :refactor-rewrite
+   :command {:title     "Unwind whole thread"
+             :command   "unwind-all"
+             :arguments [uri line character]}})
 
 (defn ^:private sort-map-action [uri line character]
-  {:title "Sort map"
-   :kind :refactor-rewrite
-   :data {:id "refactor-sort-map"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Sort map"
+   :kind    :refactor-rewrite
+   :command {:title     "Sort map"
+             :command   "sort-map"
+             :arguments [uri line character]}})
 
 (defn ^:private move-coll-entry-up-action [uri line character]
-  {:title "Move coll entry up"
-   :kind :refactor-rewrite
-   :data {:id "refactor-move-coll-entry-up"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Move coll entry up"
+   :kind    :refactor-rewrite
+   :command {:title     "Move coll entry up"
+             :command   "move-coll-entry-up"
+             :arguments [uri line character]}})
 
 (defn ^:private move-coll-entry-down-action [uri line character]
-  {:title "Move coll entry down"
-   :kind :refactor-rewrite
-   :data {:id "refactor-move-coll-entry-down"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   "Move coll entry down"
+   :kind    :refactor-rewrite
+   :command {:title     "Move coll entry down"
+             :command   "move-coll-entry-down"
+             :arguments [uri line character]}})
 
 (defn ^:private suppress-diagnostic-actions [diagnostics uri]
   (->> diagnostics
        (map (fn [{:keys [code]
                   {{:keys [line character]} :start} :range}]
-              {:title (format "Suppress '%s' diagnostic" code)
-               :kind :quick-fix
-               :data {:id "refactor-suppress-diagnostic"
-                      :uri uri
-                      :line line
-                      :character character
-                      :diagnostic-code code}}))
+              {:title   (format "Suppress '%s' diagnostic" code)
+               :kind    :quick-fix
+               :command {:title     "Suppress diagnostic"
+                         :command   "suppress-diagnostic"
+                         :arguments [uri line character code]}}))
        (medley/distinct-by :title)))
 
 (defn ^:private create-test-action [function-name-loc uri line character]
-  {:title (format "Create test for '%s'" (z/string function-name-loc))
-   :kind :refactor-rewrite
-   :data {:id "refactor-create-test"
-          :uri uri
-          :line line
-          :character character}})
+  {:title   (format "Create test for '%s'" (z/string function-name-loc))
+   :kind    :refactor-rewrite
+   :command {:title     "Create test"
+             :command   "create-test"
+             :arguments [uri line character]}})
 
 (defn ^:private create-private-function-action [uri function-to-create]
-  {:title (format "Create private function '%s'" (:name function-to-create))
-   :kind :quick-fix
-   :data {:id "refactor-create-private-function"
-          :uri uri
-          :line      (:line (:position function-to-create))
-          :character (:character (:position function-to-create))}})
+  {:title   (format "Create private function '%s'" (:name function-to-create))
+   :kind    :quick-fix
+   :command {:title     "Create function"
+             :command   "create-function"
+             :arguments [uri (:line (:position function-to-create)) (:character (:position function-to-create))]}})
 
 (defn ^:private create-public-function-action [uri {:keys [name new-ns ns position]}]
-  {:title (if new-ns
-            (format "Create namespace '%s' and '%s' function" new-ns name)
-            (format "Create function '%s' on '%s'" name ns))
-   :kind :quick-fix
-   :data {:id "refactor-create-public-function"
-          :uri uri
-          :line      (:line position)
-          :character (:character position)}})
+  {:title   (if new-ns
+              (format "Create namespace '%s' and '%s' function" new-ns name)
+              (format "Create function '%s' on '%s'" name ns))
+   :kind    :quick-fix
+   :command {:title     "Create function"
+             :command   "create-function"
+             :arguments [uri (:line position) (:character position)]}})
 
 (defn ^:private resolve-macro-as-action [uri row col macro-sym]
-  {:title (format "Resolve macro '%s' as..." (str macro-sym))
-   :kind :quick-fix
-   :data {:id "resolve-macro-as"
-          :uri uri
-          :line row
-          :character col}})
+  {:title   (format "Resolve macro '%s' as..." (str macro-sym))
+   :kind    :quick-fix
+   :command {:title     "Resolve macro as..."
+             :command   "resolve-macro-as"
+             :arguments [uri row col]}})
 
 (defn all [zloc uri row col diagnostics client-capabilities db]
   (let [line (dec row)
         character (dec col)
         workspace-edit-capability? (get-in client-capabilities [:workspace :workspace-edit])
-        resolve-action-support? (get-in client-capabilities [:text-document :code-action :resolve-support])
         inside-function?* (future (r.transform/find-function-form zloc))
         private-function-to-create* (future (find-private-function-to-create uri diagnostics db))
         public-function-to-create* (future (find-public-function-to-create uri diagnostics db))
@@ -573,7 +343,4 @@
       (conj (create-test-action (:function-name-loc @can-create-test?*) uri line character))
 
       workspace-edit-capability?
-      (conj (clean-ns-action uri line character))
-
-      (not resolve-action-support?)
-      (->> (map #(resolve-code-action-commands % zloc db))))))
+      (conj (clean-ns-action uri line character)))))

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -112,7 +112,7 @@
           :kind       :quick-fix
           :preferred? true
           :command    {:title     "Add missing require"
-                       :command   "add-missing-require"
+                       :command   "add-missing-libspec"
                        :arguments [uri (:line position) (:character position)]}})
        missing-requires))
 

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -64,7 +64,7 @@
 
 (defn hover-documentation
   [{sym-ns :ns sym-name :name :keys [doc filename arglist-strs] :as _definition} db]
-  (let [[content-format] (get-in @db [:client-capabilities :text-document :hover :content-format])
+  (let [content-formats (get-in @db [:client-capabilities :text-document :hover :content-format])
         arity-on-same-line? (or (settings/get db [:hover :arity-on-same-line?])
                                 (settings/get db [:show-docs-arity-on-same-line?]))
         hide-filename? (settings/get db [:hover :hide-file-location?])
@@ -76,7 +76,7 @@
               sym-ns (str sym-ns "/"))
         sym-line (str sym (when signatures
                             (str join-char signatures)))
-        markdown? (= "markdown" content-format)
+        markdown? (some #{"markdown"} content-formats)
         doc-line (when (seq doc)
                    (if markdown?
                      (docstring->formatted-markdown doc)

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -285,13 +285,6 @@
           client-capabilities (get @db/db :client-capabilities)]
       (f.code-actions/all zloc textDocument row col diagnostics client-capabilities db/db))))
 
-(defn resolve-code-action [{{:keys [uri line character]} :data :as action}]
-  (let [zloc (parser/safe-cursor-loc uri line character db/db)]
-    (when-let [result (f.code-actions/resolve-code-action-edits action zloc db/db)]
-      (when (:show-document-after-edit result)
-        (producer/show-document-request (:producer @db/db) (:show-document-after-edit result)))
-      result)))
-
 (defn code-lens
   [{:keys [textDocument]}]
   (process-after-changes

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -509,39 +509,3 @@
                                   []
                                   {:workspace {:workspace-edit true}}
                                   db/db)))))
-
-(deftest resolve-code-action-edits
-  (h/load-code-and-locs (h/code "(ns some-ns)"
-                                "(let [a 1] (+ 2 3))"
-                                "(defn foo [] 1)")
-                        "file:///project/src/some_ns.clj")
-  (testing "for a refactoring without extra-arg"
-    (h/assert-submap
-      {:title "Cycle privacy"
-       :edit {:changes {"file:///project/src/some_ns.clj"
-                        [{:range {:start {:line 2 :character 1}
-                                  :end {:line 2 :character 5}}
-                          :new-text "defn-"}]}}}
-      (f.code-actions/resolve-code-action-edits
-        {:title "Cycle privacy"
-         :data {:id "refactor-cycle-privacy"
-                :uri "file:///project/src/some_ns.clj"
-                :line 2
-                :character 7}}
-        (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 3 8)
-        db/db)))
-  (testing "for a refactoring with extra-arg"
-    (h/assert-submap
-      {:title "Move to let"
-       :edit {:changes {"file:///project/src/some_ns.clj"
-                        [{:range {:start {:line 1 :character 0}
-                                  :end {:line 1 :character 19}}
-                          :new-text "(let [a 1\n      new-binding +] (new-binding 2 3))"}]}}}
-      (f.code-actions/resolve-code-action-edits
-        {:title "Move to let"
-         :data {:id "refactor-move-to-let"
-                :uri "file:///project/src/some_ns.clj"
-                :line 1
-                :character 12}}
-        (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 2 13)
-        db/db))))

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -26,33 +26,40 @@
                                 "(medley.core/foo 1 2)"
                                 "(clojure.data.json/bar 1 2)"))
   (testing "simple ns"
-    (is (some #(= (:title %) "Add require '[clojure.set :as set]'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 4)
-                                  (h/file-uri "file:///a.clj")
-                                  2
-                                  4
-                                  [{:code "unresolved-namespace"
-                                    :range {:start {:line 1 :character 3}}}] {}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Add require '[clojure.set :as set]'"
+       :command {:command "add-require-suggestion"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 4)
+                         (h/file-uri "file:///a.clj")
+                         2
+                         4
+                         [{:code  "unresolved-namespace"
+                           :range {:start {:line 1 :character 3}}}] {}
+                         db/db)))
   (testing "core ns"
-    (is (some #(= (:title %) "Add require '[medley.core :as medley]'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 4)
-                                  (h/file-uri "file:///a.clj")
-                                  3
-                                  4
-                                  [{:code "unresolved-namespace"
-                                    :range {:start {:line 2 :character 3}}}] {}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Add require '[medley.core :as medley]'"
+       :command {:command "add-require-suggestion"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 4)
+                         (h/file-uri "file:///a.clj")
+                         3
+                         4
+                         [{:code  "unresolved-namespace"
+                           :range {:start {:line 2 :character 3}}}] {}
+                         db/db)))
   (testing "already used alias, we add one more suggestion"
-    (let [result (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4)
-                                     (h/file-uri "file:///a.clj")
-                                     4
-                                     4
-                                     [{:code "unresolved-namespace"
-                                       :range {:start {:line 3 :character 3}}}] {}
-                                     db/db)]
-      (is (some #(= (:title %) "Add require '[clojure.data.json :as json]'") result))
-      (is (some #(= (:title %) "Add require '[clojure.data.json :as data.json]'") result)))))
+    (h/assert-contains-submaps
+     [{:title "Add require '[clojure.data.json :as json]'"
+       :command {:command "add-require-suggestion"}}
+      {:title "Add require '[clojure.data.json :as data.json]'"
+       :command {:command "add-require-suggestion"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4)
+                         (h/file-uri "file:///a.clj")
+                         4
+                         4
+                         [{:code  "unresolved-namespace"
+                           :range {:start {:line 3 :character 3}}}] {}
+                         db/db))))
 
 (deftest add-refer-suggestion-code-actions
   (h/load-code-and-locs "(ns clojure.set) (defn union [])" (h/file-uri "file:///clojure.core.clj"))
@@ -62,25 +69,29 @@
                                 "(unit 1)"
                                 "(union #{} #{})"))
   (testing "single suggestion"
-    (is (some #(= (:title %) "Add require '[medley.core :refer [unit]]'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 3)
-                                  (h/file-uri "file:///a.clj")
-                                  2
-                                  3
-                                  [{:code "unresolved-symbol"
-                                    :message "Unresolved symbol: unit"
-                                    :range {:start {:line 1 :character 2}}}] {}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Add require '[medley.core :refer [unit]]'"
+       :command {:command "add-require-suggestion"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 3)
+                         (h/file-uri "file:///a.clj")
+                         2
+                         3
+                         [{:code    "unresolved-symbol"
+                           :message "Unresolved symbol: unit"
+                           :range   {:start {:line 1 :character 2}}}] {}
+                         db/db)))
   (testing "multiple suggestions"
-    (is (some #(= (:title %) "Add require '[clojure.set :refer [union]]'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
-                                  (h/file-uri "file:///a.clj")
-                                  3
-                                  3
-                                  [{:code "unresolved-symbol"
-                                    :message "Unresolved symbol: union"
-                                    :range {:start {:line 2 :character 2}}}] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title   "Add require '[clojure.set :refer [union]]'"
+       :command {:command "add-require-suggestion"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
+                         (h/file-uri "file:///a.clj")
+                         3
+                         3
+                         [{:code    "unresolved-symbol"
+                           :message "Unresolved symbol: union"
+                           :range   {:start {:line 2 :character 2}}}] {}
+                         db/db))))
 
 (deftest add-missing-namespace-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -108,14 +119,16 @@
                                       [] {}
                                       db/db))))
   (testing "when it has unresolved-namespace and can find namespace"
-    (is (some #(= (:title %) "Add require '[some-ns :as sns]'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 3 11)
-                                  (h/file-uri "file:///c.clj")
-                                  3
-                                  11
-                                  [{:code "unresolved-namespace"
-                                    :range {:start {:line 2 :character 10}}}] {}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Add require '[some-ns :as sns]'"
+       :command {:command "add-missing-libspec"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 3 11)
+                         (h/file-uri "file:///c.clj")
+                         3
+                         11
+                         [{:code  "unresolved-namespace"
+                           :range {:start {:line 2 :character 10}}}] {}
+                         db/db)))
   (testing "when it has unresolved-namespace but cannot find namespace"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 2 11)
@@ -126,14 +139,16 @@
                                         :range {:start {:line 1 :character 10}}}] {}
                                       db/db))))
   (testing "when it has unresolved-symbol and it's a known refer"
-    (is (some #(= (:title %) "Add require '[clojure.test :refer [deftest]]'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 2)
-                                  (h/file-uri "file:///c.clj")
-                                  4
-                                  2
-                                  [{:code "unresolved-namespace"
-                                    :range {:start {:line 3 :character 1}}}] {}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Add require '[clojure.test :refer [deftest]]'"
+       :command {:command "add-missing-libspec"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 2)
+                         (h/file-uri "file:///c.clj")
+                         4
+                         2
+                         [{:code  "unresolved-namespace"
+                           :range {:start {:line 3 :character 1}}}] {}
+                         db/db)))
   (testing "when it has unresolved-symbol but it's not a known refer"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 11)
@@ -174,24 +189,28 @@
                                         :range {:start {:line 4 :character 2}}}] {}
                                       db/db))))
   (testing "when it has unresolved-symbol and it's a common import"
-    (is (some #(= (:title %) "Add import 'java.util.Date'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 6 2)
-                                  (h/file-uri "file:///c.clj")
-                                  6
-                                  2
-                                  [{:code "unresolved-symbol"
-                                    :message "Unresolved symbol: foo"
-                                    :range {:start {:line 5 :character 2}}}] {}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Add import 'java.util.Date'"
+       :command {:command "add-missing-import"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 6 2)
+                         (h/file-uri "file:///c.clj")
+                         6
+                         2
+                         [{:code    "unresolved-symbol"
+                           :message "Unresolved symbol: foo"
+                           :range   {:start {:line 5 :character 2}}}] {}
+                         db/db)))
   (testing "when it has unresolved-namespace and it's a common import via method"
-    (is (some #(= (:title %) "Add import 'java.util.Date'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 7 2)
-                                  (h/file-uri "file:///c.clj")
-                                  7
-                                  2
-                                  [{:code "unresolved-namespace"
-                                    :range {:start {:line 6 :character 2}}}] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Add import 'java.util.Date'"
+       :command {:command "add-missing-import"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 7 2)
+                         (h/file-uri "file:///c.clj")
+                         7
+                         2
+                         [{:code  "unresolved-namespace"
+                           :range {:start {:line 6 :character 2}}}] {}
+                         db/db))))
 
 (deftest inline-symbol-code-action
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
@@ -208,13 +227,15 @@
                                       [] {}
                                       db/db))))
   (testing "when in let/def symbol"
-    (is (some #(= (:title %) "Inline symbol")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 5)
-                                  (h/file-uri "file:///b.clj")
-                                  4
-                                  5
-                                  [] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Inline symbol"
+       :command {:command "inline-symbol"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 5)
+                         (h/file-uri "file:///b.clj")
+                         4
+                         5
+                         [] {}
+                         db/db))))
 
 (deftest change-coll-code-action
   (h/load-code-and-locs (h/code "\"some string\""
@@ -232,17 +253,25 @@
                                       [] {}
                                       db/db))))
   (testing "when in a list"
-    (is (some #(= (:title %) "Change coll to map")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 1) (h/file-uri "file:///b.clj") 2 1 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Change coll to map"
+       :command {:command "change-coll"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 1) (h/file-uri "file:///b.clj") 2 1 [] {} db/db)))
   (testing "when in a map"
-    (is (some #(= (:title %) "Change coll to vector")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 1) (h/file-uri "file:///b.clj") 3 1 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title   "Change coll to vector"
+       :command {:command "change-coll"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 1) (h/file-uri "file:///b.clj") 3 1 [] {} db/db)))
   (testing "when in a vector"
-    (is (some #(= (:title %) "Change coll to set")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1) (h/file-uri "file:///b.clj") 4 1 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Change coll to set"
+       :command {:command "change-coll"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1) (h/file-uri "file:///b.clj") 4 1 [] {} db/db)))
   (testing "when in a set"
-    (is (some #(= (:title %) "Change coll to list")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 5 1) (h/file-uri "file:///b.clj") 5 1 [] {} db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Change coll to list"
+       :command {:command "change-coll"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 5 1) (h/file-uri "file:///b.clj") 5 1 [] {} db/db))))
 
 (deftest move-to-let-code-action
   (h/load-code-and-locs (h/code "(let [a 1"
@@ -259,13 +288,15 @@
                                       [] {}
                                       db/db))))
   (testing "when inside let form"
-    (is (some #(= (:title %) "Move to let")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 3)
-                                  (h/file-uri "file:///b.clj")
-                                  3
-                                  3
-                                  [] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Move to let"
+       :command {:command "move-to-let"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 3)
+                         (h/file-uri "file:///b.clj")
+                         3
+                         3
+                         [] {}
+                         db/db))))
 
 (deftest cycle-privacy-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -280,13 +311,15 @@
                                       [] {}
                                       db/db))))
   (testing "when on function location"
-    (is (some #(= (:title %) "Cycle privacy")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
-                                  (h/file-uri "file:///a.clj")
-                                  2
-                                  5
-                                  [] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Cycle privacy"
+       :command {:command "cycle-privacy"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+                         (h/file-uri "file:///a.clj")
+                         2
+                         5
+                         [] {}
+                         db/db))))
 
 (deftest extract-function-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -301,13 +334,15 @@
                                       [] {}
                                       db/db))))
   (testing "when on function location"
-    (is (some #(= (:title %) "Extract function")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
-                                  (h/file-uri "file:///a.clj")
-                                  2
-                                  5
-                                  [] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Extract function"
+       :command {:command "extract-function"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+                         (h/file-uri "file:///a.clj")
+                         2
+                         5
+                         [] {}
+                         db/db))))
 
 (deftest create-private-function-code-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -322,15 +357,17 @@
                                       [] {}
                                       db/db))))
   (testing "when in a unresolved symbol"
-    (is (some #(= (:title %) "Create private function 'some-func'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 10)
-                                  (h/file-uri "file:///a.clj")
-                                  2
-                                  10
-                                  [{:code "unresolved-symbol"
-                                    :message "Unresolved symbol: some-func"
-                                    :range {:start {:line 2 :character 11}}}] {}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Create private function 'some-func'"
+       :command {:command "create-function"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 10)
+                         (h/file-uri "file:///a.clj")
+                         2
+                         10
+                         [{:code    "unresolved-symbol"
+                           :message "Unresolved symbol: some-func"
+                           :range   {:start {:line 2 :character 11}}}] {}
+                         db/db))))
 
 (deftest thread-first-all-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -347,11 +384,15 @@
     (is (not-any? #(= (:title %) "Thread first all")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 2) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a valid function that can be threaded"
-    (is (some #(= (:title %) "Thread first all")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Thread first all"
+       :command {:command "thread-first-all"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when on a non-list node"
-    (is (some #(= (:title %) "Thread first all")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Thread first all"
+       :command {:command "thread-first-all"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
 
 (deftest thread-last-all-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -368,11 +409,15 @@
     (is (not-any? #(= (:title %) "Thread last all")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 2) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a valid function that can be threaded"
-    (is (some #(= (:title %) "Thread last all")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Thread last all"
+       :command {:command "thread-last-all"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when on a non-list node"
-    (is (some #(= (:title %) "Thread last all")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Thread last all"
+       :command {:command "thread-last-all"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
 
 (deftest unwind-thread-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -385,14 +430,20 @@
     (is (not-any? #(= (:title %) "Unwind thread once")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
   (testing "when inside thread call"
-    (is (some #(= (:title %) "Unwind thread once")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Unwind thread once"
+       :command {:command "unwind-thread"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when inside thread symbol"
-    (is (some #(= (:title %) "Unwind thread once")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 2) (h/file-uri "file:///a.clj") 3 2 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Unwind thread once"
+       :command {:command "unwind-thread"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 2) (h/file-uri "file:///a.clj") 3 2 [] {} db/db)))
   (testing "when inside any threading call"
-    (is (some #(= (:title %) "Unwind thread once")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 5 7) (h/file-uri "file:///a.clj") 5 7 [] {} db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Unwind thread once"
+       :command {:command "unwind-thread"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 5 7) (h/file-uri "file:///a.clj") 5 7 [] {} db/db))))
 
 (deftest clean-ns-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -422,13 +473,15 @@
 
   (testing "with workspace edit client capability"
     (swap! db/db assoc-in [:client-capabilities :workspace :workspace-edit] true)
-    (is (some #(= (:title %) "Clean namespace")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
-                                  (h/file-uri "file:///b.clj")
-                                  2
-                                  2
-                                  [] {:workspace {:workspace-edit true}}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Clean namespace"
+       :command {:command "clean-ns"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
+                         (h/file-uri "file:///b.clj")
+                         2
+                         2
+                         [] {:workspace {:workspace-edit true}}
+                         db/db))))
 
 (deftest resolve-macro-as-code-actions
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -436,8 +489,10 @@
                                 "(foo my-fn)"
                                 "(+ 1 2)"))
   (testing "when inside a macro usage"
-    (is (some #(= (:title %) "Resolve macro 'some-ns/foo' as...")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7) (h/file-uri "file:///a.clj") 3 7 [] {} db/db))))
+    (h/assert-contains-submaps
+     [{:title "Resolve macro 'some-ns/foo' as..."
+       :command {:command "resolve-macro-as"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7) (h/file-uri "file:///a.clj") 3 7 [] {} db/db)))
   (testing "when not inside a macro usage"
     (is (not-any? #(= (:title %) "Resolve macro 'some-ns/foo' as...")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4) (h/file-uri "file:///a.clj") 4 4 [] {} db/db)))))
@@ -447,16 +502,18 @@
                                 ""
                                 "(def ^:private a 1)"))
   (testing "unused-private-var"
-    (is (some #(= (:title %) "Suppress 'unused-private-var' diagnostic")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
-                                  (h/file-uri "file:///a.clj")
-                                  3
-                                  3
-                                  [{:code "unused-private-var"
-                                    :message "Unused private var: a"
-                                    :range {:start {:line 3 :character 11}}}]
-                                  {:workspace {:workspace-edit true}}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Suppress 'unused-private-var' diagnostic"
+       :command {:command "suppress-diagnostic"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
+                         (h/file-uri "file:///a.clj")
+                         3
+                         3
+                         [{:code    "unused-private-var"
+                           :message "Unused private var: a"
+                           :range   {:start {:line 3 :character 11}}}]
+                         {:workspace {:workspace-edit true}}
+                         db/db))))
 
 (deftest sort-map-actions
   (swap! db/db shared/deep-merge {:client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
@@ -465,23 +522,27 @@
                                 "(defn foo []"
                                 "  {:g 2 :s 3 :kj 3 :a 5})"))
   (testing "on map bracket"
-    (is (some #(= (:title %) "Sort map")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 3)
-                                  (h/file-uri "file:///project/src/some_ns.clj")
-                                  4
-                                  3
-                                  []
-                                  {:workspace {:workspace-edit true}}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Sort map"
+       :command {:command "sort-map"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 3)
+                         (h/file-uri "file:///project/src/some_ns.clj")
+                         4
+                         3
+                         []
+                         {:workspace {:workspace-edit true}}
+                         db/db)))
   (testing "On map's key"
-    (is (some #(= (:title %) "Sort map")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 5)
-                                  (h/file-uri "file:///project/src/some_ns.clj")
-                                  4
-                                  5
-                                  []
-                                  {:workspace {:workspace-edit true}}
-                                  db/db))))
+    (h/assert-contains-submaps
+     [{:title "Sort map"
+       :command {:command "sort-map"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 5)
+                         (h/file-uri "file:///project/src/some_ns.clj")
+                         4
+                         5
+                         []
+                         {:workspace {:workspace-edit true}}
+                         db/db)))
   (testing "not on map"
     (is (not-any? #(= (:title %) "Sort map")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7)
@@ -501,11 +562,13 @@
                                 "(defn foo [] 1)")
                         "file:///project/src/some_ns.clj")
   (testing "inside function"
-    (is (some #(= (:title %) "Create test for 'foo'")
-              (f.code-actions/all (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 3 6)
-                                  (h/file-uri "file:///project/src/some_ns.clj")
-                                  3
-                                  6
-                                  []
-                                  {:workspace {:workspace-edit true}}
-                                  db/db)))))
+    (h/assert-contains-submaps
+     [{:title "Create test for 'foo'"
+       :command {:command "create-test"}}]
+     (f.code-actions/all (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 3 6)
+                         (h/file-uri "file:///project/src/some_ns.clj")
+                         3
+                         6
+                         []
+                         {:workspace {:workspace-edit true}}
+                         db/db))))

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -27,39 +27,39 @@
                                 "(clojure.data.json/bar 1 2)"))
   (testing "simple ns"
     (h/assert-contains-submaps
-     [{:title "Add require '[clojure.set :as set]'"
-       :command {:command "add-require-suggestion"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 4)
-                         (h/file-uri "file:///a.clj")
-                         2
-                         4
-                         [{:code  "unresolved-namespace"
-                           :range {:start {:line 1 :character 3}}}] {}
-                         db/db)))
+      [{:title "Add require '[clojure.set :as set]'"
+        :command {:command "add-require-suggestion"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 4)
+                          (h/file-uri "file:///a.clj")
+                          2
+                          4
+                          [{:code  "unresolved-namespace"
+                            :range {:start {:line 1 :character 3}}}] {}
+                          db/db)))
   (testing "core ns"
     (h/assert-contains-submaps
-     [{:title "Add require '[medley.core :as medley]'"
-       :command {:command "add-require-suggestion"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 4)
-                         (h/file-uri "file:///a.clj")
-                         3
-                         4
-                         [{:code  "unresolved-namespace"
-                           :range {:start {:line 2 :character 3}}}] {}
-                         db/db)))
+      [{:title "Add require '[medley.core :as medley]'"
+        :command {:command "add-require-suggestion"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 4)
+                          (h/file-uri "file:///a.clj")
+                          3
+                          4
+                          [{:code  "unresolved-namespace"
+                            :range {:start {:line 2 :character 3}}}] {}
+                          db/db)))
   (testing "already used alias, we add one more suggestion"
     (h/assert-contains-submaps
-     [{:title "Add require '[clojure.data.json :as json]'"
-       :command {:command "add-require-suggestion"}}
-      {:title "Add require '[clojure.data.json :as data.json]'"
-       :command {:command "add-require-suggestion"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4)
-                         (h/file-uri "file:///a.clj")
-                         4
-                         4
-                         [{:code  "unresolved-namespace"
-                           :range {:start {:line 3 :character 3}}}] {}
-                         db/db))))
+      [{:title "Add require '[clojure.data.json :as json]'"
+        :command {:command "add-require-suggestion"}}
+       {:title "Add require '[clojure.data.json :as data.json]'"
+        :command {:command "add-require-suggestion"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4)
+                          (h/file-uri "file:///a.clj")
+                          4
+                          4
+                          [{:code  "unresolved-namespace"
+                            :range {:start {:line 3 :character 3}}}] {}
+                          db/db))))
 
 (deftest add-refer-suggestion-code-actions
   (h/load-code-and-locs "(ns clojure.set) (defn union [])" (h/file-uri "file:///clojure.core.clj"))
@@ -70,28 +70,28 @@
                                 "(union #{} #{})"))
   (testing "single suggestion"
     (h/assert-contains-submaps
-     [{:title "Add require '[medley.core :refer [unit]]'"
-       :command {:command "add-require-suggestion"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 3)
-                         (h/file-uri "file:///a.clj")
-                         2
-                         3
-                         [{:code    "unresolved-symbol"
-                           :message "Unresolved symbol: unit"
-                           :range   {:start {:line 1 :character 2}}}] {}
-                         db/db)))
+      [{:title "Add require '[medley.core :refer [unit]]'"
+        :command {:command "add-require-suggestion"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 3)
+                          (h/file-uri "file:///a.clj")
+                          2
+                          3
+                          [{:code    "unresolved-symbol"
+                            :message "Unresolved symbol: unit"
+                            :range   {:start {:line 1 :character 2}}}] {}
+                          db/db)))
   (testing "multiple suggestions"
     (h/assert-contains-submaps
-     [{:title   "Add require '[clojure.set :refer [union]]'"
-       :command {:command "add-require-suggestion"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
-                         (h/file-uri "file:///a.clj")
-                         3
-                         3
-                         [{:code    "unresolved-symbol"
-                           :message "Unresolved symbol: union"
-                           :range   {:start {:line 2 :character 2}}}] {}
-                         db/db))))
+      [{:title   "Add require '[clojure.set :refer [union]]'"
+        :command {:command "add-require-suggestion"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
+                          (h/file-uri "file:///a.clj")
+                          3
+                          3
+                          [{:code    "unresolved-symbol"
+                            :message "Unresolved symbol: union"
+                            :range   {:start {:line 2 :character 2}}}] {}
+                          db/db))))
 
 (deftest add-missing-namespace-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -120,15 +120,15 @@
                                       db/db))))
   (testing "when it has unresolved-namespace and can find namespace"
     (h/assert-contains-submaps
-     [{:title "Add require '[some-ns :as sns]'"
-       :command {:command "add-missing-libspec"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 3 11)
-                         (h/file-uri "file:///c.clj")
-                         3
-                         11
-                         [{:code  "unresolved-namespace"
-                           :range {:start {:line 2 :character 10}}}] {}
-                         db/db)))
+      [{:title "Add require '[some-ns :as sns]'"
+        :command {:command "add-missing-libspec"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 3 11)
+                          (h/file-uri "file:///c.clj")
+                          3
+                          11
+                          [{:code  "unresolved-namespace"
+                            :range {:start {:line 2 :character 10}}}] {}
+                          db/db)))
   (testing "when it has unresolved-namespace but cannot find namespace"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 2 11)
@@ -140,15 +140,15 @@
                                       db/db))))
   (testing "when it has unresolved-symbol and it's a known refer"
     (h/assert-contains-submaps
-     [{:title "Add require '[clojure.test :refer [deftest]]'"
-       :command {:command "add-missing-libspec"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 2)
-                         (h/file-uri "file:///c.clj")
-                         4
-                         2
-                         [{:code  "unresolved-namespace"
-                           :range {:start {:line 3 :character 1}}}] {}
-                         db/db)))
+      [{:title "Add require '[clojure.test :refer [deftest]]'"
+        :command {:command "add-missing-libspec"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 2)
+                          (h/file-uri "file:///c.clj")
+                          4
+                          2
+                          [{:code  "unresolved-namespace"
+                            :range {:start {:line 3 :character 1}}}] {}
+                          db/db)))
   (testing "when it has unresolved-symbol but it's not a known refer"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 11)
@@ -190,27 +190,27 @@
                                       db/db))))
   (testing "when it has unresolved-symbol and it's a common import"
     (h/assert-contains-submaps
-     [{:title "Add import 'java.util.Date'"
-       :command {:command "add-missing-import"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 6 2)
-                         (h/file-uri "file:///c.clj")
-                         6
-                         2
-                         [{:code    "unresolved-symbol"
-                           :message "Unresolved symbol: foo"
-                           :range   {:start {:line 5 :character 2}}}] {}
-                         db/db)))
+      [{:title "Add import 'java.util.Date'"
+        :command {:command "add-missing-import"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 6 2)
+                          (h/file-uri "file:///c.clj")
+                          6
+                          2
+                          [{:code    "unresolved-symbol"
+                            :message "Unresolved symbol: foo"
+                            :range   {:start {:line 5 :character 2}}}] {}
+                          db/db)))
   (testing "when it has unresolved-namespace and it's a common import via method"
     (h/assert-contains-submaps
-     [{:title "Add import 'java.util.Date'"
-       :command {:command "add-missing-import"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 7 2)
-                         (h/file-uri "file:///c.clj")
-                         7
-                         2
-                         [{:code  "unresolved-namespace"
-                           :range {:start {:line 6 :character 2}}}] {}
-                         db/db))))
+      [{:title "Add import 'java.util.Date'"
+        :command {:command "add-missing-import"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 7 2)
+                          (h/file-uri "file:///c.clj")
+                          7
+                          2
+                          [{:code  "unresolved-namespace"
+                            :range {:start {:line 6 :character 2}}}] {}
+                          db/db))))
 
 (deftest inline-symbol-code-action
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
@@ -228,14 +228,14 @@
                                       db/db))))
   (testing "when in let/def symbol"
     (h/assert-contains-submaps
-     [{:title "Inline symbol"
-       :command {:command "inline-symbol"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 5)
-                         (h/file-uri "file:///b.clj")
-                         4
-                         5
-                         [] {}
-                         db/db))))
+      [{:title "Inline symbol"
+        :command {:command "inline-symbol"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 5)
+                          (h/file-uri "file:///b.clj")
+                          4
+                          5
+                          [] {}
+                          db/db))))
 
 (deftest change-coll-code-action
   (h/load-code-and-locs (h/code "\"some string\""
@@ -254,24 +254,24 @@
                                       db/db))))
   (testing "when in a list"
     (h/assert-contains-submaps
-     [{:title "Change coll to map"
-       :command {:command "change-coll"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 1) (h/file-uri "file:///b.clj") 2 1 [] {} db/db)))
+      [{:title "Change coll to map"
+        :command {:command "change-coll"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 1) (h/file-uri "file:///b.clj") 2 1 [] {} db/db)))
   (testing "when in a map"
     (h/assert-contains-submaps
-     [{:title   "Change coll to vector"
-       :command {:command "change-coll"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 1) (h/file-uri "file:///b.clj") 3 1 [] {} db/db)))
+      [{:title   "Change coll to vector"
+        :command {:command "change-coll"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 1) (h/file-uri "file:///b.clj") 3 1 [] {} db/db)))
   (testing "when in a vector"
     (h/assert-contains-submaps
-     [{:title "Change coll to set"
-       :command {:command "change-coll"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1) (h/file-uri "file:///b.clj") 4 1 [] {} db/db)))
+      [{:title "Change coll to set"
+        :command {:command "change-coll"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1) (h/file-uri "file:///b.clj") 4 1 [] {} db/db)))
   (testing "when in a set"
     (h/assert-contains-submaps
-     [{:title "Change coll to list"
-       :command {:command "change-coll"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 5 1) (h/file-uri "file:///b.clj") 5 1 [] {} db/db))))
+      [{:title "Change coll to list"
+        :command {:command "change-coll"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 5 1) (h/file-uri "file:///b.clj") 5 1 [] {} db/db))))
 
 (deftest move-to-let-code-action
   (h/load-code-and-locs (h/code "(let [a 1"
@@ -289,14 +289,14 @@
                                       db/db))))
   (testing "when inside let form"
     (h/assert-contains-submaps
-     [{:title "Move to let"
-       :command {:command "move-to-let"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 3)
-                         (h/file-uri "file:///b.clj")
-                         3
-                         3
-                         [] {}
-                         db/db))))
+      [{:title "Move to let"
+        :command {:command "move-to-let"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 3)
+                          (h/file-uri "file:///b.clj")
+                          3
+                          3
+                          [] {}
+                          db/db))))
 
 (deftest cycle-privacy-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -312,14 +312,14 @@
                                       db/db))))
   (testing "when on function location"
     (h/assert-contains-submaps
-     [{:title "Cycle privacy"
-       :command {:command "cycle-privacy"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
-                         (h/file-uri "file:///a.clj")
-                         2
-                         5
-                         [] {}
-                         db/db))))
+      [{:title "Cycle privacy"
+        :command {:command "cycle-privacy"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+                          (h/file-uri "file:///a.clj")
+                          2
+                          5
+                          [] {}
+                          db/db))))
 
 (deftest extract-function-code-action
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -335,14 +335,14 @@
                                       db/db))))
   (testing "when on function location"
     (h/assert-contains-submaps
-     [{:title "Extract function"
-       :command {:command "extract-function"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
-                         (h/file-uri "file:///a.clj")
-                         2
-                         5
-                         [] {}
-                         db/db))))
+      [{:title "Extract function"
+        :command {:command "extract-function"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+                          (h/file-uri "file:///a.clj")
+                          2
+                          5
+                          [] {}
+                          db/db))))
 
 (deftest create-private-function-code-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -358,16 +358,16 @@
                                       db/db))))
   (testing "when in a unresolved symbol"
     (h/assert-contains-submaps
-     [{:title "Create private function 'some-func'"
-       :command {:command "create-function"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 10)
-                         (h/file-uri "file:///a.clj")
-                         2
-                         10
-                         [{:code    "unresolved-symbol"
-                           :message "Unresolved symbol: some-func"
-                           :range   {:start {:line 2 :character 11}}}] {}
-                         db/db))))
+      [{:title "Create private function 'some-func'"
+        :command {:command "create-function"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 10)
+                          (h/file-uri "file:///a.clj")
+                          2
+                          10
+                          [{:code    "unresolved-symbol"
+                            :message "Unresolved symbol: some-func"
+                            :range   {:start {:line 2 :character 11}}}] {}
+                          db/db))))
 
 (deftest thread-first-all-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -385,14 +385,14 @@
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 2) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a valid function that can be threaded"
     (h/assert-contains-submaps
-     [{:title "Thread first all"
-       :command {:command "thread-first-all"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
+      [{:title "Thread first all"
+        :command {:command "thread-first-all"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when on a non-list node"
     (h/assert-contains-submaps
-     [{:title "Thread first all"
-       :command {:command "thread-first-all"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+      [{:title "Thread first all"
+        :command {:command "thread-first-all"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
 
 (deftest thread-last-all-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -410,14 +410,14 @@
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 2) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a valid function that can be threaded"
     (h/assert-contains-submaps
-     [{:title "Thread last all"
-       :command {:command "thread-last-all"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
+      [{:title "Thread last all"
+        :command {:command "thread-last-all"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when on a non-list node"
     (h/assert-contains-submaps
-     [{:title "Thread last all"
-       :command {:command "thread-last-all"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+      [{:title "Thread last all"
+        :command {:command "thread-last-all"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
 
 (deftest unwind-thread-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -431,19 +431,19 @@
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
   (testing "when inside thread call"
     (h/assert-contains-submaps
-     [{:title "Unwind thread once"
-       :command {:command "unwind-thread"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
+      [{:title "Unwind thread once"
+        :command {:command "unwind-thread"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when inside thread symbol"
     (h/assert-contains-submaps
-     [{:title "Unwind thread once"
-       :command {:command "unwind-thread"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 2) (h/file-uri "file:///a.clj") 3 2 [] {} db/db)))
+      [{:title "Unwind thread once"
+        :command {:command "unwind-thread"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 2) (h/file-uri "file:///a.clj") 3 2 [] {} db/db)))
   (testing "when inside any threading call"
     (h/assert-contains-submaps
-     [{:title "Unwind thread once"
-       :command {:command "unwind-thread"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 5 7) (h/file-uri "file:///a.clj") 5 7 [] {} db/db))))
+      [{:title "Unwind thread once"
+        :command {:command "unwind-thread"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 5 7) (h/file-uri "file:///a.clj") 5 7 [] {} db/db))))
 
 (deftest clean-ns-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -474,14 +474,14 @@
   (testing "with workspace edit client capability"
     (swap! db/db assoc-in [:client-capabilities :workspace :workspace-edit] true)
     (h/assert-contains-submaps
-     [{:title "Clean namespace"
-       :command {:command "clean-ns"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
-                         (h/file-uri "file:///b.clj")
-                         2
-                         2
-                         [] {:workspace {:workspace-edit true}}
-                         db/db))))
+      [{:title "Clean namespace"
+        :command {:command "clean-ns"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
+                          (h/file-uri "file:///b.clj")
+                          2
+                          2
+                          [] {:workspace {:workspace-edit true}}
+                          db/db))))
 
 (deftest resolve-macro-as-code-actions
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -490,9 +490,9 @@
                                 "(+ 1 2)"))
   (testing "when inside a macro usage"
     (h/assert-contains-submaps
-     [{:title "Resolve macro 'some-ns/foo' as..."
-       :command {:command "resolve-macro-as"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7) (h/file-uri "file:///a.clj") 3 7 [] {} db/db)))
+      [{:title "Resolve macro 'some-ns/foo' as..."
+        :command {:command "resolve-macro-as"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7) (h/file-uri "file:///a.clj") 3 7 [] {} db/db)))
   (testing "when not inside a macro usage"
     (is (not-any? #(= (:title %) "Resolve macro 'some-ns/foo' as...")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4) (h/file-uri "file:///a.clj") 4 4 [] {} db/db)))))
@@ -503,17 +503,17 @@
                                 "(def ^:private a 1)"))
   (testing "unused-private-var"
     (h/assert-contains-submaps
-     [{:title "Suppress 'unused-private-var' diagnostic"
-       :command {:command "suppress-diagnostic"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
-                         (h/file-uri "file:///a.clj")
-                         3
-                         3
-                         [{:code    "unused-private-var"
-                           :message "Unused private var: a"
-                           :range   {:start {:line 3 :character 11}}}]
-                         {:workspace {:workspace-edit true}}
-                         db/db))))
+      [{:title "Suppress 'unused-private-var' diagnostic"
+        :command {:command "suppress-diagnostic"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
+                          (h/file-uri "file:///a.clj")
+                          3
+                          3
+                          [{:code    "unused-private-var"
+                            :message "Unused private var: a"
+                            :range   {:start {:line 3 :character 11}}}]
+                          {:workspace {:workspace-edit true}}
+                          db/db))))
 
 (deftest sort-map-actions
   (swap! db/db shared/deep-merge {:client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
@@ -523,26 +523,26 @@
                                 "  {:g 2 :s 3 :kj 3 :a 5})"))
   (testing "on map bracket"
     (h/assert-contains-submaps
-     [{:title "Sort map"
-       :command {:command "sort-map"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 3)
-                         (h/file-uri "file:///project/src/some_ns.clj")
-                         4
-                         3
-                         []
-                         {:workspace {:workspace-edit true}}
-                         db/db)))
+      [{:title "Sort map"
+        :command {:command "sort-map"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 3)
+                          (h/file-uri "file:///project/src/some_ns.clj")
+                          4
+                          3
+                          []
+                          {:workspace {:workspace-edit true}}
+                          db/db)))
   (testing "On map's key"
     (h/assert-contains-submaps
-     [{:title "Sort map"
-       :command {:command "sort-map"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 5)
-                         (h/file-uri "file:///project/src/some_ns.clj")
-                         4
-                         5
-                         []
-                         {:workspace {:workspace-edit true}}
-                         db/db)))
+      [{:title "Sort map"
+        :command {:command "sort-map"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 5)
+                          (h/file-uri "file:///project/src/some_ns.clj")
+                          4
+                          5
+                          []
+                          {:workspace {:workspace-edit true}}
+                          db/db)))
   (testing "not on map"
     (is (not-any? #(= (:title %) "Sort map")
                   (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7)
@@ -563,12 +563,12 @@
                         "file:///project/src/some_ns.clj")
   (testing "inside function"
     (h/assert-contains-submaps
-     [{:title "Create test for 'foo'"
-       :command {:command "create-test"}}]
-     (f.code-actions/all (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 3 6)
-                         (h/file-uri "file:///project/src/some_ns.clj")
-                         3
-                         6
-                         []
-                         {:workspace {:workspace-edit true}}
-                         db/db))))
+      [{:title "Create test for 'foo'"
+        :command {:command "create-test"}}]
+      (f.code-actions/all (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 3 6)
+                          (h/file-uri "file:///project/src/some_ns.clj")
+                          3
+                          6
+                          []
+                          {:workspace {:workspace-edit true}}
+                          db/db))))


### PR DESCRIPTION
Resolves #725 and fixes #722. This changes code actions (the action menu items) so that they always execute commands. This is as opposed to having them invoke "resolve code action". The rational for this change is in #725.

I have tested this in Emacs. The one strange behavior I noticed was that resolve-macro asks the same questions twice (to get the macro style and then the config file). I haven't check whether that's new behavior or old. In any case, the refactoring does work in the end.

I'd appreciate help testing this on other editors. I believe that all that is needed is a quick check that any of the action menu refactorings work, though to be thorough, all the [refactorings](https://clojure-lsp.io/features/#refactoring) could be checked. It would also be good to check the "interactive" menu items: resolve macro and create test.