### PR TITLE
Tidy require/import code actions and refactorings

### DIFF
--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -150,10 +150,8 @@
    (let [[[row col] :as positions] (load-code-and-locs code uri)]
      (let [position-count (count positions)]
        (assert (= 1 position-count) (format "Expected one cursor, got %s" position-count)))
-     (-> @db/db
-         (get-in [:documents uri])
-         :text
-         (parser/loc-at-pos row col)))))
+     (-> (parser/zloc-of-file @db/db uri)
+         (parser/to-pos row col)))))
 
 (defn zloc-from-code
   "Parse a zloc from a `code` block. Useful for refactorings that do not consult
@@ -162,4 +160,5 @@
   (let [[code [[row col] :as positions]] (positions-from-text code)]
     (let [position-count (count positions)]
       (assert (= 1 position-count) (format "Expected one cursor, got %s" position-count)))
-    (parser/loc-at-pos code row col)))
+    (-> (parser/zloc-of-string code)
+        (parser/to-pos row col))))

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -338,6 +338,7 @@
 (defn clean-ns-edits
   [zloc uri db]
   (let [settings (settings/all db)
+        ;; TODO: use parser?
         safe-loc (or zloc (z/of-string (get-in @db [:documents uri :text])))
         ns-loc (edit/find-namespace safe-loc)
         analysis (:analysis @db)

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -10,89 +10,63 @@
    [clojure-lsp.shared :as shared]
    [clojure.string :as string]
    [medley.core :as medley]
-   [rewrite-clj.zip :as z]
-   [taoensso.timbre :as log]))
+   [rewrite-clj.zip :as z]))
 
 (set! *warn-on-reflection* true)
 
