### PR TITLE
Abort completion in comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Fix exception during code actions calculation when in a invalid code of a map with not even key-pairs.
   - Don't return diagnostics for external files like files on jar dependencies, avoiding noise on lint when opening dependencies.
   - Support finding implementations of defprotocol and references of defrecord/deftype, implementing LSP method `textDocument/implementation`. #656
+  - Don't return completions when invoked from a comment, avoiding performance problems. #756
 
 - API/CLI
   - Small performance improvment to `format`, `clean-ns`, `diagnostics`, and `rename` via parallelizing parts of the logic.

--- a/cli/integration-test/integration/completion_test.clj
+++ b/cli/integration-test/integration/completion_test.clj
@@ -40,4 +40,8 @@
          :insertText "(defn ${1:name} [$2]\n  ${0:body})"
          :insertTextFormat 2
          :data {:filename "/clojure.core.clj" :name "defn" :ns "clojure.core", :snippet-kind 6}}]
-       (lsp/request! (fixture/completion-request "completion/a.clj" 2 4))))))
+       (lsp/request! (fixture/completion-request "completion/a.clj" 2 4)))))
+  (testing "completions in whitespace"
+    (h/assert-submaps
+      []
+      (lsp/request! (fixture/completion-request "completion/a.clj" 4 3)))))

--- a/cli/integration-test/sample-test/src/sample_test/completion/a.clj
+++ b/cli/integration-test/sample-test/src/sample_test/completion/a.clj
@@ -1,3 +1,5 @@
 (ns sample-test.completion.a)
 
 (def some-var 1)
+
+;; comment

--- a/lib/test/clojure_lsp/features/completion_test.clj
+++ b/lib/test/clojure_lsp/features/completion_test.clj
@@ -98,8 +98,8 @@
       (f.completion/completion (h/file-uri "file:///g.clj") 2 18 db/db)))
   (testing "complete without prefix return all available completions"
     (is (< 100 (count (f.completion/completion (h/file-uri "file:///g.clj") 3 1 db/db)))))
-  (testing "complete comment"
-    (is (< 100 (count (f.completion/completion (h/file-uri "file:///h.clj") 1 10 db/db))))))
+  (testing "complete comment returns nothing"
+    (is (empty? (f.completion/completion (h/file-uri "file:///h.clj") 1 10 db/db)))))
 
 (deftest completing-full-ns
   (h/load-code-and-locs


### PR DESCRIPTION
This PR skips completion when inside of a comment, as discussed in #750.

@emilaasa if you urgently need to turn completion back on, but want to avoid the heavy CPU usage in comments, you can `make` this branch and use the resulting `clojure-lsp` executable. If it's not urgent, you can wait until this is merged. Note that this doesn't address any further performance issues with completion. If we decide to research that more, we should make a follow-up Issue.

@ericdallo this PR is built off #716. Only commit 4b5c5841e3b10b2ce345ad9233707f9090b4283f is relevant to skipping completion in comments. I had to base it off #716 because otherwise the code can't distinguish between comments (where we don't want completion) and whitespace (where we do).

