### PR TITLE
Move entries intuitively in `case`, `cond` and similar functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   - Fix cljfmt settings merge during refresh/classpath configs merge to avoid multiple config vectors on same symbol.
 
 - Editor
-  - Fix wrong args on extract function from multi-arity fn. #683
+  - extract-function: Fix wrong args when extracting from multi-arity fn. #683
+  - move-coll-entry: clauses move intuitively in `assoc`, `case`, `cond`, and similar functions. #780 @mainej
 
 ## 2022.02.23-12.12.12
 

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -9,25 +9,33 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- count-siblings-left
-  "Count the number of sibling nodes to the left of the child node `zloc`."
-  [zloc]
-  (->> zloc
-       (iterate z/left)
-       (take-while (complement z/leftmost?))
-       count))
+(defn ^:private tag-p [tag-set]
+  (comp tag-set z/tag))
 
-(defn- count-siblings-right
-  "Count the number of sibling nodes to the right of the child node `zloc`."
-  [zloc]
-  (->> zloc
-       (iterate z/right)
-       (take-while (complement z/rightmost?))
-       count))
+;;;; Redefine core helpers to treat uneval as comment. See
+;;;; https://github.com/clj-commons/rewrite-clj/issues/70.
 
-(defn ^:private newline-comment? [n]
-  (and (n/comment? n)
-       (string/ends-with? (:s n) "\n")))
+;; clj-rewrite calls the #_ reader macro and its contents an "uneval" node. We
+;; duplicate several zipper movement operators, changing them to treat uneval
+;; nodes as comments. This avoids errors related to counting nodes or
+;; affiliating them with their whitespace.
+
+;; TODO: Periodically audit this namespace for mistaken uses of z/right, etc.,
+;; or for the introduction of new core helpers that depend on
+;; z/whitespace-or-comment? :/
+
+(def ^:private whitespace-or-comment?
+  "Treat uneval (#_) as comment. Otherwise the same as z/whitespace-or-comment?"
+  (tag-p #{:whitespace :newline :comma :comment :uneval}))
+
+(defn ^:private skip-whitespace [f zloc] (z/skip f whitespace-or-comment? zloc))
+(defn ^:private skip-whitespace-right [zloc] (skip-whitespace z/right* zloc))
+(defn ^:private skip-whitespace-left [zloc] (skip-whitespace z/left* zloc))
+(defn ^:private z-right [zloc] (some-> zloc z/right* skip-whitespace-right))
+(defn ^:private z-left [zloc] (some-> zloc z/left* skip-whitespace-left))
+(defn ^:private z-down [zloc] (some-> zloc z/down* skip-whitespace-right))
+(defn ^:private z-up [zloc] (some-> zloc z/up* skip-whitespace-left))
+(defn ^:private z-leftmost? [zloc] (nil? (skip-whitespace-left (z/left* zloc))))
 
 (defn ^:private z-take-while
   "Returns a sequence of locations in the direction of `f` from `zloc` that
@@ -38,6 +46,24 @@
        (take-while identity)
        (take-while (complement z/end?))
        (take-while p?)))
+
+(defn ^:private count-siblings-left
+  "Count the number of sibling nodes to the left of the child node `zloc`."
+  [zloc]
+  (-> (z-left zloc)
+      (z-take-while z-left identity)
+      count))
+
+(defn ^:private count-siblings-right
+  "Count the number of sibling nodes to the right of the child node `zloc`."
+  [zloc]
+  (-> (z-right zloc)
+      (z-take-while z-right identity)
+      count))
+
+(defn ^:private newline-comment? [n]
+  (and (n/comment? n)
+       (string/ends-with? (:s n) "\n")))
 
 (defn ^:private z-split-with
   "Like clojure.core/split-with, but for a clj-rewrite zipper. Returns two
@@ -108,7 +134,7 @@
       result
 
       (= :in-padding state)
-      (let [[padding zloc] (z-split-with zloc z/whitespace?)]
+      (let [[padding zloc] (z-split-with zloc (tag-p #{:whitespace :newline :comma}))]
         (recur zloc
                :on-elem
                idx
@@ -117,7 +143,7 @@
                              :locs padding})))
 
       (= :on-elem state)
-      (let [[prefix elem-loc] (z-split-with zloc z/whitespace-or-comment?)]
+      (let [[prefix elem-loc] (z-split-with zloc whitespace-or-comment?)]
         (if-not elem-loc
           ;; We've processed all the elements and this is trailing whitespace.
           (conj result {:type :padding
@@ -131,13 +157,12 @@
                                    ;; `a 1, ;; one comment`
                                    ;; Conceptually, the comma should stay put while
                                    ;; the pair and comment move.
-                                   (z/skip z/right* (comp #{:whitespace :comment}
-                                                          z/tag))
+                                   (z/skip z/right* (tag-p #{:whitespace :comment :uneval}))
                                    ;; relinquish that node
                                    z/left*
                                    ;; then give up as much whitespace as possible,
                                    ;; back to the (optional) comment
-                                   (z/skip z/left* z/whitespace?)
+                                   (z/skip z/left* (tag-p #{:whitespace}))
                                    ;; then forward to the padding
                                    z/right*)
                 postfix       (z-take-while postfix-start
@@ -155,28 +180,18 @@
   (meta (z/node zloc)))
 
 (defn ^:private elem-index-by-cursor-position
-  "Search for an element within `elems` that was at `cursor-position`.
-
-  We compare cursor position, not full loc, because comments have been separated
-  from their newlines by `seq-elems`.
-
-  This procedure is complicated by the possiblity that the cursor is on padding
-  between elements. If this was the case, we assume the intention was to move
-  the next element."
+  "Search for an element within `elems` that was at `cursor-position`."
   [cursor-position elems]
   (->> elems
        (filter (fn [{:keys [locs]}]
+                 ;; We compare cursor position, not full loc, because comments
+                 ;; have been separated from their newlines by `seq-elems`.
                  (some (comp #{cursor-position} z-cursor-position)
                        locs)))
        first
+       ;; If the cursor is on padding between elements, we assume the intention
+       ;; was to move the next element. This padding will have the correct idx.
        :idx))
-
-(defn ^:private elem-by-index [search-idx elems]
-  (->> elems
-       (filter (fn [{:keys [type idx]}]
-                 (and (= :elem type)
-                      (= search-idx idx))))
-       first))
 
 (defn ^:private split-elems-at-idx [elems split-idx]
   (split-with (fn [{:keys [type idx]}]
@@ -195,106 +210,88 @@
 
 (defn ^:private fix-trailing-comment
   "After reordering, the last component may now be a comment. We need to add a
-  newline because otherwise the closing bracket will be commented out. By
-  default this aligns the bracket with rightmost element, but this can be
-  modified by providing a `movement` from the rightmost."
-  ([parent-zloc] (fix-trailing-comment parent-zloc identity))
-  ([parent-zloc movement]
-   (let [last-zloc (-> parent-zloc z/down z/rightmost*)]
-     (if (-> last-zloc z/node n/comment?)
-       (let [col (-> parent-zloc
-                     z/down
-                     z/rightmost
-                     movement
-                     z-cursor-position
-                     :col)]
-         (-> last-zloc
-             (z/insert-space-right (dec col))
-             z/insert-newline-right
-             z/up))
-       parent-zloc))))
+  newline because otherwise the closing bracket will be commented out. We align
+  the closing bracket indented one space from the opening bracket."
+  [parent-zloc]
+  (let [last-zloc (-> parent-zloc z-down z/rightmost*)]
+    (if (-> last-zloc z/node n/comment?)
+      (let [col (-> parent-zloc
+                    z-cursor-position
+                    :col)]
+        (-> last-zloc
+            (z/insert-space-right col) ;; uses z/insert-right, so automatically adds one extra space
+            z/insert-newline-right
+            z-up))
+      parent-zloc)))
 
 (defn ^:private can-swap?
-  "In a few cases, the simple can-move-*? heuristics return the wrong results.
+  "In a few cases, the simple [[valid-strat?]] heuristics return the wrong results.
   This happens:
-  A) When on a comment following the first element/pair, and `move-up` is
-     invoked.
-  B) When on a padding line before the last element/pair, and `move-down` is
-     invoked.
-  Movement should not be allowed in either of these cases. Unfortunately,
-  there's no quick way to know we're in this situation until after we've
-  affiliated whitespace with elements. But now that we've done that, we can
-  detect it. It manifests as the origin-idx or dest-idx being out of bounds, in
-  which case either origin-elem or dest-elem will be missing. We bail out now to
-  avoid erroneous swaps."
-  [origin-idx dest-idx elems]
-  (and (elem-by-index origin-idx elems)
-       (elem-by-index dest-idx elems)))
+  A) When on whitespace following the first group, and `move-up` is invoked.
+  B) When on whitespace before the last group, and `move-down` is invoked.
+  `valid-strat?` thought it saw enough elements before or after the zloc to
+  permit movement, but now that we've more carefully allocated the whitespace to
+  a group, we know that isn't true. The problem manifests as the origin-idx or
+  dest-idx being out of bounds."
+  [origin-idx dest-idx {:keys [breadth pulp rind]}]
+  (let [[lower-bound _] rind
+        upper-bound (- (+ lower-bound pulp) breadth)]
+    (and (<= lower-bound origin-idx upper-bound)
+         (<= lower-bound dest-idx upper-bound))))
 
-(defn ^:private move-pair-zloc
-  "Move a pair of elements around `zloc` in direction `dir` considering multiple
-  comments cases."
-  [zloc dir]
-  (let [parent-zloc (z/up zloc)
+(defn ^:private move-group-by-strategy
+  "Move a group of `breadth` elements around `zloc` in direction of `dir`
+  ignoring elements in `rind`.
+
+  Returns three pieces of data. The first is the edited parent expression with
+  the groups swapped, whose string representation should be sent to the editor.
+  The second and third are used for positioning the cursor: a loc whose position
+  marks the top of the top group; and a series of locs, which sit between the
+  tops of the top and bottom groups. Their combined extent can be used to
+  calculate the top of the bottom group; see [[final-bottom-cursor]]."
+  [zloc {:keys [breadth dir rind] :as strategy}]
+  (let [[ignore-left _] rind
+        parent-zloc (z-up zloc)
 
         elems (seq-elems parent-zloc)
 
         origin-idx (elem-index-by-cursor-position (z-cursor-position zloc) elems)
-        ;; Here we begin to treat elements like pairs.
-        origin-idx (cond-> origin-idx
-                     ;; if on on value, go back to key
-                     (odd? origin-idx) dec)
-        dest-idx   (dir (dir origin-idx))]
-    (when (can-swap? origin-idx dest-idx elems)
+        ;; move back to first element in group
+        origin-idx (- origin-idx
+                      (mod (- origin-idx ignore-left) breadth))
+        dest-idx (->> origin-idx
+                      (iterate (case dir :up dec, :down inc))
+                      (drop breadth)
+                      first)]
+    (when (can-swap? origin-idx dest-idx strategy)
       (let [earlier-idx  (min origin-idx dest-idx)
             [before rst] (split-elems-at-idx elems earlier-idx)
 
-            [earlier-pair rst] (split-at 3 rst) ;; key, padding, value
-            [interstitial rst] (split-at 1 rst) ;; padding
-            [later-pair rst]   (split-at 3 rst) ;; key, padding, value
+            ;; the group is the elements _and_ intervening padding that are
+            ;; moving together
+            group-size          (+ breadth (dec breadth))
+            [earlier-group rst] (split-at group-size rst)
+            [interstitial rst]  (split-at 1 rst) ;; padding
+            [later-group rst]   (split-at group-size rst)
 
             swapped     (concat before
-                                later-pair
+                                later-group
                                 interstitial
-                                earlier-pair
+                                earlier-group
                                 rst)
             parent-zloc (-> parent-zloc
                             (edit-collection swapped)
-                            ;; align with last key, not value
-                            (fix-trailing-comment z/left))]
-        [parent-zloc (first earlier-pair) (concat later-pair interstitial)]))))
-
-(defn ^:private move-element-zloc
-  "Move an element around `zloc` in direction `dir` considering multiple
-  comments cases."
-  [zloc dir]
-  (let [parent-zloc (z/up zloc)
-
-        elems (seq-elems parent-zloc)
-
-        origin-idx (elem-index-by-cursor-position (z-cursor-position zloc) elems)
-        dest-idx   (dir origin-idx)]
-    (when (can-swap? origin-idx dest-idx elems)
-      (let [earlier-idx  (min origin-idx dest-idx)
-            [before rst] (split-elems-at-idx elems earlier-idx)
-
-            [[earlier-elem padding later-elem] rst] (split-at 3 rst)
-
-            swapped (concat before
-                            [later-elem
-                             padding
-                             earlier-elem]
-                            rst)
-
-            parent-zloc (-> parent-zloc
-                            (edit-collection swapped)
                             (fix-trailing-comment))]
-        [parent-zloc earlier-elem [later-elem padding]]))))
+        [parent-zloc
+         (first (:locs (first earlier-group)))
+         (mapcat :locs (concat later-group interstitial))]))))
+
+(def ^:private no-rind [0 0])
 
 (def ^:private common-binding-syms
   "Symbols that are typically used to define bindings."
   ;; We aren't concerned with macros like `if-let` that establish one binding
-  ;; only. They can be treated like regular 'move-element' vectors.
+  ;; only. They can be treated like regular breadth-1 vectors.
   '#{binding doseq for let loop with-local-vars with-open with-redefs})
 
 (defn ^:private establishes-bindings?
@@ -319,10 +316,10 @@
   definitions."
   [zloc uri {:keys [analysis]}]
   (boolean
-    (or (when-let [outer-zloc (z/left zloc)]
-          (and (z/leftmost? outer-zloc)
+    (or (when-let [outer-zloc (z-left zloc)]
+          (and (z-leftmost? outer-zloc)
                (contains? common-binding-syms (z/sexpr outer-zloc))))
-        (let [z-pos   (z-cursor-position (z/down zloc))
+        (let [z-pos   (z-cursor-position (z-down zloc))
               z-scope {:name-row     (:row z-pos)
                        :name-col     (:col z-pos)
                        :name-end-row (:end-row z-pos)
@@ -332,88 +329,130 @@
                                (shared/inside? element z-scope)))
                         (get analysis (shared/uri->filename uri)))))))
 
-(defn ^:private balanced-pairs? [parent-zloc]
-  (even? (count (z/child-sexprs parent-zloc))))
+(defn ^:private vector-strategy
+  "Returns the movement strategy for `parent-zloc`, which should be a vector
+  node."
+  [parent-zloc uri db]
+  {:breadth (if (establishes-bindings? parent-zloc uri db) 2 1)
+   :rind no-rind})
 
-(defn ^:private move-pair-up-breadth [zloc]
-  (when (and (balanced-pairs? (z/up zloc))
-             (>= (count-siblings-left zloc) 2))
-    :pairwise))
+(defn ^:private in-threading? [parent-zloc]
+  (when-let [up-op-loc (some-> parent-zloc z-up z-down)]
+    (when (z/sexpr-able? up-op-loc)
+      (contains? '#{-> cond-> some->} (z/sexpr up-op-loc)))))
 
-(defn ^:private move-element-up-breadth [zloc]
-  (when (>= (count-siblings-left zloc) 1)
-    :elementwise))
+(defn ^:private count-children [zloc]
+  (let [node (z/node zloc)]
+    (if (n/inner? node)
+      (->> node n/children (filter n/sexpr-able?) count)
+      0)))
 
-(defn ^:private move-pair-down-breadth [zloc]
-  (when (and (balanced-pairs? (z/up zloc))
-             (>= (count-siblings-right zloc) 2))
-    :pairwise))
+(defn ^:private list-strategy
+  "Returns a movement strategy for `parent-zloc`, which should be a list node.
+  The strategy will include a `:rind` and a `:breadth`. In the base case, the
+  strategy will be to move elements one by one. Some functions like case and
+  cond have groups of arguments that should be moved together. If the list node
+  is such a function call, returns the appropriate movement strategy for it.
+  Returns nil in one special case when we know we're in an invalid condp."
+  [parent-zloc child-count]
+  ;; case and condp permit final default expression, which should not be moved.
+  ;; assoc, assoc!, cond->, cond->>, and case sometimes appear inside other threading expressions.
+  ;; condp has a variation with ternary expressions.
+  (case (some-> parent-zloc z-down z/sexpr)
+    cond
+    #_=> {:breadth 2, :rind [1 0]}
+    (cond-> cond->> assoc assoc!)
+    #_=> {:breadth 2, :rind [(if (in-threading? parent-zloc) 1 2) 0]}
+    case
+    #_=> {:breadth 2, :rind (if (in-threading? parent-zloc)
+                              [1 (if (odd? child-count) 0 1)]
+                              [2 (if (even? child-count) 0 1)])}
+    condp
+    #_=> (let [breadth (if (z/find-next-value (z-down parent-zloc) z-right :>>) 3 2)
+               ignore-left 3
+               ignore-right (mod (- child-count ignore-left) breadth)
+               invalid-ternary? (= 2 ignore-right)]
+           (when-not invalid-ternary?
+             {:breadth breadth, :rind [ignore-left ignore-right]}))
+    {:breadth 1, :rind no-rind}))
 
-(defn ^:private move-element-down-breadth [zloc]
-  (when (>= (count-siblings-right zloc) 1)
-    :elementwise))
+(defn ^:private movable-sibling-counts
+  "Returns the number of movable siblings to the left and right of `zloc`."
+  [zloc [ignore-left ignore-right]]
+  [(-> zloc count-siblings-left (- ignore-left))
+   (-> zloc count-siblings-right (- ignore-right))])
 
-(defn move-up-breadth [zloc uri db]
-  (let [parent-zloc (z/up zloc)]
-    (case (some-> parent-zloc z/tag)
-      :map         (move-pair-up-breadth zloc)
-      :vector      (if (establishes-bindings? parent-zloc uri db)
-                     (move-pair-up-breadth zloc)
-                     (move-element-up-breadth zloc))
-      (:list :set) (move-element-up-breadth zloc)
-      nil)))
+(defn ^:private valid-strat?
+  "Checks whether a movement strategy can be applied to `zloc`. This isn't a
+  perfect test; see [[can-swap?]]."
+  [zloc {:keys [dir breadth pulp rind]}]
+  ;; do we have a multiple of the right number of elements?
+  (and (zero? (mod pulp breadth))
+       ;; are there enough elements before and after this zloc?
+       (let [[left right] (movable-sibling-counts zloc rind)]
+         (or
+          ;; erroneously true if on whitespace following first group
+           (and (= :up dir)   (>= left breadth) (>= right 0))
+          ;; erroneously true if on whitespace preceding last group
+           (and (= :down dir) (>= left 0)       (>= right breadth))))))
 
-(defn move-down-breadth [zloc uri db]
-  (let [parent-zloc (z/up zloc)]
-    (case (some-> parent-zloc z/tag)
-      :map         (move-pair-down-breadth zloc)
-      :vector      (if (establishes-bindings? parent-zloc uri db)
-                     (move-pair-down-breadth zloc)
-                     (move-element-down-breadth zloc))
-      (:list :set) (move-element-down-breadth zloc)
-      nil)))
+(defn ^:private pulp [[ignore-left ignore-right] child-count]
+  (- child-count ignore-left ignore-right))
+
+(defn ^:private movement-strategy
+  "Returns a movement strategy when the `zloc` can be moved in the direction
+  `dir`.
+
+  A movement strategy is three pieces of data.
+  - `:breadth`: how many element should be moved together.
+  - `:rind`: how many elements at the beginning and end of the containing
+     expression can be ignored for the purposes of movement.
+  - `:pulp`: how many elements in the interior of the expression can be moved.
+  - `:dir` A copy of the `dir`.
+
+  May return a movement strategy even when the zloc cannot actually be moved.
+  See [[valid-strat?]] and [[can-swap?]]."
+  [dir zloc uri db]
+  (let [parent-zloc (z-up zloc)
+        child-count (count-children parent-zloc)
+        strat (case (some-> parent-zloc z/tag)
+                :map    {:breadth 2, :rind no-rind}
+                :set    {:breadth 1, :rind no-rind}
+                :vector (vector-strategy parent-zloc uri db)
+                :list   (list-strategy parent-zloc child-count)
+                nil)]
+    (when strat
+      (let [strat (assoc strat
+                         :dir dir
+                         :pulp (pulp (:rind strat) child-count))]
+        (when (valid-strat? zloc strat)
+          strat)))))
 
 (defn can-move-entry-up? [zloc uri db]
-  (boolean (move-up-breadth zloc uri db)))
+  (boolean (movement-strategy :up zloc uri db)))
 
 (defn can-move-entry-down? [zloc uri db]
-  (boolean (move-down-breadth zloc uri db)))
-
-(defn ^:private movement [zloc breadth dir]
-  (case breadth
-    :pairwise    (move-pair-zloc zloc dir)
-    :elementwise (move-element-zloc zloc dir)
-    nil))
-
-(defn ^:private final-top-cursor
-  "Returns the position where the cursor should be placed after the swap in
-  order to end up on the (eventual) top element.
-
-  This is calculated from the beginning of the swapped elements `orig-top-elem`."
-  [orig-top-elem]
-  (z-cursor-position (first (:locs orig-top-elem))))
+  (boolean (movement-strategy :down zloc uri db)))
 
 (defn ^:private final-bottom-cursor
   "Returns the position where the cursor should be placed after the swap in
-  order to end up on the (eventual) bottom element.
+  order to end up at the top of the (eventual) bottom group.
 
-  This is calculated by starting at the beginning of the swapped elements
-  `orig-top-elem`, and adjusting that position by adding the extent of the
-  `intervening-elems`. The extent is calculated by re-parsing the
-  intervening-elems, counting their rows and columns by looking at their string
-  representations. This is probably slow, but it avoids needing to use
-  {:track-position? true} in the parser. If someday this project uses
-  :track-position?, this code probably should be changed to read the revised
-  position of the original zloc."
-  [orig-top-elem intervening-elems]
-  (let [top-position (final-top-cursor orig-top-elem)
+  This is calculated by starting at the beginning of the `top-loc`, and
+  adjusting that position by adding the extent of the `intervening-locs`. The
+  extent is calculated by re-parsing the intervening-locs, counting their rows
+  and columns by looking at their string representations. This is probably slow,
+  but it avoids needing to use {:track-position? true} in the parser. If someday
+  this project uses :track-position?, this code probably should be changed to
+  read the revised position of the original zloc."
+  [top-loc intervening-locs]
+  (let [top-position (z-cursor-position top-loc)
 
         [bottom-row bottom-col]
-        (->> intervening-elems
-             (mapcat :locs)
-             (reduce (fn [pos zloc]
-                       (n.protocols/+extent pos (n.protocols/extent (z/node zloc))))
-                     [(:row top-position) (:col top-position)]))]
+        (reduce (fn [pos zloc]
+                  (n.protocols/+extent pos (n.protocols/extent (z/node zloc))))
+                [(:row top-position) (:col top-position)]
+                intervening-locs)]
     {:row     bottom-row
      :col     bottom-col
      :end-row bottom-row
@@ -427,12 +466,14 @@
                               [{:range (z-cursor-position parent-loc)
                                 :loc   parent-loc}]}})
 
+(defn ^:private movement [dir zloc uri db]
+  (when-let [strategy (movement-strategy dir zloc uri db)]
+    (move-group-by-strategy zloc strategy)))
+
 (defn move-up [zloc uri db]
-  (when-let [[parent-zloc orig-top-elem _]
-             (movement zloc (move-up-breadth zloc uri db) dec)]
-    (changes uri parent-zloc (final-top-cursor orig-top-elem))))
+  (when-let [[parent-zloc top-loc _] (movement :up zloc uri db)]
+    (changes uri parent-zloc (z-cursor-position top-loc))))
 
 (defn move-down [zloc uri db]
-  (when-let [[parent-zloc orig-top-elem intervening-elems]
-             (movement zloc (move-down-breadth zloc uri db) inc)]
-    (changes uri parent-zloc (final-bottom-cursor orig-top-elem intervening-elems))))
+  (when-let [[parent-zloc top-loc intervening-locs] (movement :down zloc uri db)]
+    (changes uri parent-zloc (final-bottom-cursor top-loc intervening-locs))))

--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -44,7 +44,68 @@
     (is (not (can-move-code-up? "{|:a :b :c :d}")))
     (is (not (can-move-code-up? "{:a |:b :c :d}")))
     (is (not (can-move-code-up? "(let [|a 1 c 2])")))
-    (is (not (can-move-code-up? "(let [a |1 c 2])")))))
+    (is (not (can-move-code-up? "(let [a |1 c 2])")))
+    (testing "of special functions"
+      ;; from rind of cond
+      (is (not (can-move-code-up? "(|cond a 1 b 2)")))
+      ;; from first pair of cond
+      (is (not (can-move-code-up? "(cond |a 1 b 2)")))
+      (is (not (can-move-code-up? "(cond a |1 b 2)")))
+      ;; from rind of assoc
+      (is (not (can-move-code-up? "(|assoc x :a 1 :b 2)")))
+      (is (not (can-move-code-up? "(assoc |x :a 1 :b 2)")))
+      ;; from first pair of assoc
+      (is (not (can-move-code-up? "(assoc x |:a 1 :b 2)")))
+      (is (not (can-move-code-up? "(assoc x :a |1 :b 2)")))
+      ;; from rind of assoc!
+      (is (not (can-move-code-up? "(|assoc! x :a 1 :b 2)")))
+      (is (not (can-move-code-up? "(assoc! |x :a 1 :b 2)")))
+      ;; from first pair of assoc!
+      (is (not (can-move-code-up? "(assoc! x |:a 1 :b 2)")))
+      (is (not (can-move-code-up? "(assoc! x :a |1 :b 2)")))
+      ;; from rind of cond->
+      (is (not (can-move-code-up? "(|cond-> x a inc b dec)")))
+      (is (not (can-move-code-up? "(cond-> |x a inc b dec)")))
+      ;; from first pair of cond->
+      (is (not (can-move-code-up? "(cond-> x |a inc b dec)")))
+      (is (not (can-move-code-up? "(cond-> x a |inc b dec)")))
+      ;; from rind of cond->>
+      (is (not (can-move-code-up? "(|cond->> x a inc b dec)")))
+      (is (not (can-move-code-up? "(cond->> |x a inc b dec)")))
+      ;; from first pair of cond->>
+      (is (not (can-move-code-up? "(cond->> x |a inc b dec)")))
+      (is (not (can-move-code-up? "(cond->> x a |inc b dec)")))
+      ;; from rind of case
+      (is (not (can-move-code-up? "(|case a 1 :first 2 :second)")))
+      (is (not (can-move-code-up? "(case |a 1 :first 2 :second)")))
+      (is (not (can-move-code-up? "(case a 1 :first |:else)")))
+      (is (not (can-move-code-up? "(case a |:else)")))
+      ;; from first pair of case
+      (is (not (can-move-code-up? "(case a |1 :first)")))
+      (is (not (can-move-code-up? "(case a 1 |:first)")))
+      (is (not (can-move-code-up? "(case a |1 :first 2 :second)")))
+      (is (not (can-move-code-up? "(case a 1 |:first 2 :second)")))
+      (is (not (can-move-code-up? "(case a |1 :first :else)")))
+      (is (not (can-move-code-up? "(case a 1 |:first :else)")))
+      ;; from rind of condp
+      (is (not (can-move-code-up? "(|condp = x a 1 b 2)")))
+      (is (not (can-move-code-up? "(condp |= x a 1 b 2)")))
+      (is (not (can-move-code-up? "(condp = |x a 1 b 2)")))
+      (is (not (can-move-code-up? "(condp = x a 1 |:else)")))
+      (is (not (can-move-code-up? (h/code "(condp some [1 2 3 4]"
+                                          "  #{0 6 7} :>> inc"
+                                          "  #{4 5 9} :>> dec"
+                                          "  |:else)"))))
+      ;; from first pair of condp
+      (is (not (can-move-code-up? "(condp = |x a 1 b 2)")))
+      (is (not (can-move-code-up? "(condp = x |a 1 b 2)")))
+      (is (not (can-move-code-up? (h/code "(condp some [1 2 3 4]"
+                                          "  #{0 6 7} :>> |inc)"))))
+      ;; in invalid ternary form of condp
+      (is (not (can-move-code-up? (h/code "(condp some [1 2 3 4]"
+                                          "  #{0 6 7} :>> inc"
+                                          "  |#{4 5 9} :>> dec"
+                                          "  :else :invalid)")))))))
 
 ;; These are only the negative cases, proving when move-down is NOT offered in
 ;; the actions menu. The positive cases are all tested indirectly via
@@ -70,7 +131,58 @@
     (is (not (can-move-code-down? "{:a :b |:c :d}")))
     (is (not (can-move-code-down? "{:a :b :c |:d}")))
     (is (not (can-move-code-down? "(let [a 1 |c 2])")))
-    (is (not (can-move-code-down? "(let [a 1 c |2])")))))
+    (is (not (can-move-code-down? "(let [a 1 c |2])")))
+    (testing "of special functions"
+      ;; from rind of cond
+      (is (not (can-move-code-down? "(|cond a 1 b 2)")))
+      ;; from last pair of cond
+      (is (not (can-move-code-down? "(cond a 1 |b 2)")))
+      (is (not (can-move-code-down? "(cond a 1 b |2)")))
+      ;; from rind of cond->
+      (is (not (can-move-code-down? "(|cond-> x a inc b dec)")))
+      (is (not (can-move-code-down? "(cond-> |x a inc b dec)")))
+      ;; from last pair of cond->
+      (is (not (can-move-code-down? "(cond-> x a inc |b dec)")))
+      (is (not (can-move-code-down? "(cond-> x a inc b |dec)")))
+      ;; from rind of assoc
+      (is (not (can-move-code-down? "(|assoc x :a 1 :b 2)")))
+      (is (not (can-move-code-down? "(assoc |x :a 1 :b 2)")))
+      ;; from last pair of assoc
+      (is (not (can-move-code-down? "(assoc x :a 1 |:b 2)")))
+      (is (not (can-move-code-down? "(assoc x :a 1 :b |2)")))
+      ;; from rind of assoc!
+      (is (not (can-move-code-down? "(|assoc! x :a 1 :b 2)")))
+      (is (not (can-move-code-down? "(assoc! |x :a 1 :b 2)")))
+      ;; from last pair of assoc!
+      (is (not (can-move-code-down? "(assoc! x :a 1 |:b 2)")))
+      (is (not (can-move-code-down? "(assoc! x :a 1 :b |2)")))
+      ;; from rind of cond->>
+      (is (not (can-move-code-down? "(|cond->> x a inc b dec)")))
+      (is (not (can-move-code-down? "(cond->> |x a inc b dec)")))
+      ;; from last pair of cond->>
+      (is (not (can-move-code-down? "(cond->> x a inc |b dec)")))
+      (is (not (can-move-code-down? "(cond->> x a inc b |dec)")))
+      ;; from rind of case
+      (is (not (can-move-code-down? "(|case a 1 :first 2 :second)")))
+      (is (not (can-move-code-down? "(case |a 1 :first 2 :second)")))
+      (is (not (can-move-code-down? "(case a 1 :first |:else)")))
+      (is (not (can-move-code-down? "(case a |:else)")))
+      ;; from last pair of case
+      (is (not (can-move-code-down? "(case a 1 :first |2 :second)")))
+      (is (not (can-move-code-down? "(case a 1 :first 2 |:second)")))
+      (is (not (can-move-code-down? "(case a 1 :first |2 :second :else)")))
+      (is (not (can-move-code-down? "(case a 1 :first 2 |:second :else)")))
+      ;; from rind of condp
+      (is (not (can-move-code-down? "(|condp = x a 1 b 2)")))
+      (is (not (can-move-code-down? "(condp |= x a 1 b 2)")))
+      (is (not (can-move-code-down? "(condp = |x a 1 b 2)")))
+      (is (not (can-move-code-down? "(condp = x a 1 |:else)")))
+      ;; from last pair of condp
+      (is (not (can-move-code-down? "(condp = x a 1 |b 2)")))
+      (is (not (can-move-code-down? "(condp = x a 1 b |2)")))
+      (is (not (can-move-code-down? (h/code "(condp some [1 2 3 4]"
+                                            "  |#{4 5 9} :>> dec"
+                                            "  :else)")))))))
 
 (defn move-zloc-up [zloc]
   (f.move-coll-entry/move-up zloc h/default-uri @db/db))
@@ -190,6 +302,129 @@
                             "(foo [a 1"
                             "      |b 2]"
                             "  (inc a))")))