-(defn ^:private find-require-suggestions [uri missing-requires db diagnostic]
-  (let [{{:keys [line character] :as position} :start} (:range diagnostic)]
-    (when-let [diagnostic-zloc (parser/safe-cursor-loc uri line character db)]
-      (->> (f.add-missing-libspec/find-require-suggestions diagnostic-zloc missing-requires db)
-           (map #(assoc % :position position))))))
+(defn ^:private diagnostics-with-code [code-set diagnostics]
+  (filter (comp code-set :code) diagnostics))
 
-(defn ^:private find-all-require-suggestions [uri diagnostics missing-requires db]
-  (let [unresolved-ns-diags (filter #(= "unresolved-namespace" (:code %)) diagnostics)
-        unresolved-symbol-diags (filter #(= "unresolved-symbol" (:code %)) diagnostics)]
-    (->> (cond-> []
+(defn ^:private resolvable-diagnostics [diagnostics uri db]
+  (when-let [root-zloc (parser/safe-zloc-of-file @db uri)]
+    (->> diagnostics
+         (diagnostics-with-code #{"unresolved-namespace" "unresolved-symbol" "unresolved-var"})
+         (keep (fn [{{{:keys [line character] :as position} :start} :range :as diagnostic}]
+                 (when-let [zloc (parser/to-cursor root-zloc line character)]
+                   (assoc diagnostic
+                          :zloc     zloc
+                          :position position)))))))
 
-           (seq unresolved-ns-diags)
-           (into (map (partial find-require-suggestions uri missing-requires db)) unresolved-ns-diags)
+(defn ^:private find-require-suggestions [db {:keys [position zloc]}]
+  (->> (f.add-missing-libspec/find-require-suggestions zloc db)
+       (map #(assoc % :position position))))
 
-           (seq unresolved-symbol-diags)
-           (into (map (partial find-require-suggestions uri missing-requires db)) unresolved-symbol-diags))
-         flatten
-         (remove nil?))))
+(defn ^:private find-all-require-suggestions [diagnostics missing-requires db]
+  (->> diagnostics
+       (mapcat (partial find-require-suggestions db))
+       (remove (fn [suggestion]
+                 (some (comp #{(:ns suggestion)} :ns)
+                       missing-requires)))))
 
-(defn ^:private find-missing-require [uri db diagnostic]
-  (let [{{:keys [line character] :as position} :start} (:range diagnostic)]
-    (when-let [diagnostic-zloc (parser/safe-cursor-loc uri line character db)]
-      (when-let [missing-require (f.add-missing-libspec/find-missing-ns-require diagnostic-zloc db)]
-        (assoc missing-require :position position)))))
+(defn ^:private find-missing-require [db {:keys [position zloc]}]
+  (some-> (f.add-missing-libspec/find-missing-ns-require zloc db)
+          (assoc :position position)))
 
-(defn ^:private find-missing-requires [uri diagnostics db]
-  (let [unresolved-ns-diags (filter #(= "unresolved-namespace" (:code %)) diagnostics)
-        unresolved-symbol-diags (filter #(= "unresolved-symbol" (:code %)) diagnostics)]
-    (->> (cond-> []
+(defn ^:private find-missing-requires [diagnostics db]
+  (keep (partial find-missing-require db) diagnostics))
 
-           (seq unresolved-ns-diags)
-           (into (map (partial find-missing-require uri db) unresolved-ns-diags))
+(defn ^:private find-missing-import [{:keys [position zloc]}]
+  (when-let [missing-import (f.add-missing-libspec/find-missing-import zloc)]
+    {:missing-import missing-import
+     :position       position}))
 
-           (seq unresolved-symbol-diags)
-           (into (map (partial find-missing-require uri db) unresolved-symbol-diags)))
-         (remove nil?))))
+(defn ^:private find-missing-imports [diagnostics]
+  (keep find-missing-import diagnostics))
 
-(defn ^:private find-missing-import [uri db diagnostic]
-  (let [{{:keys [line character] :as position} :start} (:range diagnostic)]
-    (when-let [diagnostic-zloc (parser/safe-cursor-loc uri line character db)]
-      (when-let [missing-import (f.add-missing-libspec/find-missing-import diagnostic-zloc)]
-        {:missing-import missing-import
-         :position position}))))
-
-(defn ^:private find-missing-imports [uri diagnostics db]
-  (let [unresolved-ns-diags (filter #(= "unresolved-namespace" (:code %)) diagnostics)
-        unresolved-symbol-diags (filter #(= "unresolved-symbol" (:code %)) diagnostics)]
-    (->> (cond-> []
-
-           (seq unresolved-ns-diags)
-           (into (map (partial find-missing-import uri db) unresolved-ns-diags))
-
-           (seq unresolved-symbol-diags)
-           (into (map (partial find-missing-import uri db) unresolved-symbol-diags)))
-         (remove nil?))))
-
-(defn ^:private find-private-function-to-create [uri diagnostics db]
-  (when-let [{{{:keys [line character] :as position} :start} :range :as diag} (->> diagnostics
-                                                                                   (filter #(= "unresolved-symbol" (:code %)))
-                                                                                   first)]
-    (when-let [diag-loc (parser/safe-cursor-loc uri line character db)]
-      (when (r.transform/can-create-function? diag-loc)
-        {:name (last (string/split (:message diag) #"Unresolved symbol: "))
-         :position position}))))
+(defn ^:private find-private-function-to-create [diagnostics]
+  (when-let [{:keys [message position zloc]} (->> diagnostics
+                                                  (diagnostics-with-code #{"unresolved-symbol"})
+                                                  first)]
+    (when (r.transform/can-create-function? zloc)
+      {:name     (last (string/split message #"Unresolved symbol: "))
+       :position position})))
 
 (defn ^:private find-public-function-to-create [uri diagnostics db]
-  (when-let [{{{:keys [line character] :as position} :start} :range} (->> diagnostics
-                                                                          (filter #(or (= "unresolved-var" (:code %))
-                                                                                       (= "unresolved-namespace" (:code %))))
-                                                                          first)]
-    (when-let [diag-loc (parser/safe-cursor-loc uri line character db)]
-      (when (and (some-> diag-loc z/tag (= :token))
-                 (some-> diag-loc z/sexpr namespace))
-        (when-let [{:keys [new-ns ns name]} (r.transform/can-create-public-function? diag-loc uri db)]
-          {:ns ns
-           :new-ns new-ns
-           :name name
-           :position position})))))
+  (when-let [{:keys [zloc position]} (->> diagnostics
+                                          (diagnostics-with-code #{"unresolved-var" "unresolved-namespace"})
+                                          first)]
+    (some-> (r.transform/find-public-function-to-create zloc uri db)
+            (assoc :position position))))
 
 (defn ^:private require-suggestion-actions
   [uri alias-suggestions]
@@ -263,19 +237,21 @@
 (defn all [zloc uri row col diagnostics client-capabilities db]
   (let [line (dec row)
         character (dec col)
+        resolvable-diagnostics (resolvable-diagnostics diagnostics uri db)
         workspace-edit-capability? (get-in client-capabilities [:workspace :workspace-edit])
         inside-function?* (future (r.transform/find-function-form zloc))
-        private-function-to-create* (future (find-private-function-to-create uri diagnostics db))
-        public-function-to-create* (future (find-public-function-to-create uri diagnostics db))
+        private-function-to-create* (future (find-private-function-to-create resolvable-diagnostics))
+        public-function-to-create* (future (find-public-function-to-create uri resolvable-diagnostics db))
         inside-let?* (future (r.transform/find-let-form zloc))
         other-colls* (future (r.transform/find-other-colls zloc))
         can-thread?* (future (r.transform/can-thread? zloc))
         can-unwind-thread?* (future (r.transform/can-unwind-thread? zloc))
         can-create-test?* (future (r.transform/can-create-test? zloc uri db))
         macro-sym* (future (f.resolve-macro/find-full-macro-symbol-to-resolve zloc uri db))
-        missing-requires* (future (find-missing-requires uri diagnostics db))
-        missing-imports* (future (find-missing-imports uri diagnostics db))
-        require-suggestions* (future (find-all-require-suggestions uri diagnostics @missing-requires* db))
+        resolvable-require-diagnostics (diagnostics-with-code #{"unresolved-namespace" "unresolved-symbol"} resolvable-diagnostics)
+        missing-requires* (future (find-missing-requires resolvable-require-diagnostics db))
+        missing-imports* (future (find-missing-imports resolvable-require-diagnostics))
+        require-suggestions* (future (find-all-require-suggestions resolvable-require-diagnostics @missing-requires* db))
         allow-sort-map?* (future (f.sort-map/sortable-map-zloc zloc))
         allow-move-entry-up?* (future (f.move-coll-entry/can-move-entry-up? zloc uri db))
         allow-move-entry-down?* (future (f.move-coll-entry/can-move-entry-down? zloc uri db))

--- a/lib/src/clojure_lsp/feature/signature_help.clj
+++ b/lib/src/clojure_lsp/feature/signature_help.clj
@@ -77,8 +77,10 @@
 
 (defn signature-help [uri row col db]
   (let [filename (shared/uri->filename uri)
-        zloc (-> (f.file-management/force-get-document-text uri db)
-                 (parser/loc-at-pos row col))
+        zloc (some-> (f.file-management/force-get-document-text uri db)
+                     ;; TODO: use safe-zloc-of-string and handle nils
+                     (parser/zloc-of-string)
+                     (parser/to-pos row col))
         function-loc (edit/find-function-usage-name-loc zloc)]
     (when function-loc
       (let [arglist-nodes (function-loc->arglist-nodes function-loc)

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -291,10 +291,9 @@
           character (-> range :start :character)
           row (inc line)
           col (inc character)
-          zloc (some-> (parser/safe-zloc-of-file @db/db textDocument)
-                       (parser/to-pos row col))
+          root-zloc (parser/safe-zloc-of-file @db/db textDocument)
           client-capabilities (get @db/db :client-capabilities)]
-      (f.code-actions/all zloc textDocument row col diagnostics client-capabilities db/db))))
+      (f.code-actions/all root-zloc textDocument row col diagnostics client-capabilities db/db))))
 
 (defn code-lens
   [{:keys [textDocument]}]

--- a/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
+++ b/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
@@ -53,7 +53,7 @@
                                       foo.bar-test})))))
 
 (defn find-require-suggestions [code]
-  (f.add-missing-libspec/find-require-suggestions (h/zloc-from-code code) [] db/db))
+  (f.add-missing-libspec/find-require-suggestions (h/zloc-from-code code) db/db))
 
 (deftest find-require-suggestions-test
   (testing "Suggested namespaces"

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -10,11 +10,9 @@
 
 (h/reset-db-after-test)
 
-(defn zloc-at [file row col]
-  (-> @db/db
-      (get-in [:documents file])
-      :text
-      (parser/loc-at-pos row col)))
+(defn zloc-at [uri row col]
+  (-> (parser/safe-zloc-of-file @db/db uri)
+      (parser/to-pos row col)))
 
 (deftest add-alias-suggestion-code-actions
   (h/load-code-and-locs "(ns clojure.set)" (h/file-uri "file:///clojure.core.clj"))

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -10,9 +10,8 @@
 
 (h/reset-db-after-test)
 
-(defn zloc-at [uri row col]
-  (-> (parser/safe-zloc-of-file @db/db uri)
-      (parser/to-pos row col)))
+(defn zloc-of [uri]
+  (parser/safe-zloc-of-file @db/db uri))
 
 (deftest add-alias-suggestion-code-actions
   (h/load-code-and-locs "(ns clojure.set)" (h/file-uri "file:///clojure.core.clj"))
@@ -27,7 +26,7 @@
     (h/assert-contains-submaps
       [{:title "Add require '[clojure.set :as set]'"
         :command {:command "add-require-suggestion"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 4)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           2
                           4
@@ -38,7 +37,7 @@
     (h/assert-contains-submaps
       [{:title "Add require '[medley.core :as medley]'"
         :command {:command "add-require-suggestion"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 4)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           3
                           4
@@ -51,7 +50,7 @@
         :command {:command "add-require-suggestion"}}
        {:title "Add require '[clojure.data.json :as data.json]'"
         :command {:command "add-require-suggestion"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           4
                           4
@@ -70,7 +69,7 @@
     (h/assert-contains-submaps
       [{:title "Add require '[medley.core :refer [unit]]'"
         :command {:command "add-require-suggestion"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 3)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           2
                           3
@@ -82,7 +81,7 @@
     (h/assert-contains-submaps
       [{:title   "Add require '[clojure.set :refer [union]]'"
         :command {:command "add-require-suggestion"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           3
                           3
@@ -110,7 +109,7 @@
                         (h/file-uri "file:///c.clj"))
   (testing "when it has not unresolved-namespace diagnostic"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 2 10)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                                       (h/file-uri "file:///c.clj")
                                       2
                                       10
@@ -120,7 +119,7 @@
     (h/assert-contains-submaps
       [{:title "Add require '[some-ns :as sns]'"
         :command {:command "add-missing-libspec"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 3 11)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")
                           3
                           11
@@ -129,7 +128,7 @@
                           db/db)))
   (testing "when it has unresolved-namespace but cannot find namespace"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 2 11)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                                       (h/file-uri "file:///c.clj")
                                       2
                                       11
@@ -140,7 +139,7 @@
     (h/assert-contains-submaps
       [{:title "Add require '[clojure.test :refer [deftest]]'"
         :command {:command "add-missing-libspec"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 2)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")
                           4
                           2
@@ -149,7 +148,7 @@
                           db/db)))
   (testing "when it has unresolved-symbol but it's not a known refer"
     (is (not-any? #(string/starts-with? (:title %) "Add require")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 4 11)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                                       (h/file-uri "file:///c.clj")
                                       4
                                       11
@@ -169,7 +168,7 @@
                         (h/file-uri "file:///c.clj"))
   (testing "when it has no unresolved-symbol diagnostic"
     (is (not-any? #(string/starts-with? (:title %) "Add import")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 5 2)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                                       (h/file-uri "file:///c.clj")
                                       5
                                       2
@@ -178,7 +177,7 @@
 
   (testing "when it has unresolved-symbol but it's not a common import"
     (is (not-any? #(string/starts-with? (:title %) "Add import")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 5 2)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                                       (h/file-uri "file:///c.clj")
                                       5
                                       2
@@ -190,7 +189,7 @@
     (h/assert-contains-submaps
       [{:title "Add import 'java.util.Date'"
         :command {:command "add-missing-import"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 6 2)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")
                           6
                           2
@@ -202,7 +201,7 @@
     (h/assert-contains-submaps
       [{:title "Add import 'java.util.Date'"
         :command {:command "add-missing-import"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///c.clj") 7 2)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")
                           7
                           2
@@ -218,7 +217,7 @@
                         (h/file-uri "file:///b.clj"))
   (testing "when in not a let/def symbol"
     (is (not-any? #(= (:title %) "Inline symbol")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 8)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                                       (h/file-uri "file:///b.clj")
                                       4
                                       8
@@ -228,7 +227,7 @@
     (h/assert-contains-submaps
       [{:title "Inline symbol"
         :command {:command "inline-symbol"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 5)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                           (h/file-uri "file:///b.clj")
                           4
                           5
@@ -244,7 +243,7 @@
                         (h/file-uri "file:///b.clj"))
   (testing "when in not a coll"
     (is (not-any? #(= (:title %) "Change coll to")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 1 1)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                                       (h/file-uri "file:///b.clj")
                                       1
                                       1
@@ -254,22 +253,22 @@
     (h/assert-contains-submaps
       [{:title "Change coll to map"
         :command {:command "change-coll"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 1) (h/file-uri "file:///b.clj") 2 1 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj")) (h/file-uri "file:///b.clj") 2 1 [] {} db/db)))
   (testing "when in a map"
     (h/assert-contains-submaps
       [{:title   "Change coll to vector"
         :command {:command "change-coll"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 1) (h/file-uri "file:///b.clj") 3 1 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj")) (h/file-uri "file:///b.clj") 3 1 [] {} db/db)))
   (testing "when in a vector"
     (h/assert-contains-submaps
       [{:title "Change coll to set"
         :command {:command "change-coll"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1) (h/file-uri "file:///b.clj") 4 1 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj")) (h/file-uri "file:///b.clj") 4 1 [] {} db/db)))
   (testing "when in a set"
     (h/assert-contains-submaps
       [{:title "Change coll to list"
         :command {:command "change-coll"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 5 1) (h/file-uri "file:///b.clj") 5 1 [] {} db/db))))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj")) (h/file-uri "file:///b.clj") 5 1 [] {} db/db))))
 
 (deftest move-to-let-code-action
   (h/load-code-and-locs (h/code "(let [a 1"
@@ -279,7 +278,7 @@
                         (h/file-uri "file:///b.clj"))
   (testing "when not inside a let form"
     (is (not-any? #(= (:title %) "Move to let")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 4 1)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                                       (h/file-uri "file:///b.clj")
                                       4
                                       1
@@ -289,7 +288,7 @@
     (h/assert-contains-submaps
       [{:title "Move to let"
         :command {:command "move-to-let"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 3 3)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                           (h/file-uri "file:///b.clj")
                           3
                           3
@@ -302,7 +301,7 @@
                         (h/file-uri "file:///a.clj"))
   (testing "when non function location"
     (is (not-any? #(= (:title %) "Cycle privacy")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 5)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                                       (h/file-uri "file:///a.clj")
                                       1
                                       5
@@ -312,7 +311,7 @@
     (h/assert-contains-submaps
       [{:title "Cycle privacy"
         :command {:command "cycle-privacy"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           2
                           5
@@ -325,7 +324,7 @@
                         (h/file-uri "file:///a.clj"))
   (testing "when non function location"
     (is (not-any? #(= (:title %) "Extract function")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 5)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                                       (h/file-uri "file:///a.clj")
                                       1
                                       5
@@ -335,7 +334,7 @@
     (h/assert-contains-submaps
       [{:title "Extract function"
         :command {:command "extract-function"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 5)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           2
                           5
@@ -348,7 +347,7 @@
                                 "(def bar (some-func 1 2))"))
   (testing "when not in a unresolved symbol"
     (is (not-any? #(= (:title %) "Create private function")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 10)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                                       (h/file-uri "file:///a.clj")
                                       1
                                       10
@@ -358,7 +357,7 @@
     (h/assert-contains-submaps
       [{:title "Create private function 'some-func'"
         :command {:command "create-function"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 10)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           2
                           10
@@ -374,23 +373,23 @@
                         (h/file-uri "file:///a.clj"))
   (testing "when in a ns or :require"
     (is (not-any? #(= (:title %) "Thread first all")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
   (testing "when in a def similar location"
     (is (not-any? #(= (:title %) "Thread first all")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 1) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a def non-list node"
     (is (not-any? #(= (:title %) "Thread first all")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 2) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 2 2 [] {} db/db))))
   (testing "when on a valid function that can be threaded"
     (h/assert-contains-submaps
       [{:title "Thread first all"
         :command {:command "thread-first-all"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when on a non-list node"
     (h/assert-contains-submaps
       [{:title "Thread first all"
         :command {:command "thread-first-all"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 3 [] {} db/db))))
 
 (deftest thread-last-all-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -399,23 +398,23 @@
                         (h/file-uri "file:///a.clj"))
   (testing "when in a ns or :require"
     (is (not-any? #(= (:title %) "Thread last all")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
   (testing "when in a def similar location"
     (is (not-any? #(= (:title %) "Thread last all")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 1) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a def non-list node"
     (is (not-any? #(= (:title %) "Thread last all")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 2 2) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 2 1 [] {} db/db))))
   (testing "when on a valid function that can be threaded"
     (h/assert-contains-submaps
       [{:title "Thread last all"
         :command {:command "thread-last-all"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when on a non-list node"
     (h/assert-contains-submaps
       [{:title "Thread last all"
         :command {:command "thread-last-all"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3) (h/file-uri "file:///a.clj") 3 1 [] {} db/db))))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 3 [] {} db/db))))
 
 (deftest unwind-thread-action
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -426,22 +425,22 @@
                         (h/file-uri "file:///a.clj"))
   (testing "when not in a thread"
     (is (not-any? #(= (:title %) "Unwind thread once")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 1 1) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 1 1 [] {} db/db))))
   (testing "when inside thread call"
     (h/assert-contains-submaps
       [{:title "Unwind thread once"
         :command {:command "unwind-thread"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 1) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 1 [] {} db/db)))
   (testing "when inside thread symbol"
     (h/assert-contains-submaps
       [{:title "Unwind thread once"
         :command {:command "unwind-thread"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 2) (h/file-uri "file:///a.clj") 3 2 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 2 [] {} db/db)))
   (testing "when inside any threading call"
     (h/assert-contains-submaps
       [{:title "Unwind thread once"
         :command {:command "unwind-thread"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 5 7) (h/file-uri "file:///a.clj") 5 7 [] {} db/db))))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 5 7 [] {} db/db))))
 
 (deftest clean-ns-code-actions
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -462,7 +461,7 @@
                         (h/file-uri "file:///c.clj"))
   (testing "without workspace edit client capability"
     (is (not-any? #(= (:title %) "Clean namespace")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                                       (h/file-uri "file:///b.clj")
                                       2
                                       2
@@ -474,7 +473,7 @@
     (h/assert-contains-submaps
       [{:title "Clean namespace"
         :command {:command "clean-ns"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///b.clj") 2 2)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                           (h/file-uri "file:///b.clj")
                           2
                           2
@@ -490,10 +489,10 @@
     (h/assert-contains-submaps
       [{:title "Resolve macro 'some-ns/foo' as..."
         :command {:command "resolve-macro-as"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7) (h/file-uri "file:///a.clj") 3 7 [] {} db/db)))
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 3 7 [] {} db/db)))
   (testing "when not inside a macro usage"
     (is (not-any? #(= (:title %) "Resolve macro 'some-ns/foo' as...")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 4) (h/file-uri "file:///a.clj") 4 4 [] {} db/db)))))
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj")) (h/file-uri "file:///a.clj") 4 4 [] {} db/db)))))
 
 (deftest suppress-diagnostic-code-actions
   (h/load-code-and-locs (h/code "(ns some-ns)"
@@ -503,7 +502,7 @@
     (h/assert-contains-submaps
       [{:title "Suppress 'unused-private-var' diagnostic"
         :command {:command "suppress-diagnostic"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 3)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
                           3
                           3
@@ -523,7 +522,7 @@
     (h/assert-contains-submaps
       [{:title "Sort map"
         :command {:command "sort-map"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 3)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///project/src/some_ns.clj")
                           4
                           3
@@ -534,7 +533,7 @@
     (h/assert-contains-submaps
       [{:title "Sort map"
         :command {:command "sort-map"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 4 5)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///project/src/some_ns.clj")
                           4
                           5
@@ -543,7 +542,7 @@
                           db/db)))
   (testing "not on map"
     (is (not-any? #(= (:title %) "Sort map")
-                  (f.code-actions/all (zloc-at (h/file-uri "file:///a.clj") 3 7)
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                                       (h/file-uri "file:///project/src/some_ns.clj")
                                       3
                                       7
@@ -563,7 +562,7 @@
     (h/assert-contains-submaps
       [{:title "Create test for 'foo'"
         :command {:command "create-test"}}]
-      (f.code-actions/all (zloc-at (h/file-uri "file:///project/src/some_ns.clj") 3 6)
+      (f.code-actions/all (zloc-of (h/file-uri "file:///project/src/some_ns.clj"))
                           (h/file-uri "file:///project/src/some_ns.clj")
                           3
                           6

--- a/lib/test/clojure_lsp/parser_test.clj
+++ b/lib/test/clojure_lsp/parser_test.clj
@@ -9,28 +9,35 @@
 (h/reset-db-after-test)
 
 (deftest safe-zloc-of-string
-  (is (= "(ns foo) foo/bar" (z/string (z/up (#'parser/safe-zloc-of-string "(ns foo) foo/bar")))))
-  (is (= "(ns foo) foo/ (+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) foo/ (+ 1 2)"))))
-  (is (= "(ns foo) foo/\n(+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) foo/\n(+ 1 2)"))))
-  (is (= "(ns foo) (foo/)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (foo/)"))))
-  (is (= "(ns foo) :\n" (z/string (#'parser/safe-zloc-of-string "(ns foo) :\n"))))
-  (is (= "(ns foo) : " (z/string (#'parser/safe-zloc-of-string "(ns foo) : "))))
-  (is (= "(ns foo) (:)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (:)"))))
-  (is (= "(ns foo)\n:\n" (z/string (#'parser/safe-zloc-of-string "(ns foo)\n:\n"))))
-  (is (= "(ns foo) :foo/ (+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) :foo/ (+ 1 2)"))))
-  (is (= "(ns foo) (:foo/) (+ 1 2)" (z/string (#'parser/safe-zloc-of-string "(ns foo) (:foo/) (+ 1 2)"))))
-  (is (= ":user/username\n:user/\n123" (z/string (#'parser/safe-zloc-of-string ":user/username\n:user/\n123")))))
+  (is (= "(ns foo) foo/bar" (z/string (z/up (parser/safe-zloc-of-string "(ns foo) foo/bar")))))
+  (is (= "(ns foo) foo/ (+ 1 2)" (z/string (parser/safe-zloc-of-string "(ns foo) foo/ (+ 1 2)"))))
+  (is (= "(ns foo) foo/\n(+ 1 2)" (z/string (parser/safe-zloc-of-string "(ns foo) foo/\n(+ 1 2)"))))
+  (is (= "(ns foo) (foo/)" (z/string (parser/safe-zloc-of-string "(ns foo) (foo/)"))))
+  (is (= "(ns foo) :\n" (z/string (parser/safe-zloc-of-string "(ns foo) :\n"))))
+  (is (= "(ns foo) : " (z/string (parser/safe-zloc-of-string "(ns foo) : "))))
+  (is (= "(ns foo) (:)" (z/string (parser/safe-zloc-of-string "(ns foo) (:)"))))
+  (is (= "(ns foo)\n:\n" (z/string (parser/safe-zloc-of-string "(ns foo)\n:\n"))))
+  (is (= "(ns foo) :foo/ (+ 1 2)" (z/string (parser/safe-zloc-of-string "(ns foo) :foo/ (+ 1 2)"))))
+  (is (= "(ns foo) (:foo/) (+ 1 2)" (z/string (parser/safe-zloc-of-string "(ns foo) (:foo/) (+ 1 2)"))))
+  (is (= ":user/username\n:user/\n123" (z/string (parser/safe-zloc-of-string ":user/username\n:user/\n123")))))
 
-(deftest find-loc-at-pos-test
+(deftest to-pos-test
   (testing "valid code"
-    (is (= nil (z/string (parser/loc-at-pos "  foo  " 1 1))))
-    (is (= 'foo (z/sexpr (parser/loc-at-pos "  foo  " 1 3))))
-    (is (= 'foo (z/sexpr (parser/loc-at-pos "  foo  " 1 5))))
-    (is (= "  " (z/string (parser/loc-at-pos "  foo  " 1 6)))))
+    (let [zloc (parser/zloc-of-string "  foo  ")]
+      (is (= nil (z/string (parser/to-pos zloc 1 1))))
+      (is (= 'foo (z/sexpr (parser/to-pos zloc 1 3))))
+      (is (= 'foo (z/sexpr (parser/to-pos zloc 1 5))))
+      (is (= "  " (z/string (parser/to-pos zloc 1 6))))))
   (testing "invalid code"
-    (is (= "foo/" (z/string (parser/loc-at-pos "(ns foo)  (foo/)  " 1 12))))
-    (is (= "foo/" (z/string (parser/loc-at-pos "(ns foo)  foo/ " 1 11))))
-    (is (= "foo/" (z/string (parser/loc-at-pos "(ns foo)  foo/\n" 1 11))))))
+    (is (= "foo/" (-> (parser/zloc-of-string "(ns foo)  (foo/)  ")
+                      (parser/to-pos 1 12)
+                      z/string)))
+    (is (= "foo/" (-> (parser/zloc-of-string "(ns foo)  foo/ ")
+                      (parser/to-pos 1 11)
+                      z/string)))
+    (is (= "foo/" (-> (parser/zloc-of-string "(ns foo)  foo/\n")
+                      (parser/to-pos 1 11)
+                      z/string)))))
 
 (deftest find-top-forms-test
   (let [code "(a) (b c d)"]


### PR DESCRIPTION
The aim of this commit is not to change any behavior but to simplify and clarify several pieces of code, especially around the generation of actions. I was inspired to try to clean up the actions by a [comment](https://github.com/clojure-lsp/clojure-lsp/pull/716#discussion_r804280479) @ericdallo made in a previous PR.

First, in `add-missing-libspec` and `code-actions` it reorganizes the code related to generating actions. To me, this code is much more succinct now, though of course that's subjective.

Second, in the `parser`, it separates parsing from cursor positioning. When these two responsibilities are separate, they are easier to compose.

Related to this separation, there's a small performance improvement for code action generation. We now avoid parsing the code once per combination of diagnostic and possible resolution, and instead parse once, repositioning the cursor as necessary.

There's also a small performance improvement in snippet generation, where we avoid parsing the file a second time. This fix was mentioned in [#764][764].

The parser refactoring exposed the fact that `parser/safe-zloc-of-string` was actually only _mostly_ safe. It recovered from several errors related to parsing incomplete Clojure, but would still throw if the string was invalid Clojure. Its name has been updated, and a new version added that will return nil for invalid Clojure. This safe version should be used in more places, with the calling code handling nils instead of relying on exceptions to be thrown. This additional cleanup hasn't been completed.

[764]: https://github.com/clojure-lsp/clojure-lsp/pull/764
