### PR TITLE
move-coll-entry enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve settings documentation.
 - Introduce ALPHA move-form command. #566
 - move-coll-entry: clauses move intuitively in `clojure.test/are`
+- move-coll-entry: top-level clauses can be moved #891
 
 ## 2022.03.31-20.00.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improve settings documentation.
 - Introduce ALPHA move-form command. #566
+- move-coll-entry: clauses move intuitively in `clojure.test/are`
 
 ## 2022.03.31-20.00.20
 

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -420,10 +420,10 @@
   (when-let [parent-zloc (z-up zloc)]
     (let [child-count (count-children parent-zloc)
           strat (case (z/tag parent-zloc)
-                  :map        {:breadth 2, :rind no-rind}
-                  :set        {:breadth 1, :rind no-rind}
-                  :vector     (vector-strategy parent-zloc uri db)
-                  (:list :fn) (list-strategy parent-zloc child-count)
+                  :map          {:breadth 2, :rind no-rind}
+                  (:set :forms) {:breadth 1, :rind no-rind}
+                  :vector       (vector-strategy parent-zloc uri db)
+                  (:list :fn)   (list-strategy parent-zloc child-count)
                   nil)]
       (when strat
         (let [strat (assoc strat
@@ -467,7 +467,11 @@
                               :take-focus? true
                               :range       (assoc cursor-position :end-row (:row cursor-position) :end-col (:col cursor-position))}
    :changes-by-uri           {uri
-                              [{:range (z-cursor-position parent-loc)
+                              [{:range (if (= :forms (z/tag parent-loc))
+                                         ;; work around for https://github.com/clj-commons/rewrite-clj/issues/173
+                                         ;; when that's fixed, revert to else-clause: (z-cursor-position parent-loc)
+                                         shared/full-file-position
+                                         (z-cursor-position parent-loc))
                                 :loc   parent-loc}]}})
 
 (defn ^:private movement [dir zloc uri db]

--- a/lib/src/clojure_lsp/feature/move_coll_entry.clj
+++ b/lib/src/clojure_lsp/feature/move_coll_entry.clj
@@ -374,6 +374,10 @@
                invalid-ternary? (= 2 ignore-right)]
            (when-not invalid-ternary?
              {:breadth breadth, :rind [ignore-left ignore-right]}))
+    are
+    #_=> (let [param-count (-> parent-zloc z-down z-right count-children)]
+           (when (< 0 param-count)
+             {:breadth param-count, :rind [3 0]}))
     {:breadth 1, :rind no-rind}))
 
 (defn ^:private movable-sibling-counts
@@ -391,9 +395,9 @@
        ;; are there enough elements before and after this zloc?
        (let [[left right] (movable-sibling-counts zloc rind)]
          (or
-          ;; erroneously true if on whitespace following first group
+           ;; erroneously true if on whitespace following first group
            (and (= :up dir)   (>= left breadth) (>= right 0))
-          ;; erroneously true if on whitespace preceding last group
+           ;; erroneously true if on whitespace preceding last group
            (and (= :down dir) (>= left 0)       (>= right breadth))))))
 
 (defn ^:private pulp [[ignore-left ignore-right] child-count]

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -435,5 +435,8 @@
     {:start {:line (max 0 (dec (or row name-row))) :character (max 0 (dec (or col name-col)))}
      :end {:line (max 0 (dec (or end-row name-end-row))) :character (max 0 (dec (or end-col name-end-col)))}}))
 
+(def full-file-position
+  {:row 1 :col 1 :end-row 1000000 :end-col 1000000})
+
 (defn full-file-range []
-  (->range {:row 1 :col 1 :end-row 1000000 :end-col 1000000}))
+  (->range full-file-position))


### PR DESCRIPTION
This adds two features to move-coll-entry:

* Top-level forms can be moved. #891 
* Groups inside `clojure.test/are` move intuitively.

- [x] Fixes #891
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