+  (testing "within special functions"
+    (assert-move-up (h/code "(cond |b 2 a 1)")
+                    (h/code "(cond a 1 |b 2)"))
+    (assert-move-up (h/code "(cond |b 2 a 1)")
+                    (h/code "(cond a 1 b |2)"))
+    (assert-move-up (h/code "(assoc x |:b 1 :a 2)")
+                    (h/code "(assoc x :a 2 |:b 1)"))
+    (assert-move-up (h/code "(assoc x |:b 1 :a 2)")
+                    (h/code "(assoc x :a 2 :b |1)"))
+    (assert-move-up (h/code "(-> {}"
+                            "    (assoc |:b 1 :a 2))")
+                    (h/code "(-> {}"
+                            "    (assoc :a 2 |:b 1))"))
+    (assert-move-up (h/code "(some-> {}"
+                            "        (assoc |:b 1 :a 2))")
+                    (h/code "(some-> {}"
+                            "        (assoc :a 2 |:b 1))"))
+    (assert-move-up (h/code "(cond-> {}"
+                            "  true (assoc |:b 1 :a 2))")
+                    (h/code "(cond-> {}"
+                            "  true (assoc :a 2 |:b 1))"))
+    (assert-move-up (h/code "(assoc! x |:b 1 :a 2)")
+                    (h/code "(assoc! x :a 2 |:b 1)"))
+    (assert-move-up (h/code "(assoc! x |:b 1 :a 2)")
+                    (h/code "(assoc! x :a 2 :b |1)"))
+    (assert-move-up (h/code "(-> {}"
+                            "    (assoc! |:b 1 :a 2))")
+                    (h/code "(-> {}"
+                            "    (assoc! :a 2 |:b 1))"))
+    (assert-move-up (h/code "(some-> {}"
+                            "        (assoc! |:b 1 :a 2))")
+                    (h/code "(some-> {}"
+                            "        (assoc! :a 2 |:b 1))"))
+    (assert-move-up (h/code "(cond-> {}"
+                            "  true (assoc! |:b 1 :a 2))")
+                    (h/code "(cond-> {}"
+                            "  true (assoc! :a 2 |:b 1))"))
+    (assert-move-up (h/code "(cond-> x |b dec a inc)")
+                    (h/code "(cond-> x a inc |b dec)"))
+    (assert-move-up (h/code "(cond-> x |b dec a inc)")
+                    (h/code "(cond-> x a inc b |dec)"))
+    (assert-move-up (h/code "(-> 1"
+                            "    (cond-> |b dec a inc))")
+                    (h/code "(-> 1"
+                            "    (cond-> a inc |b dec))"))
+    (assert-move-up (h/code "(some-> 1"
+                            "        (cond-> |b dec a inc))")
+                    (h/code "(some-> 1"
+                            "        (cond-> a inc |b dec))"))
+    (assert-move-up (h/code "(cond-> 1"
+                            "  true (cond-> |b dec a inc))")
+                    (h/code "(cond-> 1"
+                            "  true (cond-> a inc |b dec))"))
+    (assert-move-up (h/code "(cond->> x |b dec a inc)")
+                    (h/code "(cond->> x a inc |b dec)"))
+    (assert-move-up (h/code "(cond->> x |b dec a inc)")
+                    (h/code "(cond->> x a inc b |dec)"))
+    (assert-move-up (h/code "(-> 1"
+                            "    (cond->> |b dec a inc))")
+                    (h/code "(-> 1"
+                            "    (cond->> a inc |b dec))"))
+    (assert-move-up (h/code "(some-> 1"
+                            "        (cond->> |b dec a inc))")
+                    (h/code "(some-> 1"
+                            "        (cond->> a inc |b dec))"))
+    (assert-move-up (h/code "(cond-> 1"
+                            "  true (cond->> |b dec a inc))")
+                    (h/code "(cond-> 1"
+                            "  true (cond->> a inc |b dec))"))
+    (assert-move-up (h/code "(case a |2 :second 1 :first)")
+                    (h/code "(case a 1 :first |2 :second)"))
+    (assert-move-up (h/code "(case a |2 :second 1 :first)")
+                    (h/code "(case a 1 :first 2 |:second)"))
+    (assert-move-up (h/code "(case a |2 :second 1 :first :else)")
+                    (h/code "(case a 1 :first |2 :second :else)"))
+    (assert-move-up (h/code "(case a |2 :second 1 :first :else)")
+                    (h/code "(case a 1 :first 2 |:second :else)"))
+    (assert-move-up (h/code "(-> 1"
+                            "    (case |2 :second 1 :first))")
+                    (h/code "(-> 1"
+                            "    (case 1 :first |2 :second))"))
+    (assert-move-up (h/code "(some-> 1"
+                            "        (case |2 :second 1 :first))")
+                    (h/code "(some-> 1"
+                            "        (case 1 :first |2 :second))"))
+    (assert-move-up (h/code "(cond-> 1"
+                            "  true (case |2 :second 1 :first))")
+                    (h/code "(cond-> 1"
+                            "  true (case 1 :first |2 :second))"))
+    (assert-move-up (h/code "(condp = x |b 2 a 1)")
+                    (h/code "(condp = x a 1 |b 2)"))
+    (assert-move-up (h/code "(condp = x |b 2 a 1)")
+                    (h/code "(condp = x a 1 b |2)"))
+    (assert-move-up (h/code "(condp = x |b 2 a 1 :else)")
+                    (h/code "(condp = x a 1 |b 2 :else)"))
+    (assert-move-up (h/code "(condp = x |b 2 a 1 :else)")
+                    (h/code "(condp = x a 1 b |2 :else)"))
+    (assert-move-up (h/code "(condp some [1 2 3 4]"
+                            "  |#{4 5 9} :>> dec"
+                            "  #{0 6 7} :>> inc)")
+                    (h/code "(condp some [1 2 3 4]"
+                            "  #{0 6 7} :>> inc"
+                            "  |#{4 5 9} :>> dec)"))
+    (assert-move-up (h/code "(condp some [1 2 3 4]"
+                            "  |#{4 5 9} :>> dec"
+                            "  #{0 6 7} :>> inc)")
+                    (h/code "(condp some [1 2 3 4]"
+                            "  #{0 6 7} :>> inc"
+                            "  #{4 5 9} |:>> dec)"))
+    (assert-move-up (h/code "(condp some [1 2 3 4]"
+                            "  |#{4 5 9} :>> dec"
+                            "  #{0 6 7} :>> inc)")
+                    (h/code "(condp some [1 2 3 4]"
+                            "  #{0 6 7} :>> inc"
+                            "  #{4 5 9} :>> |dec)"))
+    (assert-move-up (h/code "(condp some [1 2 3 4]"
+                            "  |#{4 5 9} :>> dec"
+                            "  #{0 6 7} :>> inc"
+                            "  :else)")
+                    (h/code "(condp some [1 2 3 4]"
+                            "  #{0 6 7} :>> inc"
+                            "  #{4 5 9} :>> |dec"
+                            "  :else)")))
   (testing "with destructuring"
     (assert-move-up (h/code "(let [[a b] [1 2]"
                             "      |e 2"
@@ -225,19 +460,8 @@
                             ""
                             " :b 2"
                             "|"
-                            " :c 2}"))
-    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
-    ;; don't at least no erroneous swaps happen
-    (let [ws-zloc (h/load-code-and-zloc (h/code "[:a"
-                                                "|"
-                                                "]"))]
-      (is (can-move-zloc-up? ws-zloc))
-      (is (nil? (move-zloc-up ws-zloc))))
-    (let [ws-zloc (h/load-code-and-zloc (h/code "{:a 1"
-                                                "|"
-                                                "}"))]
-      (is (can-move-zloc-up? ws-zloc))
-      (is (nil? (move-zloc-up ws-zloc)))))
+                            " :c 2}")))
+
   (testing "comments"
     (assert-move-up (h/code "{|:b (+ 1 1) ;; two comment"
                             " :a 1 ;; one comment"
@@ -303,11 +527,21 @@
                             " ]")
                     (h/code "[a ;; a comment"
                             " |b]"))
+    (assert-move-up (h/code "[|b"
+                            "    a ;; a comment"
+                            " ]")
+                    (h/code "[a ;; a comment"
+                            "    |b]"))
     (assert-move-up (h/code "{|:b 2"
                             " :a 1 ;; one comment"
                             " }")
                     (h/code "{:a 1 ;; one comment"
                             " |:b 2}"))
+    (assert-move-up (h/code "{|:b 2"
+                            "    :a 1 ;; one comment"
+                            " }")
+                    (h/code "{:a 1 ;; one comment"
+                            "    |:b 2}"))
     ;; moves from leading comment
     (assert-move-up (h/code "{|;; b comment"
                             " :b 2 ;; two comment"
@@ -324,16 +558,17 @@
                     (h/code "{:a 1 ;; one comment"
                             " :b 2 ;; |two comment"
                             " :c 3}"))
-    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
-    ;; don't at least no erroneous swaps happen
-    (let [ws-zloc (h/load-code-and-zloc (h/code "[:a |;; a comment"
-                                                "]"))]
-      (is (can-move-zloc-up? ws-zloc))
-      (is (nil? (move-zloc-up ws-zloc))))
-    (let [ws-zloc (h/load-code-and-zloc (h/code "{:a 1 |;; one comment"
-                                                "}"))]
-      (is (can-move-zloc-up? ws-zloc))
-      (is (nil? (move-zloc-up ws-zloc)))))
+    ;; treats uneval as comment
+    (assert-move-up (h/code "(case 1"
+                            "  |2"
+                            "  #_=> :two"
+                            "  1"
+                            "  #_=> :one)")
+                    (h/code "(case 1"
+                            "  1"
+                            "  #_=> :one"
+                            "  |2"
+                            "  #_=> :two)")))
   (testing "multi-line elements"
     (assert-move-up (h/code "[|:c"
                             " [:a"
@@ -440,6 +675,129 @@
                               "(foo [|a 1"
                               "      b 2]"
                               "  (inc a))")))
