### PR TITLE
Fix and accelerate clojure.core completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - Small performance improvement during startup on unused-public-var calculation parallelizing calculations.
   - Small performance improvement on code actions calcullation.
   - Add `:use-source-paths-from-classpath` setting defaulting to true, which makes clojure-lsp do not manually discovery source-paths but get from classpath excluding jar files and paths outside project-root. #752 #551
-  - Improve completion performance when all clojure.core or cljs.core symbols are valid completions. #764 @mainej
+  - Improve completion performance when all clojure.core or cljs.core symbols are valid completions. #764, #771 @mainej
   - Fix scenarios where the lint findings in individual files differed from what you'd expect based on the .clj-kondo/config.edn settings.
   
 - Editor

--- a/cli/integration-test/integration/completion_test.clj
+++ b/cli/integration-test/integration/completion_test.clj
@@ -41,30 +41,6 @@
          :insertTextFormat 2
          :data {:filename "/clojure.core.clj" :name "defn" :ns "clojure.core", :snippet-kind 6}}]
        (lsp/request! (fixture/completion-request "completion/a.clj" 2 4)))))
-  (testing "completions from whitespace"
-    (let [completions (lsp/request! (fixture/completion-request "completion/a.clj" 3 1))]
-      (is (< 800 (count completions)))
-      (h/assert-contains-submaps
-        [{:label "Map"
-          :kind 7
-          :detail "java.util.Map"}
-         {:label "vec"
-          :kind 3
-          :detail "clojure.core/vec"
-          :data {:filename "/clojure.core.clj", :name "vec", :ns "clojure.core"}}]
-        completions))
-    (let [completions (lsp/request! (fixture/completion-request "completion/a.cljs" 3 1))]
-      (is (< 800 (count completions)))
-      (h/assert-contains-submaps
-        [{:label "clj->js"
-          :kind 18
-          :detail "cljs.core/clj->js"
-          :data {:filename "/cljs.core.cljs", :name "clj->js", :ns "cljs.core"}}
-         {:label "vec"
-          :kind 3
-          :detail "clojure.core/vec"
-          :data {:filename "/clojure.core.clj", :name "vec", :ns "clojure.core"}}]
-        completions)))
   (testing "completions from comment"
     (h/assert-submaps
       []

--- a/cli/integration-test/integration/completion_test.clj
+++ b/cli/integration-test/integration/completion_test.clj
@@ -52,6 +52,18 @@
           :kind 3
           :detail "clojure.core/vec"
           :data {:filename "/clojure.core.clj", :name "vec", :ns "clojure.core"}}]
+        completions))
+    (let [completions (lsp/request! (fixture/completion-request "completion/a.cljs" 3 1))]
+      (is (< 800 (count completions)))
+      (h/assert-contains-submaps
+        [{:label "clj->js"
+          :kind 18
+          :detail "cljs.core/clj->js"
+          :data {:filename "/cljs.core.cljs", :name "clj->js", :ns "cljs.core"}}
+         {:label "vec"
+          :kind 3
+          :detail "clojure.core/vec"
+          :data {:filename "/clojure.core.clj", :name "vec", :ns "clojure.core"}}]
         completions)))
   (testing "completions from comment"
     (h/assert-submaps

--- a/cli/integration-test/integration/completion_test.clj
+++ b/cli/integration-test/integration/completion_test.clj
@@ -1,6 +1,6 @@
 (ns integration.completion-test
   (:require
-   [clojure.test :refer [deftest testing]]
+   [clojure.test :refer [deftest is testing]]
    [integration.fixture :as fixture]
    [integration.helper :as h]
    [integration.lsp :as lsp]))
@@ -36,12 +36,24 @@
       (h/assert-contains-submaps
        [{:label "defn"
          :kind 15
-         :detail "clojure.core/defn" 
+         :detail "clojure.core/defn"
          :insertText "(defn ${1:name} [$2]\n  ${0:body})"
          :insertTextFormat 2
          :data {:filename "/clojure.core.clj" :name "defn" :ns "clojure.core", :snippet-kind 6}}]
        (lsp/request! (fixture/completion-request "completion/a.clj" 2 4)))))
-  (testing "completions in whitespace"
+  (testing "completions from whitespace"
+    (let [completions (lsp/request! (fixture/completion-request "completion/a.clj" 3 1))]
+      (is (< 800 (count completions)))
+      (h/assert-contains-submaps
+        [{:label "Map"
+          :kind 7
+          :detail "java.util.Map"}
+         {:label "vec"
+          :kind 3
+          :detail "clojure.core/vec"
+          :data {:filename "/clojure.core.clj", :name "vec", :ns "clojure.core"}}]
+        completions)))
+  (testing "completions from comment"
     (h/assert-submaps
       []
       (lsp/request! (fixture/completion-request "completion/a.clj" 4 3)))))

--- a/cli/integration-test/integration/completion_test.clj
+++ b/cli/integration-test/integration/completion_test.clj
@@ -1,6 +1,6 @@
 (ns integration.completion-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest testing]]
    [integration.fixture :as fixture]
    [integration.helper :as h]
    [integration.lsp :as lsp]))

--- a/cli/integration-test/sample-test/src/sample_test/completion/a.cljs
+++ b/cli/integration-test/sample-test/src/sample_test/completion/a.cljs
@@ -1,5 +1,0 @@
-(ns sample-test.completion.a)
-
-(def some-var 1)
-
-;; comment

--- a/cli/integration-test/sample-test/src/sample_test/completion/a.cljs
+++ b/cli/integration-test/sample-test/src/sample_test/completion/a.cljs
@@ -1,0 +1,5 @@
+(ns sample-test.completion.a)
+
+(def some-var 1)
+
+;; comment

--- a/lib/test/clojure_lsp/features/completion_test.clj
+++ b/lib/test/clojure_lsp/features/completion_test.clj
@@ -17,7 +17,8 @@
                                 "alp"
                                 "ba") (h/file-uri "file:///b.clj"))
   (h/load-code-and-locs (h/code "(ns alpaca.ns)"
-                                "(def baff)") (h/file-uri "file:///c.cljs"))
+                                "(def baff)"
+                                "clj-") (h/file-uri "file:///c.cljs"))
   (h/load-code-and-locs (h/code "(ns d (:require [alpaca.ns :as alpaca])) frequen"
                                 "(def bar \"some good docs\"123)"
                                 "(defn barbaz [a b] 123)"
@@ -74,6 +75,9 @@
        {:label "alpaca/bazz" :kind :variable}]
       (f.completion/completion (h/file-uri "file:///a.cljc") 2 8 db/db)))
   (testing "complete-core-stuff"
+    (h/assert-submaps
+      [{:label "clj->js", :detail "cljs.core/clj->js"}]
+      (f.completion/completion (h/file-uri "file:///c.cljs") 3 4 db/db))
     (h/assert-submaps
       [{:label "frequencies", :detail "clojure.core/frequencies"}]
       (f.completion/completion (h/file-uri "file:///d.clj") 1 49 db/db))


### PR DESCRIPTION
Make completion of clojure.core more consistent by using queries. Returns slightly fewer results, because of de-duplication. Also, change filtering order to slightly improve performance of completion, especially for completions with more given characters.

This is an extension of #764.
