### PR TITLE
Try to expose errors on client side of integration tests

### DIFF
--- a/cli/integration-test/integration/initialize_test.clj
+++ b/cli/integration-test/integration/initialize_test.clj
@@ -94,4 +94,7 @@
     (lsp/await-notification :$/progress))
 
   (testing "initialized notification"
-    (lsp/notify! (fixture/initialized-notification))))
+    (lsp/notify! (fixture/initialized-notification))
+    (h/assert-submaps
+      [{:registerOptions {:watchers [{:globPattern "**/*.{clj,cljs,cljc,edn}"}]}}]
+      (:registrations (lsp/await-client-request :client/registerCapability)))))

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -55,9 +55,9 @@
       (try
         (binding [*in* *server-out*]
           (loop []
-          ;; Block, waiting for next Content-Length line, then discard it. If the
-          ;; server output stream is closed, also close the client by exiting
-          ;; this loop.
+            ;; Block, waiting for next Content-Length line, then discard it. If the
+            ;; server output stream is closed, also close the client by exiting
+            ;; this loop.
             (if-let [_content-length (read-line)]
               (let [{:keys [id method] :as json} (cheshire.core/parse-stream *in* true)] ;
                 (cond

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -2,7 +2,6 @@
   (:require
    [babashka.process :as p]
    [cheshire.core :as json]
-   [clojure.core.async :as async]
    [clojure.java.io :as io]
    [clojure.test :refer [use-fixtures]]
    [integration.helper :as h]))
@@ -44,7 +43,7 @@
 (defn ^:private keyname [key] (str (namespace key) "/" (name key)))
 
 (defn ^:private listen-output! []
-  (async/thread
+  (future
     (binding [*in* *stdout*]
       (loop []
         ;; Block, waiting for next Content-Length line, and discard it. If the
@@ -90,7 +89,7 @@
   (reset! server-notifications [])
   (reset! client-request-id 0)
   (when *clojure-lsp-listener*
-    (async/close! *clojure-lsp-listener*))
+    (future-cancel *clojure-lsp-listener*))
   (when *clojure-lsp-process*
     (p/destroy *clojure-lsp-process*)))
 

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -114,21 +114,20 @@
   (use-fixtures :each (fn [f] (clean!) (f)))
   (use-fixtures :once (fn [f] (f) (clean!))))
 
-(defn notify! [params]
-  (client-log :blue "sending notification:" params)
+(defn client-send [params]
   (binding [*out* *server-in*]
     (println (str "Content-Length: " (content-length params)))
     (println "")
     (println params)
     (flush)))
 
+(defn notify! [params]
+  (client-log :blue "sending notification:" params)
+  (client-send params))
+
 (defn request! [params]
   (client-log :cyan "sending request:" params)
-  (binding [*out* *server-in*]
-    (println (str "Content-Length: " (content-length params)))
-    (println "")
-    (println params)
-    (flush))
+  (client-send params)
   (loop [response (get @server-responses @client-request-id)]
     (if response
       (do

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -47,7 +47,7 @@
   ([color msg params]
    (client-log @client-id color msg params))
   ([client-id color msg params]
-   (println (colored color (str "Client " client-id ": " msg)) (colored :yellow params))))
+   (println (colored color (str "Client " client-id " " msg)) (colored :yellow params))))
 
 (defn ^:private listen-output! []
   (let [client-id (swap! client-id inc)]
@@ -63,24 +63,24 @@
                 (cond
                   (and id method)
                   (do
-                    (client-log client-id :magenta "Received request:" json)
+                    (client-log client-id :magenta "received request:" json)
                     (swap! server-requests conj json))
 
                   id
                   (do
-                    (client-log client-id :green "Received reponse:" json)
+                    (client-log client-id :green "received reponse:" json)
                     (swap! server-responses assoc id json))
 
                   :else
                   (do
-                    (client-log client-id :blue "Received notification:" json)
+                    (client-log client-id :blue "received notification:" json)
                     (swap! server-notifications conj json)))
                 (recur))
               (do
-                (client-log client-id :red "Closed:" "server closed")
+                (client-log client-id :red "closed:" "server closed")
                 (flush)))))
         (catch Throwable e
-          (client-log client-id :red "Closed:" "exception")
+          (client-log client-id :red "closed:" "exception")
           (println e)
           (throw e))))))
 
@@ -102,7 +102,7 @@
   (reset! server-notifications [])
   (reset! client-request-id 0)
   (when *clojure-lsp-listener*
-    (client-log :red "Closing:" "test cleanup")
+    (client-log :red "closing:" "test cleanup")
     (flush)
     (future-cancel *clojure-lsp-listener*)
     (alter-var-root #'*clojure-lsp-listener* (constantly nil)))
@@ -115,7 +115,7 @@
   (use-fixtures :once (fn [f] (f) (clean!))))
 
 (defn notify! [params]
-  (client-log :blue "Sending notification:" params)
+  (client-log :blue "sending notification:" params)
   (binding [*out* *server-in*]
     (println (str "Content-Length: " (content-length params)))
     (println "")
@@ -123,7 +123,7 @@
     (flush)))
 
 (defn request! [params]
-  (client-log :cyan "Sending request:" params)
+  (client-log :cyan "sending request:" params)
   (binding [*out* *server-in*]
     (println (str "Content-Length: " (content-length params)))
     (println "")

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -55,11 +55,11 @@
       (try
         (binding [*in* *server-out*]
           (loop []
-            ;; Block, waiting for next Content-Length line, then discard it. If the
-            ;; server output stream is closed, also close the client by exiting
-            ;; this loop.
+            ;; Block, waiting for next Content-Length line, then discard it. If
+            ;; the server output stream is closed, also close the client by
+            ;; exiting this loop.
             (if-let [_content-length (read-line)]
-              (let [{:keys [id method] :as json} (cheshire.core/parse-stream *in* true)] ;
+              (let [{:keys [id method] :as json} (cheshire.core/parse-stream *in* true)]
                 (cond
                   (and id method)
                   (do

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -70,7 +70,7 @@
                   (swap! server-notifications conj json)))
               (recur))
             (do
-              (println (colored :red (str "Client " client-id " closed")))
+              (println (colored :red (str "Client " client-id " closed:")) (colored :yellow "server closed"))
               (flush))))))))
 
 (defn start-process! []
@@ -91,9 +91,13 @@
   (reset! server-notifications [])
   (reset! client-request-id 0)
   (when *clojure-lsp-listener*
-    (future-cancel *clojure-lsp-listener*))
+    (println (colored :red (str "Client " @client-id " closing:")) (colored :yellow "test cleanup"))
+    (flush)
+    (future-cancel *clojure-lsp-listener*)
+    (alter-var-root #'*clojure-lsp-listener* (constantly nil)))
   (when *clojure-lsp-process*
-    (p/destroy *clojure-lsp-process*)))
+    (p/destroy *clojure-lsp-process*)
+    (alter-var-root #'*clojure-lsp-process* (constantly nil))))
 
 (defn clean-after-test []
   (use-fixtures :each (fn [f] (clean!) (f)))


### PR DESCRIPTION
While researching [flaky integration tests][flaky-tests] we noticed that sometimes a test will [time out][time-out] because the server has sent a response, but the client fails to read it. No exceptions are logged, the tests just hang waiting for the client to do something.

The client runs in a separate thread, looping over and parsing the server's output.

This commit removes an exception handler in the client loop. The handler was using an IOException as a signal that the server's output stream had closed, and that therefore the client could close too. We now use a different mechanism of detecting that the server has closed.

Though this is speculative, we hope is that this will expose unexpected IOExceptions, which could have caused the client to stop responding.

[flaky-tests]: https://github.com/clojure-lsp/clojure-lsp/issues/704
[time-out]: https://github.com/clojure-lsp/clojure-lsp/pull/757#issuecomment-1035760361