+  (testing "within special functions"
+    (assert-move-down (h/code "(cond b 2 |a 1)")
+                      (h/code "(cond |a 1 b 2)"))
+    (assert-move-down (h/code "(cond b 2 |a 1)")
+                      (h/code "(cond a |1 b 2)"))
+    (assert-move-down (h/code "(assoc x :b 1 |:a 2)")
+                      (h/code "(assoc x |:a 2 :b 1)"))
+    (assert-move-down (h/code "(assoc x :b 1 |:a 2)")
+                      (h/code "(assoc x :a |2 :b 1)"))
+    (assert-move-down (h/code "(-> {}"
+                              "    (assoc :b 1 |:a 2))")
+                      (h/code "(-> {}"
+                              "    (assoc |:a 2 :b 1))"))
+    (assert-move-down (h/code "(some-> {}"
+                              "        (assoc :b 1 |:a 2))")
+                      (h/code "(some-> {}"
+                              "        (assoc |:a 2 :b 1))"))
+    (assert-move-down (h/code "(cond-> {}"
+                              "  true (assoc :b 1 |:a 2))")
+                      (h/code "(cond-> {}"
+                              "  true (assoc |:a 2 :b 1))"))
+    (assert-move-down (h/code "(assoc! x :b 1 |:a 2)")
+                      (h/code "(assoc! x |:a 2 :b 1)"))
+    (assert-move-down (h/code "(assoc! x :b 1 |:a 2)")
+                      (h/code "(assoc! x :a |2 :b 1)"))
+    (assert-move-down (h/code "(-> {}"
+                              "    (assoc! :b 1 |:a 2))")
+                      (h/code "(-> {}"
+                              "    (assoc! |:a 2 :b 1))"))
+    (assert-move-down (h/code "(some-> {}"
+                              "        (assoc! :b 1 |:a 2))")
+                      (h/code "(some-> {}"
+                              "        (assoc! |:a 2 :b 1))"))
+    (assert-move-down (h/code "(cond-> {}"
+                              "  true (assoc! :b 1 |:a 2))")
+                      (h/code "(cond-> {}"
+                              "  true (assoc! |:a 2 :b 1))"))
+    (assert-move-down (h/code "(cond-> x b dec |a inc)")
+                      (h/code "(cond-> x |a inc b dec)"))
+    (assert-move-down (h/code "(cond-> x b dec |a inc)")
+                      (h/code "(cond-> x a |inc b dec)"))
+    (assert-move-down (h/code "(-> 1"
+                              "    (cond-> b dec |a inc))")
+                      (h/code "(-> 1"
+                              "    (cond-> |a inc b dec))"))
+    (assert-move-down (h/code "(some-> 1"
+                              "        (cond-> b dec |a inc))")
+                      (h/code "(some-> 1"
+                              "        (cond-> |a inc b dec))"))
+    (assert-move-down (h/code "(cond-> 1"
+                              "  true (cond-> b dec |a inc))")
+                      (h/code "(cond-> 1"
+                              "  true (cond-> |a inc b dec))"))
+    (assert-move-down (h/code "(cond->> x b dec |a inc)")
+                      (h/code "(cond->> x |a inc b dec)"))
+    (assert-move-down (h/code "(cond->> x b dec |a inc)")
+                      (h/code "(cond->> x a |inc b dec)"))
+    (assert-move-down (h/code "(-> 1"
+                              "    (cond->> b dec |a inc))")
+                      (h/code "(-> 1"
+                              "    (cond->> |a inc b dec))"))
+    (assert-move-down (h/code "(some-> 1"
+                              "        (cond->> b dec |a inc))")
+                      (h/code "(some-> 1"
+                              "        (cond->> |a inc b dec))"))
+    (assert-move-down (h/code "(cond-> 1"
+                              "  true (cond->> b dec |a inc))")
+                      (h/code "(cond-> 1"
+                              "  true (cond->> |a inc b dec))"))
+    (assert-move-down (h/code "(case a 2 :second |1 :first)")
+                      (h/code "(case a |1 :first 2 :second)"))
+    (assert-move-down (h/code "(case a 2 :second |1 :first)")
+                      (h/code "(case a 1 |:first 2 :second)"))
+    (assert-move-down (h/code "(case a 2 :second |1 :first :else)")
+                      (h/code "(case a |1 :first 2 :second :else)"))
+    (assert-move-down (h/code "(case a 2 :second |1 :first :else)")
+                      (h/code "(case a 1 |:first 2 :second :else)"))
+    (assert-move-down (h/code "(-> 1"
+                              "    (case 2 :second |1 :first))")
+                      (h/code "(-> 1"
+                              "    (case |1 :first 2 :second))"))
+    (assert-move-down (h/code "(some-> 1"
+                              "        (case 2 :second |1 :first))")
+                      (h/code "(some-> 1"
+                              "        (case |1 :first 2 :second))"))
+    (assert-move-down (h/code "(cond-> 1"
+                              "  true (case 2 :second |1 :first))")
+                      (h/code "(cond-> 1"
+                              "  true (case |1 :first 2 :second))"))
+    (assert-move-down (h/code "(condp = x b 2 |a 1)")
+                      (h/code "(condp = x |a 1 b 2)"))
+    (assert-move-down (h/code "(condp = x b 2 |a 1)")
+                      (h/code "(condp = x a |1 b 2)"))
+    (assert-move-down (h/code "(condp = x b 2 |a 1 :else)")
+                      (h/code "(condp = x |a 1 b 2 :else)"))
+    (assert-move-down (h/code "(condp = x b 2 |a 1 :else)")
+                      (h/code "(condp = x a |1 b 2 :else)"))
+    (assert-move-down (h/code "(condp some [1 2 3 4]"
+                              "  #{4 5 9} :>> dec"
+                              "  |#{0 6 7} :>> inc)")
+                      (h/code "(condp some [1 2 3 4]"
+                              "  |#{0 6 7} :>> inc"
+                              "  #{4 5 9} :>> dec)"))
+    (assert-move-down (h/code "(condp some [1 2 3 4]"
+                              "  #{4 5 9} :>> dec"
+                              "  |#{0 6 7} :>> inc)")
+                      (h/code "(condp some [1 2 3 4]"
+                              "  #{0 6 7} |:>> inc"
+                              "  #{4 5 9} :>> dec)"))
+    (assert-move-down (h/code "(condp some [1 2 3 4]"
+                              "  #{4 5 9} :>> dec"
+                              "  |#{0 6 7} :>> inc)")
+                      (h/code "(condp some [1 2 3 4]"
+                              "  #{0 6 7} :>> |inc"
+                              "  #{4 5 9} :>> dec)"))
+    (assert-move-down (h/code "(condp some [1 2 3 4]"
+                              "  #{4 5 9} :>> dec"
+                              "  |#{0 6 7} :>> inc"
+                              "  :else)")
+                      (h/code "(condp some [1 2 3 4]"
+                              "  #{0 6 7} :>> |inc"
+                              "  #{4 5 9} :>> dec"
+                              "  :else)")))
   (testing "with destructuring"
     (assert-move-down (h/code "(let [[a b] [1 2]"
                               "      {:keys [c d]} {:c 1 :d 2}"
@@ -477,17 +835,7 @@
                               "|"
                               " :b 2"
                               ""
-                              " :c 2}"))
-    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
-    ;; don't at least no erroneous swaps happen
-    (let [ws-zloc (h/load-code-and-zloc (h/code "[|"
-                                                " :a]"))]
-      (is (can-move-zloc-down? ws-zloc))
-      (is (nil? (move-zloc-down ws-zloc))))
-    (let [ws-zloc (h/load-code-and-zloc (h/code "{|"
-                                                " :a 1}"))]
-      (is (can-move-zloc-down? ws-zloc))
-      (is (nil? (move-zloc-down ws-zloc)))))
+                              " :c 2}")))
   (testing "comments"
     (assert-move-down (h/code "{:b (+ 1 1) ;; two comment"
                               " |:a 1 ;; one comment"
@@ -575,17 +923,7 @@
                               " :c 3}")
                       (h/code "{:a 1 ;; |one comment"
                               " :b 2 ;; two comment"
-                              " :c 3}"))
-    ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
-    ;; don't at least no erroneous swaps happen
-    (let [ws-zloc (h/load-code-and-zloc (h/code "[|;; a comment"
-                                                " :a]"))]
-      (is (can-move-zloc-down? ws-zloc))
-      (is (nil? (move-zloc-down ws-zloc))))
-    (let [ws-zloc (h/load-code-and-zloc (h/code "{|;; a comment"
-                                                " :a 1}"))]
-      (is (can-move-zloc-down? ws-zloc))
-      (is (nil? (move-zloc-down ws-zloc)))))
+                              " :c 3}")))
   (testing "multi-line elements"
     (assert-move-down (h/code "[:c"
                               " |[:a"
@@ -611,3 +949,55 @@
                       (h/code "{|:c 3"
                               " :a {:a/a 1"
                               "     :a/b 2}}"))))
