### PR TITLE
doc: update XDG_CONFIG_HOME config directory to clojure-lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   - Improve classpath hash to consider invaliding cache when local root deps was changed.
   - Replace datalevin cache db with transit. #703
   - Bump Graalvm from 21.3.0 to 22.0.0.2 improving binary performance/size
-  
+  - Update `XDG_CONFIG_HOME` to clojure-lsp directory in doc/settings.md
+
 - Editor
   - Support going to namespace definition on an alias. #706
   - Add LSP `textDocument/declaration`, for now adding the making possible navigate to alias and namespaces declared on the namespace. #680

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,7 +20,7 @@ Example:
 ---
 ### Global
 
-For global settings which should work for all the projects using `clojure-lsp`, you just need to add the same configs to `~/.lsp/config.edn` or `$XDG_CONFIG_HOME/.lsp/config.edn`.
+For global settings which should work for all the projects using `clojure-lsp`, you just need to add the same configs to `~/.lsp/config.edn` or `$XDG_CONFIG_HOME/clojure-lsp/config.edn`.
 
 For an example of a global `config.edn`, check [here](https://github.com/ericdallo/dotfiles/blob/master/.lsp/config.edn).
 


### PR DESCRIPTION
Update the settings documentation to use `XDG_CONFIG_HOME/clojure-lsp` rather than `XDG_CONFIG_HOME/.lsp`