### PR TITLE
Two fixes for param names when creating functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Don't return diagnostics for external files like files on jar dependencies, avoiding noise on lint when opening dependencies.
   - Support finding implementations of defprotocol and references of defrecord/deftype, implementing LSP method `textDocument/implementation`. #656
   - Don't return completions when invoked from a comment, avoiding performance problems. #756
+  - Fix small anomalies in parameter names of extracted private functions. #759 @mainej
 
 - API/CLI
   - Small performance improvment to `format`, `clean-ns`, `diagnostics`, and `rename` via parallelizing parts of the logic.

--- a/lib/test/clojure_lsp/refactor/transform_test.clj
+++ b/lib/test/clojure_lsp/refactor/transform_test.clj
@@ -517,12 +517,20 @@
              (-> "(defn a [b] (remove (partial |my-func 2) [1 2 3 4]))"
                  create-function
                  as-strings))))
-    (testing "creating from a annonymous function"
+    (testing "creating from an anonymous function"
       (h/clean-db!)
       (is (= [(h/code "(defn- my-func [arg1 element]"
                       "  )")
               (h/code "" "" "")]
              (-> "(defn a [b] (remove #(|my-func 2 %) [1 2 3 4]))"
+                 create-function
+                 as-strings))))
+    (testing "creating from an anonymous function with many args"
+      (h/clean-db!)
+      (is (= [(h/code "(defn- my-func [arg1 b element3 element2]"
+                      "  )")
+              (h/code "" "" "")]
+             (-> "(defn a [b] (#(|my-func 2 b %3 %2) 1 2 3 4))"
                  create-function
                  as-strings))))
     (testing "creating from a thread first macro with single arg"
@@ -535,7 +543,7 @@
                  as-strings))))
     (testing "creating from a thread first macro with multiple args"
       (h/clean-db!)
-      (is (= [(h/code "(defn- my-func [b a arg2]"
+      (is (= [(h/code "(defn- my-func [b a arg3]"
                       "  )")
               (h/code "" "" "")]
              (-> "(-> b (|my-func a 3) (+ 1 2))"


### PR DESCRIPTION
This includes two fixes to the way that parameters are named when creating private functions. First, it fixes an off-by-one error when naming parameters extracted from a thread-first context.

```clojure
  (-> b (|my-func 3) (+ 1 2))

  ;; BEFORE becomes...
  (defn- my-func [b arg1])

  ;; which is inconsistent with the result of extracting:
  (|my-func b 3)

  ;; AFTER, they both become
  (defn- my-func [b arg2])
```

Second, it improves support for naming parameters in anonymous functions.  The positional names of parameters are preserved.

```clojure
  #(my-func %3 b %2)

  ;; BEFORE becomes...
  (defn- my-func [arg1 b arg3])

  ;; AFTER
  (defn- my-func [element3 b element2])
```

This is to match the existing support for naming single parameters in anonymous functions.

```clojure
  #(my-func % b)

  ;; becomes
  (defn- my-func [element b])
```

It does not attempt to add support for [variadic parameters inside anonymous functions][1], because that would involve re-writting the call site and require creating a more complex parameter list.

[1]: https://www.clojure.org/guides/learn/functions#_anonymous_function_syntax