+
+;; These are macros so test failures have the right line numbers
+(defmacro assert-no-erroneous-up [code]
+  `(let [ws-zloc# (h/load-code-and-zloc ~code)]
+     (is (can-move-zloc-up? ws-zloc#))
+     (is (nil? (as-string (move-zloc-up ws-zloc#))))))
+(defmacro assert-no-erroneous-down [code]
+  `(let [ws-zloc# (h/load-code-and-zloc ~code)]
+     (is (can-move-zloc-down? ws-zloc#))
+     (is (nil? (as-string (move-zloc-down ws-zloc#))))))
+
+(deftest erroneous-swaps
+  ;; NOTE: ideally can-move-*? and move-* would always agree, but when they
+  ;; don't at least no erroneous swaps happen
+  (testing "from blank line after first element"
+    (assert-no-erroneous-up (h/code "[:a"
+                                    "|"
+                                    "]"))
+    (assert-no-erroneous-up (h/code "{:a 1"
+                                    "|"
+                                    "}"))
+    (assert-no-erroneous-up (h/code "(case a"
+                                    "   1 :first"
+                                    "|"
+                                    ")")))
+
+  (testing "from comment after first element"
+    (assert-no-erroneous-up (h/code "[:a |;; a comment"
+                                    "]"))
+    (assert-no-erroneous-up (h/code "{:a 1 |;; one comment"
+                                    "}"))
+    (assert-no-erroneous-up (h/code "(case a"
+                                    "   1 :first |;; one comment"
+                                    ")")))
+
+  (testing "from blank line before last element"
+    (assert-no-erroneous-down (h/code "[|"
+                                      " :a]"))
+    (assert-no-erroneous-down (h/code "{|"
+                                      " :a 1}"))
+    (assert-no-erroneous-down (h/code "(case a"
+                                      "|"
+                                      "   1 :first :else)")))
+
+  (testing "from comment before last element"
+    (assert-no-erroneous-down (h/code "[|;; a comment"
+                                      " :a]"))
+    (assert-no-erroneous-down (h/code "{|;; a comment"
+                                      " :a 1}"))
+    (assert-no-erroneous-down (h/code "(case a"
+                                      "   |;; one comment"
+                                      "   1 :first :else)"))))


### PR DESCRIPTION
Some functions are known to take a set of clauses which are binary expressions. For example, `case` has clauses made up of a test-constant and a result-expr. `move-coll-entry` should move these clauses together.

```clojure
(case a
  |1 :one
  2 :two)

;; should become

(case a
  2 :two
  |1 :one)
```

This patch makes clauses move together for `assoc`, `assoc!`, `case`, `cond`, `condp`, `cond->`, and `cond->>`. It handles the optional default expression in `case` and `condp`.

It's common to find some of these functions within threading macros, and so this patch handles those situations too. I don't use that syntax often so I'm not sure I've covered all the cases.

It also handles the [ternary expression syntax](https://clojuredocs.org/clojure.core/condp) of `condp`. I believe that usage is rare in the wild, but this code understands it.