### PR TITLE
fixed hardcoded file-watcher

### DIFF
--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -201,7 +201,8 @@
                                               db
                                               db/initial-db
                                               capabilites
-                                              client-settings)
+                                              client-settings
+                                              "**/*.{clj,cljs,cljc,edn}")
                                   clojure-feature-handler)
         launcher (Launcher/createLauncher server ClojureLanguageClient is os)
         language-client ^ClojureLanguageClient (.getRemoteProxy launcher)

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -415,7 +415,7 @@
   ;;   (did-delete-files doc))
   clojure-feature/IClojureLSPFeature
   (cursor-info-log [_ doc]
-    (cursor-info-log doc))
+    (cursor-info-log doc @components*))
   (cursor-info-raw [_ doc]
     (cursor-info-raw doc))
   (server-info-raw [_]

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -363,10 +363,6 @@
     (did-close doc))
   (did-change-watched-files [_ doc]
     (did-change-watched-files doc))
-  (cursor-info-log [_ doc]
-    (cursor-info-log doc @components*))
-  (cursor-info-raw [_ doc]
-    (cursor-info-raw doc))
   (references [_ doc]
     (references doc))
   (completion [_ doc]
@@ -418,6 +414,10 @@
   ;; (did-delete-files [_ doc]
   ;;   (did-delete-files doc))
   clojure-feature/IClojureLSPFeature
+  (cursor-info-log [_ doc]
+    (cursor-info-log doc))
+  (cursor-info-raw [_ doc]
+    (cursor-info-raw doc))
   (server-info-raw [_]
     (server-info-raw))
   (clojuredocs-raw [_ doc]

--- a/lsp4clj/src/lsp4clj/core.clj
+++ b/lsp4clj/src/lsp4clj/core.clj
@@ -345,7 +345,8 @@
           db
           initial-db
           capabilities-fn
-          client-settings]
+          client-settings
+          files]
   LanguageServer
   (^CompletableFuture initialize [this ^InitializeParams params]
     (start :initialize
@@ -376,7 +377,7 @@
                  (RegistrationParams.
                    [(Registration. "id" "workspace/didChangeWatchedFiles"
                                    (DidChangeWatchedFilesRegistrationOptions.
-                                     [(FileSystemWatcher. "**/*.{clj,cljs,cljc,edn}")]))]))))))
+                                     [(FileSystemWatcher. files)]))]))))))
 
   (^CompletableFuture shutdown [_]
     (logger/info "Shutting down")


### PR DESCRIPTION
This is just a quick-fix to lsp4-clj so that the watched files are passed in