### PR TITLE
Range formatting performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - General
   - Fix cljfmt settings merge during refresh/classpath configs merge to avoid multiple config vectors on same symbol.
   - Fix install script for aarch64. #794
+  - parser: more efficiently seek to cursor position, improving performance especially in large files. #793 @mainej
 
 - Editor
   - extract-function: Fix wrong args when extracting from multi-arity fn. #683
@@ -14,6 +15,7 @@
   - Improve and add lots of new snippets following practicalli config. #797
   - Improve how watched new files are analyzed avoiding infinite loops and performance issues. #796
   - Fix "incoming call hierarchy" not considering usages inside defmethods. #808
+  - range-formatting: more efficiently locate extent of range and reduce number of calls to cljfmt, improving performance especially when formatting large ranges. #795 @mainej
 
 ## 2022.02.23-12.12.12
 

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -3,6 +3,7 @@
    [cljfmt.core :as cljfmt]
    [cljfmt.main :as cljfmt.main]
    [clojure-lsp.parser :as parser]
+   [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
    [clojure.core.memoize :as memoize]
@@ -46,222 +47,23 @@
         :new-text new-text}])))
 
 (defn range-formatting [doc-id format-pos db]
-  (let [{:keys [text]} (get-in @db [:documents doc-id])
-        cljfmt-settings (cljfmt-config db)
-        forms (parser/find-top-forms-in-range text format-pos)]
-    (mapv (fn [form-loc]
-            {:range (shared/->range (-> form-loc z/node meta))
-             :new-text (n/string (cljfmt/reformat-form (z/node form-loc) cljfmt-settings))})
-          forms)))
+  (let [cljfmt-settings (cljfmt-config db)
+        root-loc (parser/zloc-of-file @db doc-id)
+        start-loc (or (parser/to-pos root-loc (:row format-pos) (:col format-pos))
+                      (z/leftmost* root-loc))
+        end-loc (or (parser/to-pos root-loc (:end-row format-pos) (:end-col format-pos))
+                    (z/rightmost* root-loc))
+        start-top-loc (edit/to-top start-loc)
+        end-top-loc (edit/to-top end-loc)
 
-(comment
-  (require '[clj-async-profiler.core :as profiler])
-  (require '[criterium.core :as bench])
-  (require '[clojure-lsp.db :as db])
-  (require '[clojure-lsp.refactor.edit :as edit])
-  (defn range-formatting-non-reduce-map-reformat [doc-id format-pos db]
-    (let [cljfmt-settings (cljfmt-config db)
-          root-loc (parser/zloc-of-file @db doc-id)
-          forms (edit/find-forms root-loc #(edit/in-range? format-pos (-> % z/node meta)))
-          start-top-loc (-> forms first (z/find z/up edit/top?))
-          end-top-loc (-> forms last (z/find z/up edit/top?))
-
-          forms (->> start-top-loc
-                     (iterate z/right*)
-                     (take-while identity)
-                     (take-while (complement z/end?))
-                     (medley/take-upto #(= % end-top-loc)))]
-      (mapv (fn [form-loc]
-              {:range (shared/->range (-> form-loc z/node meta))
-               :new-text (n/string (cljfmt/reformat-form (z/node form-loc) cljfmt-settings))})
-            forms)))
-
-  (defn range-formatting-non-reduce-merge-format [doc-id format-pos db]
-    (let [cljfmt-settings (cljfmt-config db)
-          root-loc (parser/zloc-of-file @db doc-id)
-          forms (edit/find-forms root-loc #(edit/in-range? format-pos (-> % z/node meta)))
-          start-top-loc (-> forms first (z/find z/up edit/top?))
-          end-top-loc (-> forms last (z/find z/up edit/top?))
-
-          forms (->> start-top-loc
-                     (iterate z/right*)
-                     (take-while identity)
-                     (take-while (complement z/end?))
-                     (medley/take-upto #(= % end-top-loc)))
-          span (merge (-> start-top-loc z/node meta (select-keys [:row :col]))
-                      (-> end-top-loc z/node meta (select-keys [:end-row :end-col])))]
-      [{:range (shared/->range span)
-        :new-text (-> (map z/node forms)
-                      n/forms-node
-                      (cljfmt/reformat-form cljfmt-settings)
-                      n/string)}]))
-
-  (defn range-formatting-custom-to-pos [doc-id format-pos db]
-    (let [cljfmt-settings (cljfmt-config db)
-          root-loc (parser/zloc-of-file @db doc-id)
-          start-loc (or (parser/to-pos root-loc (:row format-pos) (:col format-pos))
-                        (z/leftmost* root-loc))
-          end-loc (or (parser/to-pos start-loc (:end-row format-pos) (:end-col format-pos))
-                      (z/rightmost* root-loc))
-          start-top-loc (z/find start-loc z/up edit/top?)
-          end-top-loc (z/find end-loc z/up edit/top?)
-
-          forms (->> start-top-loc
-                     (iterate z/right*) ;; maintain comments and whitespace between nodes
-                     (take-while identity)
-                     (take-while (complement z/end?))
-                     (medley/take-upto #(= % end-top-loc)))
-          span (merge (-> start-top-loc z/node meta (select-keys [:row :col]))
-                      (-> end-top-loc z/node meta (select-keys [:end-row :end-col])))]
-      [{:range (shared/->range span)
-        :new-text (-> (map z/node forms)
-                      n/forms-node
-                      (cljfmt/reformat-form cljfmt-settings)
-                      n/string)}]))
-
-  (defn emacs->pos [el ec]
-    [el (inc ec)])
-
-  (defn stub []
-    (bench/quick-bench (* 2 3))
-    (profiler/profile
-      {:min-width 5}
-      (dotimes [_ 500]
-        (* 2 3))))
-
-  (profiler/serve-files 8080)
-
-  (def long-file-uri "file:///Users/jmaine/workspace/opensource/clojure-lsp/lib/src/clojure_lsp/feature/tmp.clj")
-  (def short-range {:row 13
-                    :col 1
-                    :end-row 15
-                    :end-col 1})
-  (def med-range {:row 11
-                  :col 1
-                  :end-row 28
-                  :end-col 2})
-  (def long-range {:row 11
-                   :col 1
-                   :end-row 1028
-                   :end-col 2})
-  (def this-uri "file:///Users/jmaine/workspace/opensource/clojure-lsp/lib/src/clojure_lsp/feature/format.clj")
-  (def uri long-file-uri)
-
-  (formatting uri db/db)
-  (formatting uri db/db)
-
-  (time
-    (let [pos {:row 145 :col 15 :end-row 152 :end-col 35}]
-      #_(range-formatting this-uri pos db/db)
-      #_(range-formatting-v1 this-uri pos db/db)
-      (range-formatting-custom-to-pos this-uri pos db/db)))
-  (time
-    (let [pos {:row 0 :col 0 :end-row 1000 :end-col 35}]
-      #_(range-formatting this-uri pos db/db)
-      #_(range-formatting-v1 this-uri pos db/db)
-      (range-formatting-custom-to-pos this-uri pos db/db)))
-
-  (def orig-result (range-formatting-non-reduce-merge-format long-file-uri med-range db/db))
-  (range-formatting-non-reduce-merge-format long-file-uri med-range db/db)
-  (range-formatting-non-reduce-merge-format long-file-uri short-range db/db)
-  (time (range-formatting-non-reduce-merge-format long-file-uri long-range db/db))
-  (do
-    (println "\n\n\n med v0")
-    (bench/quick-bench
-      (range-formatting long-file-uri med-range db/db)))
-  (do
-    (println "\n\n\n long v0")
-    (bench/quick-bench
-      (range-formatting long-file-uri long-range db/db)))
-  (do
-    (println "\n\n\n med find-forms map")
-    (bench/quick-bench
-      (range-formatting-non-reduce-map-reformat long-file-uri med-range db/db)))
-  (do
-    (println "\n\n\n long find-forms map")
-    (bench/quick-bench
-      (range-formatting-non-reduce-map-reformat long-file-uri long-range db/db)))
-  (do
-    (println "\n\n\n med find-forms merge")
-    (bench/quick-bench
-      (range-formatting-non-reduce-merge-format long-file-uri med-range db/db)))
-  (do
-    (println "\n\n\n long find-forms merge")
-    (bench/quick-bench
-      (range-formatting-non-reduce-merge-format long-file-uri long-range db/db)))
-  (do
-    (println "\n\n\n med to-pos")
-    (bench/quick-bench
-      (range-formatting-custom-to-pos long-file-uri med-range db/db)))
-  (do
-    (println "\n\n\n long to-pos")
-    (bench/quick-bench
-      (range-formatting-custom-to-pos long-file-uri long-range db/db)))
-
-  (do
-    (println "\n\n\n med custom to-pos")
-    (bench/quick-bench
-      (range-formatting-custom-to-pos long-file-uri med-range db/db)))
-  (do
-    (println "\n\n\n long custom to-pos")
-    (bench/quick-bench
-      (range-formatting-custom-to-pos long-file-uri long-range db/db)))
-  (do
-    (println "\n\n\n med v0")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 100]
-          (range-formatting long-file-uri med-range db/db)))))
-  (do
-    (println "\n\n\n long v0")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 20]
-          (range-formatting long-file-uri long-range db/db)))))
-  (do
-    (println "\n\n\n med find-forms map")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 100]
-          (range-formatting-non-reduce-map-reformat long-file-uri med-range db/db)))))
-  (do
-    (println "\n\n\n long find-forms map")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 20]
-          (range-formatting-non-reduce-map-reformat long-file-uri long-range db/db)))))
-  (do
-    (println "\n\n\n med find-forms merge")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 100]
-          (range-formatting-non-reduce-merge-format long-file-uri med-range db/db)))))
-  (do
-    (println "\n\n\n long find-forms merge")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 40]
-          (range-formatting-non-reduce-merge-format long-file-uri long-range db/db)))))
-  (do
-    (println "\n\n\n med to-loc")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 200]
-          (range-formatting-custom-to-pos long-file-uri med-range db/db)))))
-  (do
-    (println "\n\n\n long to-loc")
-    (time
-      (profiler/profile
-        {:min-width 5}
-        (dotimes [_ 40]
-          (range-formatting-custom-to-pos long-file-uri long-range db/db)))))
-
-  (range-formatting-custom-to-pos long-file-uri long-range db/db))
-
+        forms (->> start-top-loc
+                   (iterate z/right*) ;; maintain comments and whitespace between nodes
+                   (take-while (complement z/end?))
+                   (medley/take-upto #(= % end-top-loc)))
+        span (merge (-> start-top-loc z/node meta (select-keys [:row :col]))
+                    (-> end-top-loc z/node meta (select-keys [:end-row :end-col])))]
+    [{:range (shared/->range span)
+      :new-text (-> (map z/node forms)
+                    n/forms-node
+                    (cljfmt/reformat-form cljfmt-settings)
+                    n/string)}]))

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -53,3 +53,215 @@
             {:range (shared/->range (-> form-loc z/node meta))
              :new-text (n/string (cljfmt/reformat-form (z/node form-loc) cljfmt-settings))})
           forms)))
