### PR TITLE
Fixes #829 - Move to let improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Fix clean-ns not sorting properly node requires for cljs. #815
   - Fix move-to-let to ensure locals don't move out of scope. #830
   - Improve logic around require suggestions. #837
+  - Enhance move-to-let to introduce and expand let if an existing one doesn't exist. #829
 
 - Editor
   - extract-function: Fix wrong args when extracting from multi-arity fn. #683

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -20,7 +20,9 @@
 
   (testing "When a code action is available"
     (h/assert-submaps
-      [{:title "Cycle privacy"
+      [{:title "Move to let"
+        :kind "refactor.extract"}
+       {:title "Cycle privacy"
         :kind "refactor.rewrite"}
        {:title "Extract function"
         :kind "refactor.extract"}

--- a/lib/src/clojure_lsp/feature/refactor.clj
+++ b/lib/src/clojure_lsp/feature/refactor.clj
@@ -42,8 +42,8 @@
 (defmethod refactor :cycle-fn-literal [{:keys [loc]}]
   (r.transform/cycle-fn-literal loc))
 
-(defmethod refactor :expand-let [{:keys [loc]}]
-  (r.transform/expand-let loc))
+(defmethod refactor :expand-let [{:keys [loc uri db]}]
+  (r.transform/expand-let loc uri db))
 
 (defmethod refactor :extract-function [{:keys [loc uri args] {:keys [db]} :components}]
   (apply r.transform/extract-function loc uri (concat args [db])))

--- a/lib/src/clojure_lsp/feature/refactor.clj
+++ b/lib/src/clojure_lsp/feature/refactor.clj
@@ -42,7 +42,7 @@
 (defmethod refactor :cycle-fn-literal [{:keys [loc]}]
   (r.transform/cycle-fn-literal loc))
 
-(defmethod refactor :expand-let [{:keys [loc uri db]}]
+(defmethod refactor :expand-let [{:keys [loc uri] {:keys [db]} :components}]
   (r.transform/expand-let loc uri db))
 
 (defmethod refactor :extract-function [{:keys [loc uri args] {:keys [db]} :components}]
@@ -54,7 +54,7 @@
 (defmethod refactor :introduce-let [{:keys [loc args]}]
   (apply r.transform/introduce-let loc args))
 
-(defmethod refactor :move-to-let [{:keys [loc args uri db]}]
+(defmethod refactor :move-to-let [{:keys [loc args uri] {:keys [db]} :components}]
   (apply r.transform/move-to-let loc uri db args))
 
 (defmethod refactor :thread-first [{:keys [loc] {:keys [db]} :components}]

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -243,7 +243,7 @@
 
 (defn ^:private widest-scoped-local [zloc uri db]
   (let [{:keys [col row end-row end-col]} (meta (z/node zloc))
-        analysis (:analysis @db)
+        analysis (:analysis db)
         local-defs (->> (q/find-local-usages-under-form
                           analysis
                           (shared/uri->filename uri)

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -391,7 +391,7 @@
         [{:range (meta (z/node (z/up let-loc)))
           :loc   new-let-loc}])
       ;; There's no existing let to move to, introduce-let and expand until it stops.
-      (loop [{:keys [range loc] :as current-edit} (first (introduce-let zloc binding-name))
+      (loop [{:keys [loc] :as current-edit} (first (introduce-let zloc binding-name))
              previous-edit nil]
         (if current-edit
           (recur (first (expand-let loc false uri db)) current-edit)

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -243,7 +243,7 @@
 
 (defn ^:private widest-scoped-local [zloc uri db]
   (let [{:keys [col row end-row end-col]} (meta (z/node zloc))
-        analysis (:analysis db)
+        analysis (:analysis @db)
         local-defs (->> (q/find-local-usages-under-form
                           analysis
                           (shared/uri->filename uri)

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -293,29 +293,25 @@
 (defn introduce-let
   "Adds a let around the current form."
   [zloc binding-name]
-
-  (prn [ (z/sexpr (z/skip-whitespace z/right zloc))
-            (edit/top? zloc)
-             (z/sexpr (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))])
-   (when-let [zloc (or (z/skip-whitespace z/right zloc)
-                        (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))]
-      (let [sym (symbol binding-name)
-            {:keys [col]} (meta (z/node zloc))
-            loc (-> zloc
-                    (edit/wrap-around :list) ; wrap with new let list
-                    (z/insert-child 'let) ; add let
-                    (z/append-child* (n/newlines 1)) ; add new line after location
-                    (z/append-child* (n/spaces (inc col)))  ; indent body
+  (when-let [zloc (or (z/skip-whitespace z/right zloc)
+                      (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))]
+    (let [sym (symbol binding-name)
+          {:keys [col]} (meta (z/node zloc))
+          loc (-> zloc
+                  (edit/wrap-around :list) ; wrap with new let list
+                  (z/insert-child 'let) ; add let
+                  (z/append-child* (n/newlines 1)) ; add new line after location
+                  (z/append-child* (n/spaces (inc col)))  ; indent body
                     ;; TODO we should add proper spaces to whole sym body to match indentation
-                    (z/append-child sym) ; add new symbol to body of let
-                    (z/down) ; enter let list
-                    (z/right) ; skip 'let
-                    (edit/wrap-around :vector) ; wrap binding vec around form
-                    (z/insert-child sym) ; add new symbol as binding
-                    z/up
-                    (edit/join-let))]
-        [{:range (meta (z/node (or loc zloc)))
-          :loc   loc}])))
+                  (z/append-child sym) ; add new symbol to body of let
+                  (z/down) ; enter let list
+                  (z/right) ; skip 'let
+                  (edit/wrap-around :vector) ; wrap binding vec around form
+                  (z/insert-child sym) ; add new symbol as binding
+                  z/up
+                  (edit/join-let))]
+      [{:range (meta (z/node (or loc zloc)))
+        :loc   loc}])))
 
 (defn expand-let
   "Expand the scope of the next let up the tree."

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -280,7 +280,15 @@
                           1
                           4
                           [] {}
-                          db/db))))
+                          db/db)))
+  (testing "when not a valid zloc"
+    (is (not-any? #(= (:title %) "Introduce let")
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
+                                      (h/file-uri "file:///b.clj")
+                                      4
+                                      14
+                                      [] {}
+                                      db/db)))))
 
 (deftest move-to-let-code-action
   (h/load-code-and-locs (h/code "(let [a 1"
@@ -288,12 +296,12 @@
                                 "  (+ 1 2))"
                                 "(+ 1 2)")
                         (h/file-uri "file:///b.clj"))
-  (testing "when not inside a let form"
+  (testing "when a valid zloc"
     (is (not-any? #(= (:title %) "Move to let")
                   (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
                                       (h/file-uri "file:///b.clj")
                                       4
-                                      1
+                                      14
                                       [] {}
                                       db/db))))
   (testing "when inside let form"


### PR DESCRIPTION
Move to let will now fallback to introducing a let and expanding it if an existing one can't be found

- [x] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
