### PR TITLE
Improve performance of notify-references

### DIFF
--- a/lib/src/clojure_lsp/crawler.clj
+++ b/lib/src/clojure_lsp/crawler.clj
@@ -62,9 +62,7 @@
     analysis))
 
 (defn analyze-reference-filenames! [filenames db]
-  (let [result (shared/logging-task
-                 :analyze-reference-files
-                 (lsp.kondo/run-kondo-on-reference-filenames! filenames db))
+  (let [result (lsp.kondo/run-kondo-on-reference-filenames! filenames db)
         analysis (->> (:analysis result)
                       lsp.kondo/normalize-analysis
                       (group-by :filename))

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -145,25 +145,21 @@
   [var-defs kw-defs project-analysis {:keys [config reg-finding!]}]
   (let [var-definitions (remove (partial exclude-public-diagnostic-definition? config) var-defs)
         var-nses (set (map :ns var-definitions)) ;; optimization to limit usages to internal namespaces, or in the case of a single file, to its namespaces
-        var-usage-signature (juxt :to :name)
         var-usages (into #{}
                          (comp
                            (q/xf-all-var-usages-to-namespaces var-nses)
-                           (map var-usage-signature))
+                           (map q/var-usage-signature))
                          project-analysis)
         var-used? (fn [var-def]
-                    (some (fn [var-name]
-                            (contains? var-usages [(:ns var-def) var-name]))
-                          (q/var-definition-names var-def)))
-        kw-signature (juxt :ns :name)
+                    (some var-usages (q/var-definition-signatures var-def)))
         kw-definitions (remove (partial exclude-public-diagnostic-definition? config) kw-defs)
         kw-usages (into #{}
                         (comp
                           q/xf-all-keyword-usages
-                          (map kw-signature))
+                          (map q/kw-signature))
                         project-analysis)
         kw-used? (fn [kw-def]
-                   (contains? kw-usages (kw-signature kw-def)))
+                   (contains? kw-usages (q/kw-signature kw-def)))
         findings (->> (concat (remove var-used? var-definitions)
                               (remove kw-used? kw-definitions))
                       (map (fn [unused-var]

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -175,8 +175,8 @@
 (defn ^:private file-var-definitions [project-analysis filename]
   (q/find-var-definitions project-analysis filename false))
 (def ^:private file-kw-definitions q/find-keyword-definitions)
-(def ^:private project-var-definitions q/find-all-var-definitions)
-(def ^:private project-kw-definitions q/find-all-keyword-definitions)
+(def ^:private all-var-definitions q/find-all-var-definitions)
+(def ^:private all-kw-definitions q/find-all-keyword-definitions)
 
 (defn custom-lint-project!
   [new-analysis kondo-ctx db]
@@ -188,6 +188,16 @@
       (lint-defs! (all-var-definitions project-analysis)
                   (all-kw-definitions project-analysis)
                   project-analysis kondo-ctx))))
+
+(defn custom-lint-files!
+  [filenames new-analysis kondo-ctx db]
+  (let [project-analysis (into {}
+                               (q/filter-project-analysis-xf db)
+                               new-analysis)
+        file-analyses (select-keys project-analysis filenames)]
+    (lint-defs! (all-var-definitions file-analyses)
+                (all-kw-definitions file-analyses)
+                project-analysis kondo-ctx)))
 
 (defn custom-lint-file!
   [filename analysis kondo-ctx db]

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -10,6 +10,7 @@
    [clojure-lsp.shared :as shared]
    [clojure.core.async :as async]
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as string]
    [lsp4clj.protocols.logger :as logger]
    [lsp4clj.protocols.producer :as producer]
@@ -84,26 +85,31 @@
     (find-changed-elems-by usage-signature old-var-usages new-var-usages)))
 
 (defn reference-filenames [filename old-local-analysis new-local-analysis db]
-  (let [project-analysis (into {} (q/filter-project-analysis-xf db) (:analysis @db))
-        source-paths (settings/get db [:source-paths])
-        changed-var-definitions (find-changed-var-definitions old-local-analysis new-local-analysis)
-        references-filenames (->> changed-var-definitions
-                                  ;; TODO: switch from nested-loop join to hash join
-                                  (mapcat #(q/find-references project-analysis % false db))
-                                  (map :filename))
+  (let [changed-var-definitions (find-changed-var-definitions old-local-analysis new-local-analysis)
         changed-var-usages (find-changed-var-usages old-local-analysis new-local-analysis)
-        definitions-filenames (->> changed-var-usages
-                                   ;; TODO: remove usages of external namespaces (clojure.core, etc.) here
-                                   ;; TODO: switch from nested-loop join to hash join
-                                   (keep #(q/find-definition project-analysis % db))
-                                   (filter (fn [d]
-                                             ;; TODO: this excludes "private calls", but they are counted in code lens, so maybe shouldn't exclude
-                                             (and (not (:private d))
-                                                  ;; TODO: is this extra work? The definition came from project-analysis, so should be on the source-paths.
-                                                  (some #(string/starts-with? (:filename d) %) source-paths))))
-                                   (map :filename))]
-    (disj (set (concat references-filenames definitions-filenames))
-          filename)))
+        project-analysis (into {}
+                               (q/filter-project-analysis-xf db)
+                               (dissoc (:analysis @db) filename)) ;; don't notify self
+        source-paths (settings/get db [:source-paths])
+        references-filenames (into #{}
+                                   (comp
+                                     ;; TODO: switch from nested-loop join to hash join
+                                     (mapcat #(q/find-references project-analysis % false db))
+                                     (map :filename))
+                                   changed-var-definitions)
+        definitions-filenames (into #{}
+                                    (comp
+                                      ;; TODO: remove usages of external namespaces (clojure.core, etc.) here
+                                      ;; TODO: switch from nested-loop join to hash join
+                                      (keep #(q/find-definition project-analysis % db))
+                                      (filter (fn [d]
+                                                ;; TODO: this excludes "private calls", but they are counted in code lens, so maybe shouldn't exclude
+                                                (and (not (:private d))
+                                                     ;; TODO: is this extra work? The definition came from project-analysis, so should be on the source-paths.
+                                                     (some #(string/starts-with? (:filename d) %) source-paths))))
+                                      (map :filename))
+                                    changed-var-usages)]
+    (set/union references-filenames definitions-filenames)))
 
 (defn ^:private notify-references [filename old-local-analysis new-local-analysis {:keys [db producer]}]
   (async/go

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -102,8 +102,12 @@
                                        (map :filename))
                                      project-analysis)))
         outgoing-filenames (when (seq changed-var-usages)
+                             ;; If definition is in both a clj and cljs file, and this is a clj
+                             ;; usage, we are careful to notify only the clj file. But, it wouldn't
+                             ;; really hurt to notify both files. So, if it helps readability,
+                             ;; maintenance, or symmetry with `incoming-filenames`, we could look
+                             ;; at just signature, not signature and lang.
                              (let [usage-signs->langs (->> changed-var-usages
-                                                           ;; If definition is in both a clj and cljs file, and this is a clj usage, only notify the clj file.
                                                            (reduce (fn [result usage]
                                                                      (assoc result (q/var-usage-signature usage) (q/elem-langs usage)))
                                                                    {}))]

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -126,8 +126,8 @@
     (shared/logging-task
       :notify-references
       (let [filenames (shared/logging-task
-                       :reference-files/find
-                       (reference-filenames filename old-local-analysis new-local-analysis db))]
+                        :reference-files/find
+                        (reference-filenames filename old-local-analysis new-local-analysis db))]
         (when (seq filenames)
           (logger/debug "Analyzing references for files:" filenames)
           (shared/logging-task

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -115,10 +115,14 @@
   (async/go
     (shared/logging-task
       :notify-references
-      (let [filenames (reference-filenames filename old-local-analysis new-local-analysis db)]
+      (let [filenames (shared/logging-task
+                       :reference-files/find
+                       (reference-filenames filename old-local-analysis new-local-analysis db))]
         (when (seq filenames)
           (logger/debug "Analyzing references for files:" filenames)
-          (crawler/analyze-reference-filenames! filenames db)
+          (shared/logging-task
+            :reference-files/analyze
+            (crawler/analyze-reference-filenames! filenames db))
           (doseq [filename filenames]
             (f.diagnostic/sync-publish-diagnostics! (shared/filename->uri filename db) db))
           (producer/refresh-code-lens producer))))))

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -33,7 +33,7 @@
                       (update-analysis uri (:analysis kondo-result))
                       (update-findings uri (:findings kondo-result))
                       (assoc :kondo-config (:config kondo-result)))))
-      (f.diagnostic/async-lint-file! uri db)))
+      (f.diagnostic/async-publish-diagnostics! uri db)))
   (when-let [new-ns (and allow-create-ns
                          (string/blank? text)
                          (contains? #{:clj :cljs :cljc} (shared/uri->file-type uri))
@@ -114,7 +114,7 @@
           (logger/debug "Analyzing references for files:" filenames)
           (crawler/analyze-reference-filenames! filenames db)
           (doseq [filename filenames]
-            (f.diagnostic/sync-lint-file! (shared/filename->uri filename db) db))
+            (f.diagnostic/sync-publish-diagnostics! (shared/filename->uri filename db) db))
           (producer/refresh-code-lens producer))))))
 
 (defn ^:private offsets [lines line col end-line end-col]
@@ -174,7 +174,7 @@
                                                   (update :processing-changes disj uri)
                                                   (assoc :kondo-config (:config kondo-result))))
               (do
-                (f.diagnostic/sync-lint-file! uri db)
+                (f.diagnostic/sync-publish-diagnostics! uri db)
                 (when (settings/get db [:notify-references-on-file-change] true)
                   (notify-references filename old-local-analysis (get-in @db [:analysis filename]) components))
                 (clojure-producer/refresh-test-tree producer [uri]))
@@ -206,7 +206,7 @@
                       (update :analysis merge analysis)
                       (assoc :kondo-config (:config result))
                       (update :findings merge (group-by :filename (:findings result))))))
-      (f.diagnostic/lint-project-files! filenames db)
+      (f.diagnostic/publish-all-diagnostics! filenames db)
       (clojure-producer/refresh-test-tree producer uris))))
 
 (defn did-change-watched-files [changes db]
@@ -238,7 +238,7 @@
                                      (shared/dissoc-in [:documents uri])
                                      (shared/dissoc-in [:analysis filename])
                                      (shared/dissoc-in [:findings filename]))))
