### PR TITLE
Add missing test

### DIFF
--- a/lib/test/clojure_lsp/features/completion_test.clj
+++ b/lib/test/clojure_lsp/features/completion_test.clj
@@ -312,12 +312,17 @@
     (h/code "(ns other.ns (:require [some.alpaca :as alp]))"
             "::alp/"
             "") "file:///someother/ns.clj")
-  (testing "return all reg keywords for that aliased keyword"
+  (testing "return all matching reg keywords for that aliased keyword"
+    (h/assert-submaps
+      [{:label "::alp/foo" :kind :keyword}
+       {:label "::alp/foob" :kind :keyword}]
+      (f.completion/completion (h/file-uri "file:///other/ns.clj") 2 8 db/db)))
+  (testing "return all reg keywords for plain alias"
     (h/assert-submaps
       [{:label "::alp/bar" :kind :keyword}
        {:label "::alp/foo" :kind :keyword}
        {:label "::alp/foob" :kind :keyword}]
-      (f.completion/completion (h/file-uri "file:///someother/ns.clj") 2 6 db/db))))
+      (f.completion/completion (h/file-uri "file:///someother/ns.clj") 2 7 db/db))))
 
 (deftest completing-sorting
   (h/load-code-and-locs


### PR DESCRIPTION
This new test ensures we have completion tests for both `::alp/` and `::alp/f`. Relevant [conditional](https://github.com/clojure-lsp/clojure-lsp/blob/master/lib/src/clojure_lsp/feature/completion.clj#L395-L399). The fixture data was already there, so it looks like it was always the intention to test this.