### PR TITLE
Add integration test for prepareRename

### DIFF
--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -49,6 +49,11 @@
                  :options {:tabSize 2
                            :insertSpaces true}}))
 
+(defn prepare-rename-request [path row col]
+  (lsp-json-rpc :textDocument/prepareRename
+                {:textDocument {:uri (h/source-path->uri path)}
+                 :position {:line row :character col}}))
+
 (defn rename-request [path new-name row col]
   (lsp-json-rpc :textDocument/rename
                 {:textDocument {:uri (h/source-path->uri path)}

--- a/cli/integration-test/integration/rename_test.clj
+++ b/cli/integration-test/integration/rename_test.clj
@@ -74,9 +74,6 @@
 
   (testing "Renaming local keywords"
     (h/assert-submap
-      {:start {:line 12, :character 14}, :end {:line 12, :character 21}}
-      (lsp/request! (fixture/prepare-rename-request "rename/a.cljc" 12 15)))
-    (h/assert-submap
       {:changes
        {(keyword (h/source-path->uri "rename/a.cljc"))
         [{:range {:start {:line 12 :character 15} :end {:line 12 :character 21}}
@@ -181,3 +178,19 @@
          {:range {:start {:line 8 :character 1} :end {:line 8 :character 8}}
           :newText "your-func"}]}}
       (lsp/request! (fixture/rename-request "rename/b.cljc" "your-func" 1 52)))))
+
+(deftest prepare-rename
+  (lsp/start-process!)
+  (lsp/request! (fixture/initialize-request))
+  (lsp/notify! (fixture/initialized-notification))
+  (lsp/notify! (fixture/did-open-notification "rename/a.cljc"))
+  (lsp/notify! (fixture/did-open-notification "rename/b.cljc"))
+  (lsp/notify! (fixture/did-open-notification "rename/single_a.clj"))
+  (lsp/notify! (fixture/did-open-notification "rename/single_b.clj"))
+
+  (h/assert-submap
+    {:error {:code -32602, :message "Can't rename, no element found."}}
+    (lsp/request! (fixture/prepare-rename-request "rename/a.cljc" 12 6)))
+  (h/assert-submap
+    {:start {:line 12, :character 14}, :end {:line 12, :character 21}}
+    (lsp/request! (fixture/prepare-rename-request "rename/a.cljc" 12 15))))

--- a/cli/integration-test/integration/rename_test.clj
+++ b/cli/integration-test/integration/rename_test.clj
@@ -74,6 +74,9 @@
 
   (testing "Renaming local keywords"
     (h/assert-submap
+      {:start {:line 12, :character 14}, :end {:line 12, :character 21}}
+      (lsp/request! (fixture/prepare-rename-request "rename/a.cljc" 12 15)))
+    (h/assert-submap
       {:changes
        {(keyword (h/source-path->uri "rename/a.cljc"))
         [{:range {:start {:line 12 :character 15} :end {:line 12 :character 21}}

--- a/lib/src/clojure_lsp/feature/rename.clj
+++ b/lib/src/clojure_lsp/feature/rename.clj
@@ -175,48 +175,56 @@
     :else
     {:result :success}))
 
+(def ^:private error-no-element
+  {:error {:code :invalid-params
+           :message "Can't rename, no element found."}})
+
 (defn prepare-rename
   [uri row col db]
   (let [filename (shared/uri->filename uri)
-        element (q/find-element-under-cursor (:analysis db) filename row col)
-        references (q/find-references (:analysis db) element true db)
-        definition (q/find-definition (:analysis db) element db)
-        source-paths (settings/get db [:source-paths])
-        client-capabilities (:client-capabilities db)
-        {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
-    (if error
-      result
-      (shared/->range element))))
+        element (q/find-element-under-cursor (:analysis db) filename row col)]
+    (if-not element
+      error-no-element
+      (let [references (q/find-references (:analysis db) element true db)
+            definition (q/find-definition (:analysis db) element db)
+            source-paths (settings/get db [:source-paths])
+            client-capabilities (:client-capabilities db)
+            {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
+        (if error
+          result
+          (shared/->range element))))))
 
 (defn rename
   [uri new-name row col db*]
   (let [db @db*
         filename (shared/uri->filename uri)
-        element (q/find-element-under-cursor (:analysis db) filename row col)
-        references (q/find-references (:analysis db) element true db)
-        definition (q/find-definition (:analysis db) element db)
-        source-paths (settings/get db [:source-paths])
-        client-capabilities (:client-capabilities db)
-        {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
-    (if error
-      result
-      (let [replacement (string/replace new-name #".*/([^/]*)$" "$1")
-            changes (rename-changes element definition references replacement new-name db)
-            doc-changes (->> changes
-                             (group-by :text-document)
-                             (remove (comp empty? val))
-                             (map (fn [[text-document edits]]
-                                    {:text-document text-document
-                                     :edits (mapv #(dissoc % :text-document) edits)})))]
-        (if (and (identical? :namespace-definitions (:bucket definition))
-                 (not (identical? :namespace-alias (:bucket element))))
-          (let [new-uri (shared/namespace->uri replacement source-paths (:filename definition) db)]
-            (swap! db* (fn [db] (-> db
-                                    (update :documents #(set/rename-keys % {filename (shared/uri->filename new-uri)}))
-                                    (update :analysis #(set/rename-keys % {filename (shared/uri->filename new-uri)})))))
-            (shared/client-changes (concat doc-changes
-                                           [{:kind "rename"
-                                             :old-uri uri
-                                             :new-uri new-uri}])
-                                   db))
-          (shared/client-changes doc-changes db))))))
+        element (q/find-element-under-cursor (:analysis db) filename row col)]
+    (if-not element
+      error-no-element
+      (let [references (q/find-references (:analysis db) element true db)
+            definition (q/find-definition (:analysis db) element db)
+            source-paths (settings/get db [:source-paths])
+            client-capabilities (:client-capabilities db)
+            {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
+        (if error
+          result
+          (let [replacement (string/replace new-name #".*/([^/]*)$" "$1")
+                changes (rename-changes element definition references replacement new-name db)
+                doc-changes (->> changes
+                                 (group-by :text-document)
+                                 (remove (comp empty? val))
+                                 (map (fn [[text-document edits]]
+                                        {:text-document text-document
+                                         :edits (mapv #(dissoc % :text-document) edits)})))]
+            (if (and (identical? :namespace-definitions (:bucket definition))
+                     (not (identical? :namespace-alias (:bucket element))))
+              (let [new-uri (shared/namespace->uri replacement source-paths (:filename definition) db)]
+                (swap! db* (fn [db] (-> db
+                                        (update :documents #(set/rename-keys % {filename (shared/uri->filename new-uri)}))
+                                        (update :analysis #(set/rename-keys % {filename (shared/uri->filename new-uri)})))))
+                (shared/client-changes (concat doc-changes
+                                               [{:kind "rename"
+                                                 :old-uri uri
+                                                 :new-uri new-uri}])
+                                       db))
+              (shared/client-changes doc-changes db))))))))

--- a/lib/test/clojure_lsp/features/rename_test.clj
+++ b/lib/test/clojure_lsp/features/rename_test.clj
@@ -145,6 +145,12 @@
            (f.rename/rename (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))))
 
 (deftest prepare-rename
+  (testing "rename local var"
+    (h/clean-db!)
+    (let [[[row col]] (h/load-code-and-locs "(let [|a 1] a)")
+          result (f.rename/prepare-rename h/default-uri row col @db/db*)]
+      (is (= {:start {:line 0, :character 6}, :end {:line 0, :character 7}}
+             result))))
   (testing "should not rename when on unnamed element"
     (h/clean-db!)
     (let [[[row col]] (h/load-code-and-locs "|[]")

--- a/lib/test/clojure_lsp/features/rename_test.clj
+++ b/lib/test/clojure_lsp/features/rename_test.clj
@@ -143,3 +143,41 @@
               :old-uri (h/file-uri "file:///my-project/src/foo/bar_baz.clj")
               :new-uri (h/file-uri "file:///my-project/src/foo/baz_qux.clj")}]}
            (f.rename/rename (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))))
+
+(deftest prepare-rename
+  (testing "should not rename when on unnamed element"
+    (h/clean-db!)
+    (let [[[row col]] (h/load-code-and-locs "|[]")
+          result (f.rename/prepare-rename h/default-uri row col @db/db*)]
+      (is (= {:error {:code :invalid-params
+                      :message "Can't rename, no element found."}}
+             result))))
+  (testing "should not rename plain keywords"
+    (h/clean-db!)
+    (let [[[row col]] (h/load-code-and-locs "|:a")
+          result (f.rename/prepare-rename h/default-uri row col @db/db*)]
+      (is (= {:error {:code :invalid-params
+                      :message "Can't rename, only namespaced keywords can be renamed."}}
+             result))))
+  (testing "when client has valid source-paths but no document-changes capability"
+    (h/clean-db!)
+    (swap! db/db* shared/deep-merge
+           {:project-root-uri (h/file-uri "file:///")
+            :settings {:source-paths #{(h/file-path "/")}}
+            :client-capabilities {:workspace {:workspace-edit {:document-changes false}}}})
+    (let [[[row col]] (h/load-code-and-locs "(ns |foo.bar-baz)")]
+      (h/assert-submap
+        {:error {:code :invalid-params
+                 :message "Can't rename namespace, client does not support file renames."}}
+        (f.rename/prepare-rename h/default-uri row col @db/db*))))
+  (testing "when client has document-changes capability but no valid source-paths"
+    (h/clean-db!)
+    (swap! db/db* shared/deep-merge
+           {:project-root-uri (h/file-uri "file:///")
+            :settings {:source-paths #{(h/file-path "/bla")}}
+            :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
+    (let [[[row col]] (h/load-code-and-locs "(ns |foo.bar-baz)")]
+      (h/assert-submap
+        {:error {:code :invalid-params
+                 :message "Can't rename namespace, invalid source-paths. Are project :source-paths configured correctly?"}}
+        (f.rename/prepare-rename h/default-uri row col @db/db*)))))


### PR DESCRIPTION
This adds an integration test for prepareRename. I confirmed that it would have caught the [missing deref](https://github.com/clojure-lsp/clojure-lsp/pull/902/commits/fb5bef502baf8974b42dc6483c3bf392bcebb2be) @ericdallo noticed during review of #902. There are a few other integration tests that call rename... let me know if you want me to add prepareRename tests for them too, or if you want a test that demonstrates how prepareRename behaves when the cursor is on a location that can't be renamed.