+
+(comment
+  (require '[clj-async-profiler.core :as profiler])
+  (require '[criterium.core :as bench])
+  (require '[clojure-lsp.db :as db])
+  (require '[clojure-lsp.refactor.edit :as edit])
+  (defn range-formatting-non-reduce-map-reformat [doc-id format-pos db]
+    (let [cljfmt-settings (cljfmt-config db)
+          root-loc (parser/zloc-of-file @db doc-id)
+          forms (edit/find-forms root-loc #(edit/in-range? format-pos (-> % z/node meta)))
+          start-top-loc (-> forms first (z/find z/up edit/top?))
+          end-top-loc (-> forms last (z/find z/up edit/top?))
+
+          forms (->> start-top-loc
+                     (iterate z/right*)
+                     (take-while identity)
+                     (take-while (complement z/end?))
+                     (medley/take-upto #(= % end-top-loc)))]
+      (mapv (fn [form-loc]
+              {:range (shared/->range (-> form-loc z/node meta))
+               :new-text (n/string (cljfmt/reformat-form (z/node form-loc) cljfmt-settings))})
+            forms)))
+
+  (defn range-formatting-non-reduce-merge-format [doc-id format-pos db]
+    (let [cljfmt-settings (cljfmt-config db)
+          root-loc (parser/zloc-of-file @db doc-id)
+          forms (edit/find-forms root-loc #(edit/in-range? format-pos (-> % z/node meta)))
+          start-top-loc (-> forms first (z/find z/up edit/top?))
+          end-top-loc (-> forms last (z/find z/up edit/top?))
+
+          forms (->> start-top-loc
+                     (iterate z/right*)
+                     (take-while identity)
+                     (take-while (complement z/end?))
+                     (medley/take-upto #(= % end-top-loc)))
+          span (merge (-> start-top-loc z/node meta (select-keys [:row :col]))
+                      (-> end-top-loc z/node meta (select-keys [:end-row :end-col])))]
+      [{:range (shared/->range span)
+        :new-text (-> (map z/node forms)
+                      n/forms-node
+                      (cljfmt/reformat-form cljfmt-settings)
+                      n/string)}]))
+
+  (defn range-formatting-custom-to-pos [doc-id format-pos db]
+    (let [cljfmt-settings (cljfmt-config db)
+          root-loc (parser/zloc-of-file @db doc-id)
+          start-loc (or (parser/to-pos root-loc (:row format-pos) (:col format-pos))
+                        (z/leftmost* root-loc))
+          end-loc (or (parser/to-pos start-loc (:end-row format-pos) (:end-col format-pos))
+                      (z/rightmost* root-loc))
+          start-top-loc (z/find start-loc z/up edit/top?)
+          end-top-loc (z/find end-loc z/up edit/top?)
+
+          forms (->> start-top-loc
+                     (iterate z/right*) ;; maintain comments and whitespace between nodes
+                     (take-while identity)
+                     (take-while (complement z/end?))
+                     (medley/take-upto #(= % end-top-loc)))
+          span (merge (-> start-top-loc z/node meta (select-keys [:row :col]))
+                      (-> end-top-loc z/node meta (select-keys [:end-row :end-col])))]
+      [{:range (shared/->range span)
+        :new-text (-> (map z/node forms)
+                      n/forms-node
+                      (cljfmt/reformat-form cljfmt-settings)
+                      n/string)}]))
+
+  (defn emacs->pos [el ec]
+    [el (inc ec)])
+
+  (defn stub []
+    (bench/quick-bench (* 2 3))
+    (profiler/profile
+      {:min-width 5}
+      (dotimes [_ 500]
+        (* 2 3))))
+
+  (profiler/serve-files 8080)
+
+  (def long-file-uri "file:///Users/jmaine/workspace/opensource/clojure-lsp/lib/src/clojure_lsp/feature/tmp.clj")
+  (def short-range {:row 13
+                    :col 1
+                    :end-row 15
+                    :end-col 1})
+  (def med-range {:row 11
+                  :col 1
+                  :end-row 28
+                  :end-col 2})
+  (def long-range {:row 11
+                   :col 1
+                   :end-row 1028
+                   :end-col 2})
+  (def this-uri "file:///Users/jmaine/workspace/opensource/clojure-lsp/lib/src/clojure_lsp/feature/format.clj")
+  (def uri long-file-uri)
+
+  (formatting uri db/db)
+  (formatting uri db/db)
+
+  (time
+    (let [pos {:row 145 :col 15 :end-row 152 :end-col 35}]
+      #_(range-formatting this-uri pos db/db)
+      #_(range-formatting-v1 this-uri pos db/db)
+      (range-formatting-custom-to-pos this-uri pos db/db)))
+  (time
+    (let [pos {:row 0 :col 0 :end-row 1000 :end-col 35}]
+      #_(range-formatting this-uri pos db/db)
+      #_(range-formatting-v1 this-uri pos db/db)
+      (range-formatting-custom-to-pos this-uri pos db/db)))
+
+  (def orig-result (range-formatting-non-reduce-merge-format long-file-uri med-range db/db))
+  (range-formatting-non-reduce-merge-format long-file-uri med-range db/db)
+  (range-formatting-non-reduce-merge-format long-file-uri short-range db/db)
+  (time (range-formatting-non-reduce-merge-format long-file-uri long-range db/db))
+  (do
+    (println "\n\n\n med v0")
+    (bench/quick-bench
+      (range-formatting long-file-uri med-range db/db)))
+  (do
+    (println "\n\n\n long v0")
+    (bench/quick-bench
+      (range-formatting long-file-uri long-range db/db)))
+  (do
+    (println "\n\n\n med find-forms map")
+    (bench/quick-bench
+      (range-formatting-non-reduce-map-reformat long-file-uri med-range db/db)))
+  (do
+    (println "\n\n\n long find-forms map")
+    (bench/quick-bench
+      (range-formatting-non-reduce-map-reformat long-file-uri long-range db/db)))
+  (do
+    (println "\n\n\n med find-forms merge")
+    (bench/quick-bench
+      (range-formatting-non-reduce-merge-format long-file-uri med-range db/db)))
+  (do
+    (println "\n\n\n long find-forms merge")
+    (bench/quick-bench
+      (range-formatting-non-reduce-merge-format long-file-uri long-range db/db)))
+  (do
+    (println "\n\n\n med to-pos")
+    (bench/quick-bench
+      (range-formatting-custom-to-pos long-file-uri med-range db/db)))
+  (do
+    (println "\n\n\n long to-pos")
+    (bench/quick-bench
+      (range-formatting-custom-to-pos long-file-uri long-range db/db)))
+
+  (do
+    (println "\n\n\n med custom to-pos")
+    (bench/quick-bench
+      (range-formatting-custom-to-pos long-file-uri med-range db/db)))
+  (do
+    (println "\n\n\n long custom to-pos")
+    (bench/quick-bench
+      (range-formatting-custom-to-pos long-file-uri long-range db/db)))
+  (do
+    (println "\n\n\n med v0")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 100]
+          (range-formatting long-file-uri med-range db/db)))))
+  (do
+    (println "\n\n\n long v0")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 20]
+          (range-formatting long-file-uri long-range db/db)))))
+  (do
+    (println "\n\n\n med find-forms map")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 100]
+          (range-formatting-non-reduce-map-reformat long-file-uri med-range db/db)))))
+  (do
+    (println "\n\n\n long find-forms map")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 20]
+          (range-formatting-non-reduce-map-reformat long-file-uri long-range db/db)))))
+  (do
+    (println "\n\n\n med find-forms merge")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 100]
+          (range-formatting-non-reduce-merge-format long-file-uri med-range db/db)))))
+  (do
+    (println "\n\n\n long find-forms merge")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 40]
+          (range-formatting-non-reduce-merge-format long-file-uri long-range db/db)))))
+  (do
+    (println "\n\n\n med to-loc")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 200]
+          (range-formatting-custom-to-pos long-file-uri med-range db/db)))))
+  (do
+    (println "\n\n\n long to-loc")
+    (time
+      (profiler/profile
+        {:min-width 5}
+        (dotimes [_ 40]
+          (range-formatting-custom-to-pos long-file-uri long-range db/db)))))
+
+  (range-formatting-custom-to-pos long-file-uri long-range db/db))
+

