### PR TITLE
Fixes #837

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Fix handling cljfmt config files that end in `.clj` https://github.com/weavejester/cljfmt/issues/190
   - parser: more efficiently seek to cursor position, improving performance especially in large files. #793 @mainej
   - Fix clean-ns not sorting properly node requires for cljs. #815
+  - Improve logic around require suggestions. #837
 
 - Editor
   - extract-function: Fix wrong args when extracting from multi-arity fn. #683

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -303,7 +303,6 @@
       :else
       (resolve-best-namespaces-suggestions cursor-namespace-str aliases->namespaces namespaces->aliases))))
 
-
 (defn find-require-suggestions [zloc uri db]
   (when-let [cursor-sym (safe-sym zloc)]
     (let [cursor-namespace-str (namespace cursor-sym)
@@ -316,7 +315,7 @@
                                                                 :filename
                                                                 (shared/filename->uri db)
                                                                 shared/uri->available-langs)
-                                                       langs))))
+                                                            langs))))
                            (map (juxt (comp str :to) (comp str :alias))))
           ns-definition-names (->> (q/find-all-ns-definition-names analysis)
                                    (map (juxt str (constantly nil))))
@@ -379,8 +378,8 @@
   (when zloc
     (let [all-suggestions (find-require-suggestions zloc uri db)]
       (when-let [suggestion (some->> all-suggestions
-                              seq
-                              first)]
+                                     seq
+                                     first)]
         (add-require-suggestion
           zloc
           (:ns suggestion)

--- a/lib/src/clojure_lsp/feature/refactor.clj
+++ b/lib/src/clojure_lsp/feature/refactor.clj
@@ -18,8 +18,8 @@
 (defmethod refactor :add-import-to-namespace [{:keys [loc args db]}]
   (apply f.add-missing-libspec/add-import-to-namespace loc (concat args [db])))
 
-(defmethod refactor :add-missing-libspec [{:keys [loc db]}]
-  (f.add-missing-libspec/add-missing-libspec loc db))
+(defmethod refactor :add-missing-libspec [{:keys [loc uri db]}]
+  (f.add-missing-libspec/add-missing-libspec loc uri db))
 
 (defmethod refactor :add-require-suggestion [{:keys [loc args db]}]
   (apply f.add-missing-libspec/add-require-suggestion loc (concat args [db])))

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -44,11 +44,9 @@
                           [{:code  "unresolved-namespace"
                             :range {:start {:line 2 :character 3}}}] {}
                           db/db)))
-  (testing "already used alias, we add one more suggestion"
+  (testing "already used alias, we add proper suggestion"
     (h/assert-contains-submaps
-      [{:title "Add require '[clojure.data.json :as json]'"
-        :command {:command "add-require-suggestion"}}
-       {:title "Add require '[clojure.data.json :as data.json]'"
+      [{:title "Add require '[clojure.data.json :as data.json]'"
         :command {:command "add-require-suggestion"}}]
       (f.code-actions/all (zloc-of (h/file-uri "file:///a.clj"))
                           (h/file-uri "file:///a.clj")
@@ -118,7 +116,7 @@
   (testing "when it has unresolved-namespace and can find namespace"
     (h/assert-contains-submaps
       [{:title "Add require '[some-ns :as sns]'"
-        :command {:command "add-missing-libspec"}}]
+        :command {:command "add-require-suggestion"}}]
       (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")
                           3
@@ -138,7 +136,7 @@
   (testing "when it has unresolved-symbol and it's a known refer"
     (h/assert-contains-submaps
       [{:title "Add require '[clojure.test :refer [deftest]]'"
-        :command {:command "add-missing-libspec"}}]
+        :command {:command "add-require-suggestion"}}]
       (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")
                           4


### PR DESCRIPTION
A number of logic changes to what gets suggested, the principle is not
to introduce conflicting aliases and to reuse existing ones as much as
possible.

Combines the logic for add missing libspec and find suggestions
Removed add missing libspec from code actions because it's redundant
when a user chooses.

- [x] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

