### PR TITLE
Scan fewer elements when range formatting

### DIFF
--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -53,9 +53,9 @@
         root-loc (parser/zloc-of-file @db doc-id)
         start-loc (or (parser/to-pos root-loc (:row format-pos) (:col format-pos))
                       (z/leftmost* root-loc))
-        end-loc (or (parser/to-pos root-loc (:end-row format-pos) (:end-col format-pos))
-                    (z/rightmost* root-loc))
         start-top-loc (edit/to-top start-loc)
+        end-loc (or (parser/to-pos start-top-loc (:end-row format-pos) (:end-col format-pos))
+                    (z/rightmost* root-loc))
         end-top-loc (edit/to-top end-loc)
 
         forms (->> start-top-loc


### PR DESCRIPTION
This is a small improvement to the work done in #795 to improve range formattting performance. Instead of scanning from the beginning of the file to find the start of the range and again to find the end, we scan to the start, and then from there to the end.
