### PR TITLE
Try to avoid infinite loop when analyzing several files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Generate stubs async after startup, improving startup time. #788
   - Improve and add lots of new snippets following practicalli config. #797
   - Improve how watched new files are analyzed avoiding infinite loops and performance issues. #796
+  - Avoid infinite loops when several files are changed simultaneously. #796 @mainej
   - Fix "incoming call hierarchy" not considering usages inside defmethods. #808
   - range-formatting: more efficiently locate extent of range and reduce number of calls to cljfmt, improving performance especially when formatting large ranges. #795 @mainej
   - cycle-fn-literal: *new feature* convert between function-literal syntaxes `(fn [] ...)` <-> `#(...)`. #774

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -163,6 +163,7 @@
         handler (handlers/->ClojureFeatureHandler)
         server (ClojureLspServer. (LSPServer. handler
                                               db/db
+                                              db/initial-db
                                               capabilites
                                               client-settings)
                                   handler)

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -46,8 +46,9 @@
   ([]
    (clean-db! :unit-test))
   ([env]
-   (reset! db/db {:env env
-                  :producer (->TestProducer)})
+   (reset! db/db (assoc db/initial-db
+                        :env env
+                        :producer (->TestProducer)))
    (reset! mock-diagnostics {})
    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
    (alter-var-root #'db/current-changes-chan (constantly (async/chan 1)))

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -9,7 +9,9 @@
 
 (set! *warn-on-reflection* true)
 
-(defonce db (atom {:documents {}}))
+(def initial-db {:documents {}
+                 :processing-changes #{}})
+(defonce db (atom initial-db))
 (defonce current-changes-chan (async/chan 1))
 (defonce diagnostics-chan (async/chan 1))
 (defonce created-watched-files-chan (async/chan 1))

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -149,7 +149,7 @@
           (if (compare-and-set! db state-db (-> state-db
                                                 (update-analysis uri (:analysis kondo-result))
                                                 (update-findings uri (:findings kondo-result))
-                                                (assoc :processing-changes false)
+                                                (update :processing-changes disj uri)
                                                 (assoc :kondo-config (:config kondo-result))))
             (do
               (f.diagnostic/sync-lint-file! uri db)
@@ -164,7 +164,7 @@
     (swap! db (fn [state-db] (-> state-db
                                  (assoc-in [:documents uri :v] version)
                                  (assoc-in [:documents uri :text] final-text)
-                                 (assoc :processing-changes true))))
+                                 (update :processing-changes conj uri))))
     (async/>!! db/current-changes-chan {:uri uri
                                         :text final-text
                                         :version version})))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -40,7 +40,7 @@
      (loop [backoff# 1]
        (if (> (quot (- (System/nanoTime) ~'_time) 1000000) 60000) ; one minute timeout
          (log/warn "Timeout waiting for changes for body")
-         (if (:processing-changes @db/db)
+         (if (seq (:processing-changes @db/db))
            (do
              (Thread/sleep backoff#)
              (recur (min 200 (* 2 backoff#)))) ; 2^0, 2^1, ..., up to 200ms

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -36,10 +36,12 @@
 (set! *warn-on-reflection* true)
 
 (defmacro process-after-changes [task-id uri & body]
-  `(let [~'_time (System/nanoTime)]
+  `(let [start-time# (System/nanoTime)]
      (loop [backoff# 1]
-       (if (> (quot (- (System/nanoTime) ~'_time) 1000000) 60000) ; one minute timeout
-         (log/warnf "Timeout in %s waiting for changes to %s" ~task-id ~uri)
+       (if (> (quot (- (System/nanoTime) start-time#) 1000000) 60000) ; one minute timeout
+         ~(with-meta
+            `(log/warnf "Timeout in %s waiting for changes to %s" ~task-id ~uri)
+            (meta &form))
          (if (contains? (:processing-changes @db/db) ~uri)
            (do
              (Thread/sleep backoff#)

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -35,12 +35,12 @@
 
 (set! *warn-on-reflection* true)
 
-(defmacro process-after-changes [& body]
+(defmacro process-after-changes [task-id uri & body]
   `(let [~'_time (System/nanoTime)]
      (loop [backoff# 1]
        (if (> (quot (- (System/nanoTime) ~'_time) 1000000) 60000) ; one minute timeout
-         (log/warn "Timeout waiting for changes for body")
-         (if (seq (:processing-changes @db/db))
+         (log/warnf "Timeout in %s waiting for changes to %s" ~task-id ~uri)
+         (if (contains? (:processing-changes @db/db) ~uri)
            (do
              (Thread/sleep backoff#)
              (recur (min 200 (* 2 backoff#)))) ; 2^0, 2^1, ..., up to 200ms
@@ -150,6 +150,7 @@
 
 (defn document-highlight [{:keys [textDocument position]}]
   (process-after-changes
+    :document-highlight textDocument
     (let [line (-> position :line inc)
           column (-> position :character inc)
           filename (shared/uri->filename textDocument)
@@ -258,6 +259,7 @@
 
 (defn range-formatting [doc-id format-pos]
   (process-after-changes
+    :range-formatting doc-id
     (f.format/range-formatting doc-id format-pos db/db)))
 
 (defmulti extension (fn [method _] method))
@@ -274,6 +276,7 @@
 (defn code-actions
   [{:keys [range context textDocument]}]
   (process-after-changes
+    :code-actions textDocument
     (let [diagnostics (-> context :diagnostics)
           line (-> range :start :line)
           character (-> range :start :character)
@@ -286,6 +289,7 @@
 (defn code-lens
   [{:keys [textDocument]}]
   (process-after-changes
+    :code-lens textDocument
     (f.code-lens/reference-code-lens textDocument db/db)))
 
 (defn code-lens-resolve
@@ -295,12 +299,14 @@
 (defn semantic-tokens-full
   [{:keys [textDocument]}]
   (process-after-changes
+    :semantic-tokens-full textDocument
     (let [data (f.semantic-tokens/full-tokens textDocument db/db)]
       {:data data})))
 
 (defn semantic-tokens-range
   [{:keys [textDocument] {:keys [start end]} :range}]
   (process-after-changes
+    :semantic-tokens-range textDocument
     (let [range {:name-row (inc (:line start))
                  :name-col (inc (:character start))
                  :name-end-row (inc (:line end))

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -148,7 +148,7 @@
         (async/go-loop [tries 1]
           (if (>= tries 200)
             (log/info "Max tries reached when async custom linting" uri)
-            (if (:processing-changes @db)
+            (if (contains? (:processing-changes @db) uri)
               (do
                 (Thread/sleep 50)
                 (recur (inc tries)))

--- a/lib/src/clojure_lsp/settings.clj
+++ b/lib/src/clojure_lsp/settings.clj
@@ -74,20 +74,17 @@
 (def ^:private memoized-settings
   (memoize/ttl get-refreshed-settings :ttl/threshold ttl-threshold-milis))
 
-(defn all [db]
+(defn all
+  "Get memoized settings from db.
+  Refreshes settings if memoize threshold met."
+  [db]
   (if (or (not (:settings-auto-refresh? @db))
           (#{:unit-test :api-test} (:env @db)))
     (get-refreshed-settings db)
     (memoized-settings db)))
 
 (defn get
-  "Memorize get settings from db.
-  Re-set settings in db if reaches memoize threshold."
   ([db kws]
    (get db kws nil))
   ([db kws default]
-   (let [settings (if (or (not (:settings-auto-refresh? @db))
-                          (#{:unit-test :api-test} (:env @db)))
-                    (get-refreshed-settings db)
-                    (memoized-settings db))]
-     (get-in settings kws default))))
+   (get-in (all db) kws default)))

--- a/lsp4clj/src/lsp4clj/core.clj
+++ b/lsp4clj/src/lsp4clj/core.clj
@@ -308,7 +308,7 @@
         (.exit ^LanguageServer server)))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(deftype LSPServer [^ILSPFeature handler db capabilities client-settings]
+(deftype LSPServer [^ILSPFeature handler db initial-db capabilities client-settings]
   LanguageServer
   (^CompletableFuture initialize [this ^InitializeParams params]
     (start :initialize
@@ -341,7 +341,7 @@
 
   (^CompletableFuture shutdown [_]
     (log/info "Shutting down")
-    (reset! db {:documents {}})
+    (reset! db initial-db)
     (CompletableFuture/completedFuture
       {:result nil}))
   (exit [_]


### PR DESCRIPTION
This is another attempt at fixing #796. The basic idea is that this avoids a situation where when two files are updated simultaneously, the first one finishes and sets :processing-changes to false before the second one is actually done processing changes. This creates conditions where it is more likely that the app will get into an infinite loop. See #796 for details about what those conditions are.

- [x] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
