### PR TITLE
Optimize unused public var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - Make find-implementations consider `reify`. #827
   - Fix namespace on file creation when nested source-paths are available. #832
   - unused-public-var: fix to show warnings on vars defined with declare. #840
+  - unused-public-var: large performance improvements, especially for large projects. #861 @mainej
 
 - API/CLI
   - Extract lsp4clj as a seperate library. #807 @Cyrik Supported by [Scarlet](https://www.scarletcomply.com)

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -12,7 +12,6 @@
                              :exclude [com.cognitect/transit-clj]}
         com.cognitect/transit-clj {:mvn/version "1.0.329"}
         com.github.clj-easy/stub {:mvn/version "0.2.3"}
-        com.climate/claypoole {:mvn/version "1.1.4"}
         lsp4clj/protocols {:local/root "../protocols"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -205,3 +205,250 @@
          (remove #(identical? :clojure-lsp/unused-public-var (:type %)))
          (concat kondo-findings)
          vec)))
+
+(comment
+  (require '[criterium.core :as bm])
+  (require '[clj-async-profiler.core :as profiler])
+  (require '[clojure.string :as string])
+
+  (defn lint-file [filename]
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          definitions (file-definitions project-analysis filename)
+          parallelize-fn (if false pmap pmap-light)]
+      (->> definitions
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (parallelize-fn #(when (= 0 (count (q/find-references project-analysis % false db)))
+                              %))
+           (remove nil?)
+           (group-by :filename))))
+
+  (defn lint-project []
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          definitions (project-definitions project-analysis)
+          parallelize-fn (if true pmap pmap-light)]
+      (->> definitions
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (parallelize-fn #(when (= 0 (count (q/find-references project-analysis % false db)))
+                              %))
+           (remove nil?)
+           (group-by :filename))))
+
+  (defn find-references-v2
+    [analysis element include-declaration? _db]
+    (let [names (q/var-definition-names element)
+          exclude-declaration? (not include-declaration?)]
+      (sequence
+        (comp
+          (mapcat val)
+          (remove (fn rm-kww [reference] (identical? :keywords (:bucket reference))))
+          (filter (fn matches-name [reference] (contains? names (:name reference))))
+          (filter (fn matches-ns [reference] (#'q/safe-equal? (:ns element) (or (:ns reference) (:to reference)))))
+          (remove (fn exclude-decl [reference]
+                    (and exclude-declaration?
+                         (or
+                           (identical? :var-definitions (:bucket reference))
+                            ;; usage from own definition
+                           (and (:from-var reference)
+                                (= (:from-var reference) (:name element))
+                                (= (:from reference) (:ns element)))
+                           (:defmethod reference)))))
+          (medley/distinct-by
+            (fn distinction [{:keys [filename name row col]}]
+              [filename name row col])))
+        analysis)))
+
+  (defn lint-file-v2
+    ;; 102 -> 178ms
+    [filename]
+    (let [db db/db
+          analysis (:analysis @db)
+          project-analysis (q/filter-project-analysis analysis db)
+          definitions (file-definitions project-analysis filename)]
+      (->> definitions
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (keep #(when (not (seq (find-references-v2 project-analysis % false db)))
+                    %))
+           (group-by :filename))))
+
+  (defn lint-usages-v3
+    ;; 102 -> 10.1 ms
+    [var-definitions kw-definitions project-analysis db]
+    (let [var-nses (set (map :ns var-definitions))
+          kw-signature (juxt :ns :name)
+          kws (set (map kw-signature kw-definitions))
+          usages (medley/map-vals (fn [elems]
+                                    (filter #(case (:bucket %)
+                                               :var-usages (contains? var-nses (:to %))
+                                               :keywords (contains? kws (kw-signature %))
+                                               false)
+                                            elems))
+                                  project-analysis)]
+      (->> (concat var-definitions
+                   kw-definitions)
+           (remove (partial exclude-public-diagnostic-definition? nil))
+           (keep #(when (not (seq (q/find-references usages % false db)))
+                    %))
+           (group-by :filename))))
+
+  (defn lint-file-v3
+    ;; 102 -> 10.1 ms
+    [filename]
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-var-definitions project-analysis filename false)
+          kw-definitions (q/find-keyword-definitions project-analysis filename)]
+      (lint-usages-v3 var-definitions kw-definitions project-analysis db)))
+
+  (defn lint-project-v3
+    ;; 1140 -> 612ms
+    []
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-all-var-definitions project-analysis)
+          kw-definitions (q/find-all-keyword-definitions project-analysis)]
+      (lint-usages-v3 var-definitions kw-definitions project-analysis db)))
+
+  (defn lint-project-v4
+    []
+    (let [db db/db
+          analysis (:analysis @db)
+          project-analysis (q/filter-project-analysis analysis db)
+          var-definitions (->> project-analysis
+                               q/find-all-var-definitions
+                               (remove (partial exclude-public-diagnostic-definition? nil)))
+          signature (juxt :ns :name)
+          var-defs-by-sign (group-by signature var-definitions)
+          kw-definitions (->> project-analysis
+                              q/find-all-keyword-definitions
+                              (remove (partial exclude-public-diagnostic-definition? nil)))
+          kw-defs-by-sign (group-by signature kw-definitions)
+
+          var-usage-signs (into #{}
+                                (comp
+                                  (mapcat val)
+                                  (filter (fn rm-kw [reference] (identical? :var-usages (:bucket reference))))
+                                  (remove (fn rm-decl [reference]
+                                            (or
+                                             ;; usage from own definition
+                                              (and (:from-var reference)
+                                                   (= (:from-var reference) (:name reference))
+                                                   (= (:from reference) (:to reference)))
+                                              (:defmethod reference))))
+                                  (map (juxt :to :name)))
+                                project-analysis)
+          kw-usage-signs (into #{}
+                               (comp
+                                 (mapcat val)
+                                 (filter (fn rm-kw [reference] (identical? :keywords (:bucket reference))))
+                                 (remove (fn rm-decl [reference]
+                                           (:reg reference)))
+                                 (map signature))
+                               project-analysis)]
+      (merge-with concat
+                  (->> (apply dissoc kw-defs-by-sign kw-usage-signs)
+                       (mapcat val)
+                       (group-by :filename))
+                  (->> (apply dissoc var-defs-by-sign var-usage-signs)
+                       (mapcat val)
+                       (keep #(when (not (seq (q/find-references project-analysis % false db)))
+                                %))
+                       (group-by :filename)))))
+
+  (defn lint-usages-v5
+    [var-defs kw-defs project-analysis]
+    (let [var-definitions (remove (partial exclude-public-diagnostic-definition? nil) var-defs)
+          var-nses (set (map :ns var-definitions)) ;; optimization to limit usages to internal namespaces, or in the case of a single file, to its namespaces
+          var-usages (into #{}
+                           (comp
+                             (mapcat val)
+                             (filter #(identical? :var-usages (:bucket %)))
+                             (filter #(contains? var-nses (:to %)))
+                             (remove q/var-usage-from-own-definition?)
+                             (map (juxt :to :name)))
+                           project-analysis)
+          var-used? (fn [var-def]
+                      (some (fn [var-name]
+                              (contains? var-usages [(:ns var-def) var-name]))
+                            (q/var-definition-names var-def)))
+          kw-signature (juxt :ns :name)
+          kw-definitions (remove (partial exclude-public-diagnostic-definition? nil) kw-defs)
+          kw-usages (into #{}
+                          (comp
+                            (mapcat val)
+                            (filter #(identical? :keywords (:bucket %)))
+                            (remove :reg)
+                            (map kw-signature))
+                          project-analysis)
+          kw-used? (fn [kw-def]
+                     (contains? kw-usages (kw-signature kw-def)))]
+      (->> (concat (remove var-used? var-definitions)
+                   (remove kw-used? kw-definitions))
+           (group-by :filename))))
+
+  (defn lint-project-v5
+    []
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-all-var-definitions project-analysis)
+          kw-definitions (q/find-all-keyword-definitions project-analysis)]
+      (lint-usages-v5 var-definitions kw-definitions project-analysis)))
+
+  (defn lint-file-v5
+    [filename]
+    (let [db db/db
+          project-analysis (q/filter-project-analysis (:analysis @db) db)
+          var-definitions (q/find-var-definitions project-analysis filename false)
+          kw-definitions (q/find-keyword-definitions project-analysis filename)]
+      (lint-usages-v5 var-definitions kw-definitions project-analysis)))
+
+  (def initial-result (set (lint-project)))
+  initial-result
+
+  ;; kw heavy file
+  (def test-file "/Users/jmaine/workspace/opensource/clojure-lsp/lsp4clj/src/lsp4clj/coercer.clj")
+  ;; large file
+  (def test-file "/Users/jmaine/workspace/opensource/clojure-lsp/lib/src/clojure_lsp/queries.clj")
+
+  (time (medley/map-vals count (lint-file test-file)))
+  (time (medley/map-vals count (lint-file-v2 test-file)))
+  (time (medley/map-vals count (lint-file-v3 test-file)))
+  (time (medley/map-vals count (lint-file-v5 test-file)))
+
+  (time (= (lint-file test-file)
+           (lint-file-v5 test-file)))
+
+  (time (medley/map-vals count (lint-project)))
+  (time (medley/map-vals count (lint-project-v3)))
+  (time (medley/map-vals count (lint-project-v4)))
+  (time (medley/map-vals count (lint-project-v5)))
+
+  (time (= (lint-project) (lint-project-v4)))
+  (time (= (lint-project) (lint-project-v5)))
+
+  (profiler/profile {:min-width 5
+                     :return-file true
+                     :transform (fn [s]
+                                  (string/replace s #"clojure.lsp" "lsp"))}
+                    (time (dotimes [_ 300] (lint-file test-file))))
+
+  (bm/quick-bench (lint-file test-file))
+  (bm/quick-bench (lint-file-v2 test-file))
+  (bm/quick-bench (lint-file-v3 test-file))
+  (bm/quick-bench (lint-file-v5 test-file))
+
+  (profiler/profile {:min-width 5
+                     :return-file true
+                     :transform (fn [s]
+                                  (string/replace s #"clojure.lsp" "lsp"))}
+                    (time (dotimes [_ 10] (lint-project))))
+  (profiler/profile {:min-width 5
+                     :return-file true
+                     :transform (fn [s]
+                                  (string/replace s #"clojure.lsp" "lsp"))}
+                    (time (dotimes [_ 400] (lint-project-v5))))
+
+  (bm/quick-bench (lint-project))
+  (bm/quick-bench (lint-project-v3))
+  (bm/quick-bench (lint-project-v5)))

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -188,10 +188,7 @@
 
 (defn lint-and-publish-project-diagnostics!
   [paths new-analysis kondo-ctx db]
-  (let [project-analysis (q/filter-project-analysis new-analysis db)
-        kondo-findings (unused-public-vars-lint! (project-var-definitions project-analysis)
-                                                 (project-kw-definitions project-analysis)
-                                                 project-analysis kondo-ctx)]
+  (let [kondo-findings (lint-project-diagnostics! new-analysis kondo-ctx db)]
     (loop [state-db @db]
       (let [cur-findings (:findings state-db)
             new-findings (merge-with #(->> (into %1 %2)

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -121,14 +121,10 @@
       (if (:api? @db)
         (do
           (logger/info (format "Starting to lint whole project files..."))
-          (shared/logging-time
-            "Linting whole project files took %s secs"
-            (f.diagnostic/lint-project-diagnostics! new-analysis kondo-ctx db)))
+          (f.diagnostic/lint-project-diagnostics! new-analysis kondo-ctx db))
         (when (settings/get db [:lint-project-files-after-startup?] true)
           (async/go
-            (shared/logging-time
-              "Linting whole project files took %s secs"
-              (f.diagnostic/lint-and-publish-project-diagnostics! paths new-analysis kondo-ctx db))))))))
+            (f.diagnostic/lint-and-publish-project-diagnostics! paths new-analysis kondo-ctx db)))))))
 
 (defn ^:private custom-lint-for-reference-files!
   [files db {:keys [analysis] :as kondo-ctx}]

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -60,7 +60,7 @@
     , #{name (symbol (str "->" name))}
     , #{name}))
 
-(defn var-usage-from-own-definition? [usage]
+(defn ^:private var-usage-from-own-definition? [usage]
   (and (:from-var usage)
        (= (:from-var usage) (:name usage))
        (= (:from usage) (:to usage))))
@@ -613,3 +613,16 @@
         (-> excluded-full-qualified-vars
             set
             (contains? fqsn)))))
+
+(defn xf-all-var-usages-to-namespaces [namespaces]
+  (comp
+    (mapcat val)
+    (filter #(identical? :var-usages (:bucket %)))
+    (filter #(contains? namespaces (:to %)))
+    (remove var-usage-from-own-definition?)))
+
+(def xf-all-keyword-usages
+  (comp
+    (mapcat val)
+    (filter #(identical? :keywords (:bucket %)))
+    (remove :reg)))


### PR DESCRIPTION
The baseline algorithm for finding unused public vars has the following performance characteristics.

|  clojure-lsp             |   time | std-dev |
|---------------|-------:|--------:|
| queries.clj (large file)    |   `98` ms |     `1` ms |
| coercer.clj (kw-heavy file) |  `249` ms |    `11` ms |
| whole project | `1220` ms |    `11` ms |

This commit changes algorithms to improve performance:

|  clojure-lsp             | time | std-dev |
|---------------|-----:|--------:|
| queries.clj (large file)    | `13` ms |  `0.20` ms |
| coercer.clj (kw-heavy file) | `13` ms |  `0.20` ms |
| whole project | `24` ms |  `0.16` ms |

Larger projects see a more pronounced improvement:

| clj-kondo                 |  baseline |      new |
|---------------------------|----------:|--------:|
| analyzer.clj (large file) |  `294` ms | `18` ms |
| whole project             | `2330` ms | `32` ms |

| clojure.core          |  baseline |      new |
|-----------------------|----------:|--------:|
| core.clj (large file) | `3270` ms | `44` ms |
| whole project         | `6570` ms | `63` ms |

Impressively, and unlike the baseline algorithm, this performance is achieved without any parallelization.

To compare the algorithms, first consider the baseline algorithm. First it loops through the project analysis once to find var definitions and once to find keyword definitions. Then, for each definition, it loops through the analysis once again, looking for any usages. This has quadratic performance, based on the size of the project analysis (# of definitions * # of usages).

The new algorithm is linear in the size of the project analysis (# of definitions + # of usages).  Instead of looking for usages of one definition at a time, first it looks for all usages. It loops once through the project analysis to find all var usages, and once for all keyword usages. Then it loops once for all var definitions, using set logic to remove any that have usages, and another time for keyword definitions.

This is the biggest optimization, converting an O(N*N) algorithm to O(N). There are also some smaller optimizations to constrain the number of var usages that are inspected, reducing the size of N. This is particularly helpful during single-file analysis, when we can ignore usages of other namespaces.

Since whole-project linting is not much slower than single-file linting, perhaps it would be simpler to re-lint the full project after every file change. Then we wouldn't need to re-lint the files that reference the first file. This work is not done in this PR, but should be researched afterward.

See https://github.com/mainej/clojure-lsp/pull/1 for more discussion.

- [ ] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