--- a/lib/src/clojure_lsp/parser.clj
+++ b/lib/src/clojure_lsp/parser.clj
@@ -24,7 +24,10 @@
 (def ^:private zero-width-space
   "A unicode character that is incredibly unlikely to be used in regular code.
   During parsing, used as a valid and easily identified subsitute for what would
-  otherwise be an invalid character."
+  otherwise be an invalid character. This character was chosen because
+  rewrite-clj parses it as a single character in a symbol, not as whitespace,
+  and because a zero-width space is invisible and so has little use in source
+  code."
   "\u200b")
 
 (defn ^:private replace-incomplete-token [s invalid-str valid-str]

--- a/lib/src/clojure_lsp/parser.clj
+++ b/lib/src/clojure_lsp/parser.clj
@@ -21,12 +21,6 @@
        (= c name-col)
        (= ec name-end-col)))
 
-(defn find-top-forms-in-range
-  [code pos]
-  (->> (edit/find-forms (z/of-string code) #(edit/in-range? pos (-> % z/node meta)))
-       (mapv (fn [loc] (z/find loc z/up edit/top?)))
-       (distinct)))
-
 (def ^:private zero-width-space
   "A unicode character that is incredibly unlikely to be used in regular code.
   During parsing, used as a valid and easily identified subsitute for what would

--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -25,22 +25,6 @@
        (if (= r row) (>= c col) true)
        (if (= er end-row) (< ec end-col) true)))
 
