### PR TITLE
Namespace suggestion regessions and improvements

### DIFF
--- a/lib/src/clojure_lsp/diff.clj
+++ b/lib/src/clojure_lsp/diff.clj
@@ -1,17 +1,17 @@
 (ns clojure-lsp.diff
   (:require
    [clojure-lsp.shared :as shared]
-   [clojure.string :as str])
+   [clojure.string :as string])
   (:import
    [difflib DiffUtils]))
 
 (set! *warn-on-reflection* true)
 
 (defn- lines [s]
-  (str/split s #"\n"))
+  (string/split s #"\n"))
 
 (defn- unlines [ss]
-  (str/join "\n" ss))
+  (string/join "\n" ss))
 
 (defn unified-diff
   ([old-uri new-uri original revised project-root-uri]
@@ -42,10 +42,10 @@
 
 (defn colorize-diff [diff-text]
   (-> diff-text
-      (str/replace #"(?m)^(rename from .*)$"  (shared/colorize "$1" :yellow))
-      (str/replace #"(?m)^(rename to .*)$"  (shared/colorize "$1" :yellow))
-      (str/replace #"(?m)^(\-\-\-\sa.*)$"  (shared/colorize "$1" :yellow))
-      (str/replace #"(?m)^(\+\+\+\sb.*)$"  (shared/colorize "$1" :yellow))
-      (str/replace #"(?m)^(@@.*@@)$"       (shared/colorize "$1" :cyan))
-      (str/replace #"(?m)^(\+(?!\+\+).*)$" (shared/colorize "$1" :green))
-      (str/replace #"(?m)^(-(?!--).*)$"    (shared/colorize "$1" :red))))
+      (string/replace #"(?m)^(rename from .*)$"  (shared/colorize "$1" :yellow))
+      (string/replace #"(?m)^(rename to .*)$"  (shared/colorize "$1" :yellow))
+      (string/replace #"(?m)^(\-\-\-\sa.*)$"  (shared/colorize "$1" :yellow))
+      (string/replace #"(?m)^(\+\+\+\sb.*)$"  (shared/colorize "$1" :yellow))
+      (string/replace #"(?m)^(@@.*@@)$"       (shared/colorize "$1" :cyan))
+      (string/replace #"(?m)^(\+(?!\+\+).*)$" (shared/colorize "$1" :green))
+      (string/replace #"(?m)^(-(?!--).*)$"    (shared/colorize "$1" :red))))

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -48,7 +48,7 @@
 
 (defn ^:private find-missing-ns-alias-require [zloc db]
   (let [require-alias (some-> zloc safe-sym namespace symbol)
-        alias->info (->> (q/find-all-aliases (:analysis @db))
+        alias->info (->> (q/find-all-aliases (:analysis @db) db)
                          (group-by :alias))
         possibilities (or (some->> (get alias->info require-alias)
                                    (medley/distinct-by (juxt :to))
@@ -217,33 +217,57 @@
        (take 1)))
 
 (defn ^:private resolve-best-namespaces-suggestions
-  [alias-str aliases->namespaces namespaces->aliases]
-  (let [alias-segments (string/split alias-str #"\.")
-        all-definition-segments (map #(string/split % #"\.") (keys namespaces->aliases))]
+  [given-alias aliases->namespaces namespaces->aliases]
+  (let [given-segments (string/split given-alias #"\.")
+        all-definition-segments (mapv #(vec (string/split % #"\.")) (keys namespaces->aliases))]
     (->> all-definition-segments
-         (filter #(sub-segment? alias-segments %))
+         (filter #(sub-segment? given-segments %))
          (filter #(not (string/ends-with? (last %) "-test")))
-         (map #(string/join "." %))
-         (remove aliases->namespaces)
-         (mapcat (fn [suggested-ns]
-                   ;; Does the ns have existing aliases
-                   (if-let [aliases (->> (get namespaces->aliases suggested-ns)
-                                         (map (fn [[alias n]]
-                                                {:alias alias
-                                                 :ns suggested-ns
-                                                 :count n}))
-                                         seq)]
-                     aliases
-                     ;; Can we generate good alias suggestions for the found namespace
-                     (if-let [alias-suggestions (->> (resolve-best-alias-suggestions suggested-ns aliases->namespaces)
-                                                     (map (fn [suggested-alias]
-                                                            {:alias suggested-alias
-                                                             :ns suggested-ns}))
-                                                     seq)]
-                       alias-suggestions
-                       ;; We found it so use the given alias as last resort
-                       [{:alias alias-str
-                         :ns suggested-ns}]))))
+         (sort)
+         (mapcat (fn [suggested-ns-segments]
+                   (let [suggested-ns (string/join "." suggested-ns-segments)]
+                     (when (not (contains? aliases->namespaces suggested-ns))
+                       ;; Does the ns have existing aliases
+                       (if-let [aliases (->> (get namespaces->aliases suggested-ns)
+                                             (map (fn [[alias n]]
+                                                    {:ns suggested-ns
+                                                     :alias alias
+                                                     :count n}))
+                                             seq)]
+                         aliases
+                         (let [single-segment? (= 1 (count given-segments))
+                               matches-last? (= (last suggested-ns-segments) (last given-segments))
+                               ns-like-search? (= (count suggested-ns-segments) (count given-segments))
+                               expand-last? (and (not single-segment?) (not ns-like-search?) (not matches-last?))
+                               best-alias (->> (resolve-best-alias-suggestions suggested-ns aliases->namespaces)
+                                               (map (fn [suggested-alias]
+                                                      {:ns suggested-ns
+                                                       :alias suggested-alias
+                                                       :heuristic-order (if matches-last? 0 1)})))]
+                           (cond
+                             single-segment?
+                             best-alias
+
+                             matches-last?
+                             [{:ns suggested-ns
+                               :alias given-alias
+                               :heuristic-order 2}]
+
+                             ns-like-search?
+                             (concat
+                               best-alias
+                               [{:ns suggested-ns
+                                 :heuristic-order 3}])
+
+                             expand-last?
+                             [{:ns suggested-ns
+                               :alias (string/join "." (concat (butlast given-segments) [(last suggested-ns-segments)]))
+                               :heuristic-order 4}])))))))
+         (remove #(= (:ns %) (:alias %)))
+         (sort-by (juxt :heuristic-order :ns))
+         (map #(dissoc % :heuristic-order))
+         distinct
+         vec
          seq)))
 
 (defn ^:private find-namespace-suggestions
@@ -325,7 +349,7 @@
           cursor-name-str (name cursor-sym)
           analysis (:analysis @db)
           langs (shared/uri->available-langs uri)
-          all-aliases (->> (q/find-all-aliases analysis)
+          all-aliases (->> (q/find-all-aliases analysis db)
                            (filter (fn [element]
                                      (seq (set/intersection (-> element
                                                                 :filename
@@ -371,11 +395,12 @@
   (when-let [cursor-sym (safe-sym zloc)]
     (let [cursor-namespace-str (namespace cursor-sym)]
       (->> (if chosen-alias
-             (concat (add-known-alias zloc (symbol chosen-alias) (symbol chosen-ns) db)
+             (concat (->> (add-known-alias zloc (symbol chosen-alias) (symbol chosen-ns) db)
+                          (cleaning-ns-edits uri db))
                      (cond
                        cursor-namespace-str
-                    ;; When we're aliasing clojure.string to string, we want to change
-                    ;; all nodes after the namespace like clojure.string/split to string/split.
+                       ;; When we're aliasing clojure.string to string, we want to change
+                       ;; all nodes after the namespace like clojure.string/split to string/split.
                        (->> (find-forms (z/next (edit/find-namespace zloc))
                                         #(when-let [sym-ns (some-> % safe-sym namespace)]
                                            (and (or
@@ -386,14 +411,14 @@
 
                        (some-> zloc safe-sym)
                        [(add-ns-to-loc-change zloc chosen-alias)]))
-             (add-known-refer zloc (symbol chosen-refer) (symbol chosen-ns) db))
-           seq
-           (cleaning-ns-edits uri db)))))
+             (->> (add-known-refer zloc (some-> chosen-refer symbol) (symbol chosen-ns) db)
+                  (cleaning-ns-edits uri db)))
+           seq))))
 
 (defn add-missing-libspec
   [zloc uri db]
   (when zloc
-    (let [all-suggestions (find-require-suggestions zloc uri db)]
+    (let [all-suggestions (vec (remove :remove-from-add-missing? (find-require-suggestions zloc uri db)))]
       (when-let [suggestion (some->> all-suggestions
                                      seq
                                      first)]

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -71,8 +71,12 @@
 
 (defn ^:private require-suggestion-actions
   [uri alias-suggestions]
-  (map (fn [{:keys [ns alias refer position]}]
-         {:title      (format "Add require '[%s %s %s]'" ns (if alias ":as" ":refer") (or alias (str "[" refer "]")))
+  (map (fn [{:keys [ns alias refer position count]}]
+         {:title      (format "Add require '[%s%s%s]'%s"
+                              ns
+                              (if alias (str " :as " alias) "")
+                              (if refer (str " :refer [" refer "]") "")
+                              (if count (str " × " count) ""))
           :kind       :quick-fix
           :preferred? true
           :command    {:title     "Add require suggestion"

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -492,13 +492,13 @@
           (map :name))
         analysis))
 
-(defn find-all-aliases [analysis]
+(defn find-all-aliases [analysis db]
   (into #{}
         (comp
           (mapcat val)
           (filter #(identical? :namespace-alias (:bucket %)))
           (filter :alias))
-        analysis))
+        (filter-project-analysis analysis db)))
 
 (defn find-unused-aliases [analysis findings filename]
   (let [local-analysis (get analysis filename)]

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -115,7 +115,7 @@
                                       db/db))))
   (testing "when it has unresolved-namespace and can find namespace"
     (h/assert-contains-submaps
-      [{:title "Add require '[some-ns :as sns]'"
+      [{:title "Add require '[some-ns :as sns]' × 1"
         :command {:command "add-require-suggestion"}}]
       (f.code-actions/all (zloc-of (h/file-uri "file:///c.clj"))
                           (h/file-uri "file:///c.clj")

--- a/lib/test/clojure_lsp/features/semantic_tokens_test.clj
+++ b/lib/test/clojure_lsp/features/semantic_tokens_test.clj
@@ -3,7 +3,7 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
    [clojure-lsp.test-helper :as h]
-   [clojure.string :as clojure.string]
+   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
@@ -41,7 +41,7 @@
 (def refered-tokens
   (map #(->token % :function) refered-usages))
 
-(defn code [& strings] (clojure.string/join "\n" strings))
+(defn code [& strings] (string/join "\n" strings))
 
 (deftest usage->absolute-token
   (is (= [6 3 3 2 0]

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -223,7 +223,7 @@
                              "Date.")
                         (h/file-uri "file:///c.clj"))
   (testing "when it has unresolved-namespace and can find namespace"
-    (is (some #(= (:title %) "Add require '[some-ns :as sns]'")
+    (is (some #(= (:title %) "Add require '[some-ns :as sns]' × 1")
               (handlers/code-actions
                 {:textDocument (h/file-uri "file:///c.clj")
                  :context {:diagnostics [{:code "unresolved-namespace"


### PR DESCRIPTION
There are number of decisions that go into ns suggestions and there's a
lot of guessing as to what the user might be intending.

Consider `clojure.data.xml` that the user is trying to require.
Question if what the user types is their intended alias or a search for
a namespace, or something in between.

* `xml` feels like intended alias.
* `d.xml` feels like it could be intended.
* `c.d.x` feels like a search.
* `d.x` feels like a search or do they intend `d.xml`?

We split the given alias and possible ns into segments and follow this
logic:
1. if only a single segment is given, suggest the best segments from the
   ns (first available alias of `xml` and `data.xml`)
2. if the last given segment matches the last ns segment, use given
   alias (`d.xml` => `[clojure.data.xml :as d.xml]`)
3. if the segment counts are the same, suggest best and a plain ns
   require (`[clojure.data.xml :as xml]` and `[clojure.data.xml]`)
4. otherwise, expand the given segment to the last ns segment (`d.x` =>
   `d.xml`)

I believe there is room here for user setting to control some of this.
A setting that follows this logic by default or always pick best, given, or plain-ns could be added in the future.
I believe there's also room for the logic to only accept given prefixes
as well. ex: If your project requires `[models.* :as m.*]` everywhere only take given
if it starts with the known alias prefix `m.` otherwise fallback to best segments.

Since a given alias could match hundreds of namespaces it's important to
be restrictive on suggestions.

- [ ] I created a issue to discuss the problem I am trying to solve or there is already a open issue.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
