### PR TITLE
Ignore kondo config nested under the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Small performance improvement on code actions calcullation.
   - Add `:use-source-paths-from-classpath` setting defaulting to true, which makes clojure-lsp do not manually discovery source-paths but get from classpath excluding jar files and paths outside project-root. #752 #551
   - Improve completion performance when all clojure.core or cljs.core symbols are valid completions. #764 @mainej
+  - Fix scenarios where the lint findings in individual files differed from what you'd expect based on the .clj-kondo/config.edn settings.
   
 - Editor
   - Fix exception during code actions calculation when in a invalid code of a map with not even key-pairs.


### PR DESCRIPTION
As discussed in this [thread][slack-thread], sometimes users would see
lint findings that didn't match their .clj-kondo config. This happened
both on the command line and in editors.

It was determined that if a user had, for example, both a .clj-kondo
directory and a lib/.clj-kondo directory, the settings in the second
would take precedence when clojure-lsp linted an individual file in
lib/.

The root config is used when invoking `clj-kondo` on the command line,
leading to different results depending on which tool linted the file.

We think that users never intend to have a nested config directory. If
they do, they should delete it, perhaps after merging its settings into
the root config directory.

But, to prevent confusion, this patch makes clojure-lsp ignore nested
config dirs when linting individual files.

- ~I created a issue to discuss the problem I am trying to solve or there is already a open issue.~ See [Slack thread][slack-thread].
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~

[slack-thread]: https://app.slack.com/client/T03RZGPFR/CPABC1H61/thread/CPABC1H61-1644946235.338589