-(defn z-filter
-  "Return list of nodes satisfying the given predicate `p?`, moving in direction
-  `f` from initial zipper location `zloc`."
-  ([zloc f p?]
-   (->> zloc
-        (iterate f)
-        (take-while identity)
-        (take-while (complement z/end?))
-        (filter p?))))
-
-(defn find-forms
-  "Find sexpr-able nodes satisfying the given predicate depth first from initial
-  zipper location."
-  [zloc p?]
-  (z-filter zloc z/next p?))
-
 (defn ^:private zloc-in-range?
   "Checks whether the `loc`s node is [[in-range?]] of the given `pos`."
   [loc pos]

--- a/lib/test/clojure_lsp/parser_test.clj
+++ b/lib/test/clojure_lsp/parser_test.clj
@@ -80,13 +80,6 @@
       (is (= "a" (to-pos ":foo/ a" 1 7)))
       (is (= "a" (to-pos "::foo/ a" 1 8))))))
 
-(deftest find-top-forms-test
-  (let [code "(a) (b c d)"]
-    (is (= '[(a) (b c d)]
-           (->> {:row 1 :col 2 :end-row 1 :end-col (count code)}
-                (parser/find-top-forms-in-range code)
-                (map z/sexpr))))))
-
 (deftest lein-file->edn
   (testing "simple defproject on root"
     (is (= {:foo 1


### PR DESCRIPTION
This code investigates performance in range-formatting. Historically there have been reports (#266) of poor range formatting performance, particularly in large files for users who have auto-formatting turned on and who use paredit.

I haven't been able to reproduce really terrible performance. The worst I can do is a little over half a second to re-format large chunks of long files. For example when re-formatting the first half of a 2000 line file, which is mostly repeats of the line `(= (+ 1 2) 3)`, I get the following performance data:

```
original algorithm
614ms, std-dev 14ms
7% parsing
52% finding top forms
21% formatting
```

So that's odd... Why does it spend so much time finding the top-level forms? Let's look at `parser/find-top-forms-in-range`. First it finds every node in the range—every token, every sexp, everything. Then for _each one_ it searches upwards, to find a top-level node. Then it distincts those nodes. This is ... inefficient.

It would work equally well to search upward from the first node in the range, and the last node, and then take all the intervening top-level nodes. Let's try that.

```
first-and-last top-level
358ms, std-dev 5ms
10% parsing
9% finding top forms
43% formattting
```

This is better. (I think it also fixes some off-by-one bugs where the full range isn't formatted, but that's tangential.) Can we improve formatting time too? The original algorithm loops over the top level forms that cover the range, calling `cljfmt` for each one. But, perhaps it'd be faster to pass a single node that contains the top-level forms to `cljfmt`, so we only have to call it once.

```
first-and-last top-level, with merged formatting
301ms, std-dev 9ms
14% parsing
10% finding top forms
42% formatting
```

Not a huge improvement, but still better. And one last attempt... What if we use the more efficient cursor navigation from the `economy-of-motion` branch, which this branch is built on, to find the first and last top-level forms?

```
efficient first-and-last top-level, with merged formatting
271ms, std-dev 7ms
15% parsing
0.6% finding top forms
48% formatting
```

All together, that's about 50% faster, just by improving the `clojure-lsp` side. I still wouldn't call 271ms _fast_. I imagine it would be too slow for paredit users. But at least now most of the time is spent outside of `clojure-lsp`—in `rewrite-clj` or `cljfmt`. I think that's a win.

I'll clean this up and turn it into a real PR.