-        (f.diagnostic/clean! uri db)))))
+        (f.diagnostic/publish-empty-diagnostics! uri db)))))
 
 (defn force-get-document-text
   "Get document text from db, if document not found, tries to open the document"

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -101,7 +101,7 @@
         components)
       (when (settings/get db [:lint-project-files-after-startup?] true)
         (async/go
-          (f.diagnostic/lint-project-files! (-> @db :settings :source-paths) db)))
+          (f.diagnostic/publish-all-diagnostics! (-> @db :settings :source-paths) db)))
       (async/go
         (f.clojuredocs/refresh-cache! components))
       (async/go

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -142,8 +142,7 @@
     :lint-reference-files
     (let [new-analysis (group-by :filename (normalize-analysis analysis))
           updated-analysis (merge (:analysis @db) new-analysis)]
-      (doseq [file files]
-        (f.diagnostic/custom-lint-file! file updated-analysis kondo-ctx db)))))
+      (f.diagnostic/custom-lint-files! files updated-analysis kondo-ctx db))))
 
 (defn ^:private custom-lint-file!
   [{:keys [analysis config] :as kondo-ctx} uri db]

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -139,7 +139,7 @@
 (defn ^:private custom-lint-files!
   [files db {:keys [analysis] :as kondo-ctx}]
   (shared/logging-task
-    :lint-reference-files
+    :reference-files/lint
     (let [new-analysis (group-by :filename (normalize-analysis analysis))
           updated-analysis (merge (:analysis @db) new-analysis)]
       (f.diagnostic/custom-lint-files! files updated-analysis kondo-ctx db))))

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -46,13 +46,13 @@
                     (filter pred?))
                   analysis))))
 
