### PR TITLE
parallelize a part of `clean-ns!` via pmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - Fix exception during code actions calculation when in a invalid code of a map with not even key-pairs.
   - Don't return diagnostics for external files like files on jar dependencies, avoiding noise on lint when opening dependencies.
 
+- API/CLI
+  - Small performance improvment to `format`, `clean-ns`, `diagnostics`, and `rename` via parallelizing parts of the logic.
+
 ## 2022.02.01-20.02.32
 
 - General


### PR DESCRIPTION
Was taking a quick look at `clean-ns` to try to get a feel for where the time break-down for it was.

I decided to try replacing some `map`s with `pmap`s. The improvement isn't so great but still something, so figured I'd post a PR in case it looks worth upstreaming.

I'm assuming that mutations to the `db` atom are done in a parallizable way for `clean-ns` assuming each parallel unit is running over a distinct clojure file. If that isn't the case then this might be a dangerous change

## timing details

I ran `clojure-lsp clean-ns --dry` on two projects, both getting 2-3 second improvements, or the core clean-ns (not counting analysis) is now running in 0.7 the original time

averaging 3 runs on clojure-lsp repo itself: _before_ `7780ms`, _after_ `5480ms` (with analysis taking `~6000ms`)
averaging 3 runs on another larger repo: _before_ `11070ms`, _after_ `7691ms` (with analysis taking `~20000ms`)