### PR TITLE
Fix move-coll-entry NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Editor
   - extract-function: Fix wrong args when extracting from multi-arity fn. #683
   - move-coll-entry: clauses move intuitively in `assoc`, `case`, `cond`, and similar functions. #780 @mainej
+  - move-coll-entry: fix NPE when when invoked from top-level #803 @mainej
   - Generate stubs async after startup, improving startup time. #788
   - Improve and add lots of new snippets following practicalli config. #797
 

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -413,20 +413,20 @@
   May return a movement strategy even when the zloc cannot actually be moved.
   See [[valid-strat?]] and [[can-swap?]]."
   [dir zloc uri db]
-  (let [parent-zloc (z-up zloc)
-        child-count (count-children parent-zloc)
-        strat (case (some-> parent-zloc z/tag)
-                :map        {:breadth 2, :rind no-rind}
-                :set        {:breadth 1, :rind no-rind}
-                :vector     (vector-strategy parent-zloc uri db)
-                (:list :fn) (list-strategy parent-zloc child-count)
-                nil)]
-    (when strat
-      (let [strat (assoc strat
-                         :dir dir
-                         :pulp (pulp (:rind strat) child-count))]
-        (when (valid-strat? zloc strat)
-          strat)))))
+  (when-let [parent-zloc (z-up zloc)]
+    (let [child-count (count-children parent-zloc)
+          strat (case (z/tag parent-zloc)
+                  :map        {:breadth 2, :rind no-rind}
+                  :set        {:breadth 1, :rind no-rind}
+                  :vector     (vector-strategy parent-zloc uri db)
+                  (:list :fn) (list-strategy parent-zloc child-count)
+                  nil)]
+      (when strat
+        (let [strat (assoc strat
+                           :dir dir
+                           :pulp (pulp (:rind strat) child-count))]
+          (when (valid-strat? zloc strat)
+            strat))))))
 
 (defn can-move-entry-up? [zloc uri db]
   (boolean (movement-strategy :up zloc uri db)))

--- a/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
+++ b/lib/test/clojure_lsp/feature/move_coll_entry_test.clj
@@ -29,6 +29,7 @@
     (is (not (can-move-code-up? "{1 2 |3}")))
     (is (not (can-move-code-up? "(let [1 2 |3])"))))
   (testing "outside collection"
+    (is (not (can-move-code-up? "|")))
     (is (not (can-move-code-up? "|[]")))
     (is (not (can-move-code-up? "|{:a :b :c :d}")))
     (is (not (can-move-code-up? "|#{:a :b :c :d}")))


### PR DESCRIPTION
This fixes #803 by ensuring a node has a parent before checking whether it can be moved.

- [x] Issue: #803 
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] ~I updated documentation if applicable (`docs` folder)~
