### PR TITLE
Fix wrong args on extract function from multi-arity fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - General
   - Fix cljfmt settings merge during refresh/classpath configs merge to avoid multiple config vectors on same symbol.
 
+- Editor
+  - Fix wrong args on extract function from multi-arity fn. #683
+
 ## 2022.02.23-12.12.12
 
 - General

--- a/cli/integration-test/sample-test/src/sample_test/stubs/a.clj
+++ b/cli/integration-test/sample-test/src/sample_test/stubs/a.clj
@@ -1,4 +1,4 @@
-(ns sample-test.src.sample-test.stubs.a
+(ns sample-test.stubs.a
   (:require [datomic.api :as d]))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -9,7 +9,7 @@
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
         medley/medley {:mvn/version "1.3.0"}
         anonimitoraf/clj-flx {:mvn/version "1.2.0"}
-        clj-kondo/clj-kondo {:mvn/version "2022.02.09"
+        clj-kondo/clj-kondo {:mvn/version "2022.02.10-20220228.221653-9"
                              :exclude [com.cognitect/transit-clj]}
         com.cognitect/transit-clj {:mvn/version "1.0.329"}
         com.github.clj-easy/stub {:mvn/version "0.2.3"}

--- a/lib/test/clojure_lsp/refactor/transform_test.clj
+++ b/lib/test/clojure_lsp/refactor/transform_test.clj
@@ -380,6 +380,19 @@
                        "  |(+ 1 a))")
                (extract-function "foo")
                as-strings))))
+  (testing "On multi-arity function"
+    (is (= [(h/code ""
+                    "(defn foo [a b]"
+                    "  (= a b))"
+                    "")
+            (h/code "(foo a b)")]
+           (-> (h/code "(defn mytest"
+                       "  ([a b]"
+                       "   (if |(= a b)"
+                       "      1"
+                       "      2)))")
+               (extract-function "foo")
+               as-strings))))
   (testing "from comment"
     (is (= [(h/code ""
                     "(defn foo [a]"


### PR DESCRIPTION
This bumps clj-kondo to include a fix that adds scope-end to the args of multi-arity fns. This fix ensures that these args are included as params when a new function is extracted from their body, fixing #683.

Also includes some test changes to avoid false negatives from a new diagnostic in clj-kondo.