+(defn elem-langs [element]
+  (or (some-> element :lang list set)
+      (shared/uri->available-langs (:filename element))))
+
 (defn ^:private match-file-lang
   [check-element match-element]
-  (let [match-file-lang (or (some-> match-element :lang list set)
-                            (shared/uri->available-langs (:filename match-element)))
-        check-file-lang (or (some-> check-element :lang list set)
-                            (shared/uri->available-langs (:filename check-element)))]
-    (seq (set/intersection match-file-lang check-file-lang))))
+  (some (elem-langs match-element) (elem-langs check-element)))
 
 (defn var-definition-names [{:keys [defined-by name]}]
   (case defined-by

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -62,6 +62,14 @@
     , #{name (symbol (str "->" name))}
     , #{name}))
 
+(def kw-signature (juxt :ns :name))
+(def var-usage-signature (juxt :to :name))
+(defn var-definition-signatures [var-def]
+  (->> (var-definition-names var-def)
+       (map (fn [var-name]
+              [(:ns var-def) var-name]))
+       (into #{})))
+
 (defn ^:private var-usage-from-own-definition? [usage]
   (and (:from-var usage)
        (= (:from-var usage) (:name usage))

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -19,7 +19,7 @@
   (h/load-code-and-locs (h/code "(ns some-ns) (defn ^:export foobar (fn []))") (h/file-uri "file:///d.cljs"))
   (testing "when linter level is :info"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -37,7 +37,7 @@
       @findings))
   (testing "when linter level is :warning"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -55,7 +55,7 @@
       @findings))
   (testing "when linter level is :error"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -73,7 +73,7 @@
       @findings))
   (testing "when linter level is :off"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -91,7 +91,7 @@
       @findings))
   (testing "linter level by default is :info"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -109,7 +109,7 @@
       @findings))
   (testing "excluding the whole ns"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -120,7 +120,7 @@
       @findings))
   (testing "excluding the simple var from ns"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -131,7 +131,7 @@
       @findings))
   (testing "excluding the specific var"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/a.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -142,7 +142,7 @@
       @findings))
   (testing "excluding specific syms"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/b.clj"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -153,7 +153,7 @@
       @findings))
   (testing "unused keyword definitions"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/c.cljs"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)
@@ -179,7 +179,7 @@
       @findings))
   (testing "var marked ^:export is excluded"
     (reset! findings [])
-    (f.diagnostic/unused-public-var-lint-for-single-file!
+    (f.diagnostic/custom-lint-file!
       "/d.cljs"
       (:analysis @db/db)
       {:reg-finding! #(swap! findings conj %)


### PR DESCRIPTION
This replaces the nested-loop joins in notify-references with hash joins.

This PR doesn't really change the performance when there aren't any files to notify. But when there are, it makes a difference.

To test I inserted an unmatched delimiter into `clojure-lsp.feature.diagnostics`, making the file invalid. This file uses 5 namespaces, and 5 other namespaces use it. They all get notified.

Before this PR, in this scenario notify-references takes about 2 seconds. About half of that is finding the files and the other half is analyzing and linting them. After the patch it takes about 1 second, with about 100ms finding files, 800ms analyzing and 100ms linting. 

For follow-on work, finding files and linting each execute `q/filter-project-analysis`, which takes about 100ms itself, meaning that almost all their time is in that function. So, making `q/filter-project-analysis` faster will improve `notify-references` further.

In addition to removing the nested loops, this PR:

* Renames diagnostic helpers to delineate which calculate custom lint data and which publish that data to clients.
* Lints all reference files in one batch, rather than linting each file individually

- [x] This is follow up work from #885

This PR builds on #887. You can either merge that one first and this second, or do them both by merging this one alone.