### PR TITLE
Print tail of log when integration tests fail or time out

### DIFF
--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -50,7 +50,7 @@
     (print-log-tail!))
   (original-report data))
 
-(defmacro report-log-tail
+(defmacro with-log-tail-report
   "Execute body with modified test reporting functions that prints log tail on failure."
   [& body]
   `(binding [original-report t/report
@@ -66,7 +66,7 @@
   (apply require namespaces)
 
   (let [test-results (timeout 600000
-                              #(report-log-tail
+                              #(with-log-tail-report
                                  (apply t/run-tests namespaces)))]
 
     (when (= test-results :timed-out)

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -35,7 +35,7 @@
     ret))
 
 (defn log-tail []
-  (:out (sh/sh "tail" "-n" "300" "/tmp/clojure-lsp.integration.out")))
+  (:out (sh/sh "tail" "-n" "300" "clojure-lsp.integration-test.out" :dir "integration-test/sample-test/")))
 
 (defn print-log-tail! []
   (binding [*out* *err*]

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -35,7 +35,7 @@
     ret))
 
 (defn log-tail []
-  (:out (sh/sh "tail" "-n" "100" "/tmp/clojure-lsp.integration.out")))
+  (:out (sh/sh "tail" "-n" "300" "/tmp/clojure-lsp.integration.out")))
 
 (defn print-log-tail! []
   (binding [*out* *err*]

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -1,6 +1,7 @@
 (ns entrypoint
   (:require
-   [clojure.test :as t]))
+   [clojure.test :as t]
+   [clojure.java.shell :as sh]))
 
 (def namespaces
   '[
@@ -33,6 +34,29 @@
       (future-cancel fut))
     ret))
 
+(defn log-tail []
+  (:out (sh/sh "tail" "-n" "100" "/tmp/clojure-lsp.integration.out")))
+
+(defn print-log-tail! []
+  (binding [*out* *err*]
+    (println "--- RECENT LOG OUTPUT ---")
+    (print (log-tail))
+    (println "--- END RECENT LOG OUTPUT ---")))
+
+(declare ^:dynamic original-report)
+
+(defn log-tail-report [data]
+  (when (contains? #{:fail :error} (:type data))
+    (print-log-tail!))
+  (original-report data))
+
+(defmacro report-log-tail
+  "Execute body with modified test reporting functions that prints log tail on failure."
+  [& body]
+  `(binding [original-report t/report
+             t/report log-tail-report]
+     ~@body))
+
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn run-all [& args]
   (when-not (first args)
@@ -42,9 +66,12 @@
   (apply require namespaces)
 
   (let [test-results (timeout 600000
-                              #(apply t/run-tests namespaces))]
+                              #(report-log-tail
+                                 (apply t/run-tests namespaces)))]
 
     (when (= test-results :timed-out)
+      (print-log-tail!)
+      (println)
       (println "Timeout running integration tests!")
       (System/exit 1))
 

--- a/cli/integration-test/sample-test/.lsp/config.edn
+++ b/cli/integration-test/sample-test/.lsp/config.edn
@@ -1,4 +1,4 @@
 {:linters {:clj-kondo {:ns-exclude-regex ""
                        :async-custom-lint? false}}
- :log-path "/tmp/clojure-lsp.integration.out"
+ :log-path "clojure-lsp.integration-test.out"
  :api {:exit-on-errors? false}}

--- a/cli/integration-test/sample-test/.lsp/config.edn
+++ b/cli/integration-test/sample-test/.lsp/config.edn
@@ -1,3 +1,4 @@
 {:linters {:clj-kondo {:ns-exclude-regex ""
                        :async-custom-lint? false}}
+ :log-path "/tmp/clojure-lsp.integration.out"
  :api {:exit-on-errors? false}}

--- a/cli/src/clojure_lsp/main.clj
+++ b/cli/src/clojure_lsp/main.clj
@@ -120,7 +120,7 @@
 (defn ^:private exit [status msg]
   (when msg
     (println msg))
-  (System/exit status))
+  (System/exit (or status 1)))
 
 (defn ^:private with-required-options [options required fn]
   (doseq [option required]
@@ -134,7 +134,7 @@
   (if (= "listen" action)
     (do
       (with-out-str @(server/run-server!))
-      {:exit-code 0})
+      {:result-code 0})
     (try
       (case action
         "pod" (pod/run-pod)


### PR DESCRIPTION
This prints a tail of the log when an integration tests fails, has an error, or times out. The need for this has been discussed in #704.

While implementing this, I noticed that the CLI throws an NPE when shutting down from the "listen" command. This PR also fixes that.

I don't love hard-coding the log file, but it seemed easier than trying to extract it from clojure-lsp, which is running in a separate process and which may have died. If you have other ideas, I'd be happy to try them.