### PR TITLE
Exclude declare when calculating unused-public-vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   - Add new code action `Introduce let` for existing command. #825
   - Make find-implementations consider `reify`. #827
   - Fix namespace on file creation when nested source-paths are available. #832
-  - Fix to show unused-public-var warnings on defmultis and vars defined with declare. #840 #841
+  - unused-public-var: fix to show warnings on vars defined with declare. #840
 
 - API/CLI
   - Extract lsp4clj as a seperate library. #807 @Cyrik Supported by [Scarlet](https://www.scarletcomply.com)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   - Add new code action `Introduce let` for existing command. #825
   - Make find-implementations consider `reify`. #827
   - Fix namespace on file creation when nested source-paths are available. #832
+  - Fix to show unused-public-var warnings on defmultis and vars defined with declare. #840 #841
 
 - API/CLI
   - Extract lsp4clj as a seperate library. #807 @Cyrik Supported by [Scarlet](https://www.scarletcomply.com)

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -340,8 +340,7 @@
                             ;; usage from own definition
                             (and (:from-var %)
                                  (= (:from-var %) (:name element))
-                                 (= (:from %) (:ns element)))
-                            (:defmethod %))))
+                                 (= (:from %) (:ns element))))))
             (medley/distinct-by (juxt :filename :name :row :col)))
           analysis)))
 

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -259,7 +259,7 @@
          :to a}]
       (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") 7 9 false db/db))))
 
-(deftest find-references-from-defmethod
+(deftest find-references-for-defmulti
   (let [[[defmulti-r defmulti-c]]
         (h/load-code-and-locs (h/code "(ns a)"
                                       "(defmulti |my-multi :some-key)"))
@@ -270,29 +270,40 @@
                                       " [_]"
                                       " :foo)"
                                       "(|f/my-multi {:some-value 123})") (h/file-uri "file:///b.clj"))
-        usage-element '{:name-row 5 :name-col 2 :name-end-row 5 :name-end-col 12
-                        :row 5 :col 1 :end-row 5 :end-col 31
-                        :name my-multi
-                        :filename "/b.clj"
-                        :alias f
-                        :from b
-                        :arity 1
-                        :bucket :var-usages
-                        :to a}]
+        references '[;; defmethod
+                     {:name-row 2 :name-col 12 :name-end-row 2 :name-end-col 22
+                      :row 2 :col 12 :end-row 2 :end-col 22
+                      :name my-multi
+                      :filename "/b.clj"
+                      :alias f
+                      :from b
+                      :bucket :var-usages
+                      :defmethod true
+                      :to a}
+                     ;; usage
+                     {:name-row 5 :name-col 2 :name-end-row 5 :name-end-col 12
+                      :row 5 :col 1 :end-row 5 :end-col 31
+                      :name my-multi
+                      :filename "/b.clj"
+                      :alias f
+                      :from b
+                      :arity 1
+                      :bucket :var-usages
+                      :to a}]]
     (testing "from defmulti method name"
       (h/assert-submaps
-        [usage-element]
+        references
         (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") defmulti-r defmulti-c false db/db)))
     (testing "from defmethod method name"
       (h/assert-submaps
-        [usage-element]
+        references
         (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") defmethod-r defmethod-c false db/db)))
     (testing "from usage name"
       (h/assert-submaps
-        [usage-element]
+        references
         (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") usage-r usage-c false db/db)))))
 
-(deftest find-references-from-defmethod-without-usages
+(deftest find-references-for-defmulti-without-usages
   (let [[[defmulti-r defmulti-c]]
         (h/load-code-and-locs (h/code "(ns a)"
                                       "(defmulti |my-multi :some-key)"))
@@ -300,14 +311,24 @@
         (h/load-code-and-locs (h/code "(ns b (:require [a :as f]))"
                                       "(defmethod |f/my-multi :some-value"
                                       " [_]"
-                                      " :foo)") (h/file-uri "file:///b.clj"))]
+                                      " :foo)") (h/file-uri "file:///b.clj"))
+        references '[;; defmethod
+                     {:name-row 2 :name-col 12 :name-end-row 2 :name-end-col 22
+                      :row 2 :col 12 :end-row 2 :end-col 22
+                      :name my-multi
+                      :filename "/b.clj"
+                      :alias f
+                      :from b
+                      :bucket :var-usages
+                      :defmethod true
+                      :to a}]]
     (testing "from defmulti method name"
       (h/assert-submaps
-        '[]
+        references
         (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") defmulti-r defmulti-c false db/db)))
     (testing "from defmethod method name"
       (h/assert-submaps
-        '[]
+        references
         (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") defmethod-r defmethod-c false db/db)))))
 
 (deftest find-references-from-declare

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -260,25 +260,98 @@
       (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") 7 9 false db/db))))
 
 (deftest find-references-from-defmethod
-  (h/load-code-and-locs (h/code "(ns a)"
-                                "(defmulti my-multi :some-key)"))
-  (h/load-code-and-locs (h/code "(ns b (:require [a :as f]))"
-                                "(defmethod f/my-multi :some-value"
-                                " [_]"
-                                " :foo)"
-                                "(f/my-multi {:some-value 123})") (h/file-uri "file:///b.clj"))
-  (testing "from defmethod method name"
-    (h/assert-submaps
-      '[{:name-row 5 :name-col 2 :name-end-row 5 :name-end-col 12
-         :row 5 :col 1 :end-row 5 :end-col 31
-         :name my-multi
-         :filename "/b.clj"
-         :alias f
-         :from b
-         :arity 1
-         :bucket :var-usages
-         :to a}]
-      (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") 2 12 false db/db))))
+  (let [[[defmulti-r defmulti-c]]
+        (h/load-code-and-locs (h/code "(ns a)"
+                                      "(defmulti |my-multi :some-key)"))
+        [[defmethod-r defmethod-c]
+         [usage-r usage-c]]
+        (h/load-code-and-locs (h/code "(ns b (:require [a :as f]))"
+                                      "(defmethod |f/my-multi :some-value"
+                                      " [_]"
+                                      " :foo)"
+                                      "(|f/my-multi {:some-value 123})") (h/file-uri "file:///b.clj"))
+        usage-element '{:name-row 5 :name-col 2 :name-end-row 5 :name-end-col 12
+                        :row 5 :col 1 :end-row 5 :end-col 31
+                        :name my-multi
+                        :filename "/b.clj"
+                        :alias f
+                        :from b
+                        :arity 1
+                        :bucket :var-usages
+                        :to a}]
+    (testing "from defmulti method name"
+      (h/assert-submaps
+        [usage-element]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") defmulti-r defmulti-c false db/db)))
+    (testing "from defmethod method name"
+      (h/assert-submaps
+        [usage-element]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") defmethod-r defmethod-c false db/db)))
+    (testing "from usage name"
+      (h/assert-submaps
+        [usage-element]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") usage-r usage-c false db/db)))))
+
+(deftest find-references-from-defmethod-without-usages
+  (let [[[defmulti-r defmulti-c]]
+        (h/load-code-and-locs (h/code "(ns a)"
+                                      "(defmulti |my-multi :some-key)"))
+        [[defmethod-r defmethod-c]]
+        (h/load-code-and-locs (h/code "(ns b (:require [a :as f]))"
+                                      "(defmethod |f/my-multi :some-value"
+                                      " [_]"
+                                      " :foo)") (h/file-uri "file:///b.clj"))]
+    (testing "from defmulti method name"
+      (h/assert-submaps
+        '[]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") defmulti-r defmulti-c false db/db)))
+    (testing "from defmethod method name"
+      (h/assert-submaps
+        '[]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") defmethod-r defmethod-c false db/db)))))
+
+(deftest find-references-from-declare
+  (let [[[declare-r declare-c]
+         [def-r def-c]
+         [usage-r usage-c]]
+        (h/load-code-and-locs (h/code "(ns a)"
+                                      "(declare |my-declared)"
+                                      "(def |my-declared 1)"
+                                      "(inc |my-declared)"))
+        usage-element '{:name-row 4 :name-col 6 :name-end-row 4 :name-end-col 17
+                        :row 4 :col 6 :end-row 4 :end-col 17
+                        :name my-declared
+                        :filename "/a.clj"
+                        :from a
+                        :bucket :var-usages
+                        :to a}]
+    (testing "from declare"
+      (h/assert-submaps
+        [usage-element]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") declare-r declare-c false db/db)))
+    (testing "from def"
+      (h/assert-submaps
+        [usage-element]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") def-r def-c false db/db)))
+    (testing "from usage name"
+      (h/assert-submaps
+        [usage-element]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") usage-r usage-c false db/db)))))
+
+(deftest find-references-from-declare-without-usages
+  (let [[[declare-r declare-c]
+         [def-r def-c]]
+        (h/load-code-and-locs (h/code "(ns a)"
+                                      "(declare |my-declared)"
+                                      "(def |my-declared 1)"))]
+    (testing "from declare"
+      (h/assert-submaps
+        '[]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/a.clj") declare-r declare-c false db/db)))
+    (testing "from def"
+      (h/assert-submaps
+        '[]
+        (q/find-references-from-cursor (:analysis @db/db) (h/file-path "/b.clj") def-r def-c false db/db)))))
 
 (deftest find-definition-from-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"


### PR DESCRIPTION
Edit: this used to address #840 and #841. Now it only addresses #840. 

This resolves https://github.com/clojure-lsp/clojure-lsp/issues/840 ~and https://github.com/clojure-lsp/clojure-lsp/issues/841.~

Before this, `declare` and `def/defn` counted in each other's usages, and so they weren't marked as unused-public-vars, even if they had no real usages. ~Similarly, `defmethod` counted for `defmulti`'s usages, so a `defmulti` with at least one `defmethod` was never marked as an unused-public-var, even if it didn't have any real usages.~

~This also changes the code lens reference counts.~

~In the case of defmulti, it means that defmethods are no longer included when invoking find-references (a.k.a. go to references). You can still get from a defmulti to its defmethods with find-implementations. We may add defmethods back to find-references at some point, at the same time as we add protocol method implementations.~

- [x] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
