### PR TITLE
Update clojure.core completion items for 1.10 and 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - drag: clauses move intuitively in `clojure.test/are`
   - drag: top-level forms can be dragged #891
   - Improve completion performance for most cases, reducing time to compute clj/cljs core symbols.
+  - completion: suggest functions defined in Clojure 1.10 and 1.11
 
 ## 2022.03.31-20.00.20
 

--- a/lib/src/clojure_lsp/common_symbols.clj
+++ b/lib/src/clojure_lsp/common_symbols.clj
@@ -284,11 +284,18 @@
      {:name ->> :kind :function}
      {:name ->ArrayChunk :kind :reference}
      {:name ArrayChunk :kind :variable}
+     {:name ArrayManager, :kind :variable}
      {:name ->Eduction :kind :reference}
      {:name Eduction :kind :variable}
+     {:name IVecImpl, :kind :variable}
+     {:name NaN?, :kind :function}
+     {:name PrintWriter-on, :kind :function}
      {:name ->Vec :kind :reference}
+     {:name Vec, :kind :variable}
      {:name ->VecNode :kind :reference}
+     {:name VecNode, :kind :variable}
      {:name ->VecSeq :kind :reference}
+     {:name VecSeq, :kind :variable}
      {:name -cache-protocol-fn :kind :function}
      {:name -reset-methods :kind :function}
      {:name . :kind :function}
@@ -300,6 +307,7 @@
      {:name == :kind :function}
      {:name > :kind :function}
      {:name >= :kind :function}
+     {:name abs, :kind :function}
      {:name accessor :kind :function}
      {:name aclone :kind :function}
      {:name add-classpath :kind :function}
@@ -521,6 +529,7 @@
      {:name future-cancelled? :kind :function}
      {:name future-done? :kind :function}
      {:name future? :kind :function}
+     {:name gen-and-load-class, :kind :function}
      {:name gen-class :kind :function}
      {:name gen-interface :kind :function}
      {:name gensym :kind :function}
@@ -530,6 +539,7 @@
      {:name get-proxy-class :kind :function}
      {:name get-thread-bindings :kind :function}
      {:name get-validator :kind :function}
+     {:name global-hierarchy, :kind :variable}
      {:name group-by :kind :function}
      {:name halt-when :kind :function}
      {:name hash :kind :function}
@@ -571,6 +581,7 @@
      {:name io! :kind :function}
      {:name isa? :kind :function}
      {:name iterate :kind :function}
+     {:name iteration, :kind :function}
      {:name iterator-seq :kind :function}
      {:name juxt :kind :function}
      {:name keep :kind :function}
@@ -662,6 +673,10 @@
      {:name odd? :kind :function}
      {:name or :kind :function}
      {:name parents :kind :function}
+     {:name parse-boolean, :kind :function}
+     {:name parse-double, :kind :function}
+     {:name parse-long, :kind :function}
+     {:name parse-uuid, :kind :function}
      {:name partial :kind :function}
      {:name partition :kind :function}
      {:name partition-all :kind :function}
@@ -691,6 +706,7 @@
      {:name println-str :kind :function}
      {:name prn :kind :function}
      {:name prn-str :kind :function}
+     {:name process-annotation, :kind :variable}
      {:name promise :kind :function}
      {:name proxy :kind :function}
      {:name proxy-call-with-super :kind :function}
@@ -721,6 +737,7 @@
      {:name re-seq :kind :function}
      {:name read :kind :function}
      {:name read-line :kind :function}
+     {:name read+string, :kind :function}
      {:name read-string :kind :function}
      {:name reader-conditional :kind :function}
      {:name reader-conditional? :kind :function}
@@ -753,6 +770,7 @@
      {:name replace :kind :function}
      {:name replicate :kind :function}
      {:name require :kind :function}
+     {:name requiring-resolve, :kind :function}
      {:name reset! :kind :function}
      {:name reset-meta! :kind :function}
      {:name reset-vals! :kind :function}
@@ -772,6 +790,7 @@
      {:name send-off :kind :function}
      {:name send-via :kind :function}
      {:name seq :kind :function}
+     {:name seq-to-map-for-destructuring, :kind :function}
      {:name seq? :kind :function}
      {:name seqable? :kind :function}
      {:name seque :kind :function}
@@ -874,7 +893,9 @@
      {:name unsigned-bit-shift-right :kind :function}
      {:name update :kind :function}
      {:name update-in :kind :function}
+     {:name update-keys, :kind :function}
      {:name update-proxy :kind :function}
+     {:name update-vals, :kind :function}
      {:name uri? :kind :function}
      {:name use :kind :function}
      {:name uuid? :kind :function}

--- a/lib/src/clojure_lsp/common_symbols.clj
+++ b/lib/src/clojure_lsp/common_symbols.clj
@@ -283,7 +283,9 @@
      {:name -> :kind :function}
      {:name ->> :kind :function}
      {:name ->ArrayChunk :kind :reference}
+     {:name ArrayChunk :kind :variable}
      {:name ->Eduction :kind :reference}
+     {:name Eduction :kind :variable}
      {:name ->Vec :kind :reference}
      {:name ->VecNode :kind :reference}
      {:name ->VecSeq :kind :reference}
@@ -301,6 +303,7 @@
      {:name accessor :kind :function}
      {:name aclone :kind :function}
      {:name add-classpath :kind :function}
+     {:name add-tap :kind :function}
      {:name add-watch :kind :function}
      {:name agent :kind :function}
      {:name agent-error :kind :function}
@@ -476,8 +479,10 @@
      {:name even? :kind :function}
      {:name every-pred :kind :function}
      {:name every? :kind :function}
+     {:name ex-cause :kind :function}
      {:name ex-data :kind :function}
      {:name ex-info :kind :function}
+     {:name ex-message :kind :function}
      {:name extend :kind :function}
      {:name extend-protocol :kind :function}
      {:name extend-type :kind :function}
@@ -546,6 +551,7 @@
      {:name inc :kind :function}
      {:name inc' :kind :function}
      {:name indexed? :kind :function}
+     {:name infinite? :kind :function}
      {:name init-proxy :kind :function}
      {:name Inst :kind :variable}
      {:name inst-ms :kind :function}
@@ -702,6 +708,7 @@
      {:name rand-int :kind :function}
      {:name rand-nth :kind :function}
      {:name random-sample :kind :function}
+     {:name random-uuid :kind :function}
      {:name range :kind :function}
      {:name ratio? :kind :function}
      {:name rational? :kind :function}
@@ -739,6 +746,7 @@
      {:name remove-all-methods :kind :function}
      {:name remove-method :kind :function}
      {:name remove-ns :kind :function}
+     {:name remove-tap :kind :function}
      {:name remove-watch :kind :function}
      {:name repeat :kind :function}
      {:name repeatedly :kind :function}
@@ -822,6 +830,7 @@
      {:name take-last :kind :function}
      {:name take-nth :kind :function}
      {:name take-while :kind :function}
+     {:name tap> :kind :function}
      {:name test :kind :function}
      {:name the-ns :kind :function}
      {:name thread-bound? :kind :function}
@@ -1072,7 +1081,6 @@
      {:name -write :kind :function}
      {:name APersistentVector :kind :variable}
      {:name ASeq :kind :variable}
-     {:name ArrayChunk :kind :variable}
      {:name ArrayIter :kind :variable}
      {:name ArrayList :kind :variable}
      {:name ArrayNode :kind :variable}
@@ -1095,7 +1103,6 @@
      {:name ES6Iterator :kind :variable}
      {:name ES6IteratorSeq :kind :variable}
      {:name ES6SetEntriesIterator :kind :variable}
-     {:name Eduction :kind :variable}
      {:name Empty :kind :variable}
      {:name EmptyList :kind :variable}
      {:name ExceptionInfo :kind :function}
@@ -1219,7 +1226,6 @@
      {:name Var :kind :variable}
      {:name VectorNode :kind :variable}
      {:name Volatile :kind :variable}
-     {:name add-tap :kind :function}
      {:name add-to-string-hash-cache :kind :function}
      {:name array :kind :function}
      {:name array-chunk :kind :function}
@@ -1244,8 +1250,6 @@
      {:name es6-iterator :kind :function}
      {:name es6-iterator-seq :kind :function}
      {:name es6-set-entries-iterator :kind :function}
-     {:name ex-cause :kind :function}
-     {:name ex-message :kind :function}
      {:name exists? :kind :function}
      {:name find-macros-ns :kind :function}
      {:name find-ns-obj :kind :function}
@@ -1255,7 +1259,6 @@
      {:name hash-string* :kind :function}
      {:name ifind? :kind :function}
      {:name imul :kind :function}
-     {:name infinite? :kind :function}
      {:name int-rotate-left :kind :function}
      {:name is_proto_ :kind :function}
      {:name iter :kind :function}
@@ -1296,11 +1299,9 @@
      {:name print-meta? :kind :function}
      {:name print-prefix-map :kind :function}
      {:name prn-str-with-opts :kind :function}
-     {:name random-uuid :kind :function}
      {:name ranged-iterator :kind :function}
      {:name reduceable? :kind :function}
      {:name regexp? :kind :function}
-     {:name remove-tap :kind :function}
      {:name seq-iter :kind :function}
      {:name set-from-indexed-seq :kind :function}
      {:name set-print-err-fn! :kind :function}
@@ -1312,7 +1313,6 @@
      {:name string-print :kind :function}
      {:name symbol-identical? :kind :function}
      {:name system-time :kind :function}
-     {:name tap> :kind :function}
      {:name this-as :kind :function}
      {:name transformer-iterator :kind :function}
      {:name truth_ :kind :function}


### PR DESCRIPTION
This adds new definitions added in Clojure 1.10 and 1.11, or in a few cases, moves them from ClojureScript.

* I moved `ArrayChunk` from cljs to clj. clj already had `->ArrayChunk`, so now it has both. Is this correct? It's not obvious because the `->*` versions must have all been added manually to `clojure-lsp`, since they're only implied to exist.
* Same question for `Eduction`.
* There's a new symbol `ArrayManager` (of kind `:variable`). Should I add `->ArrayManager`, of kind `:reference` too? Again, it's not clear because the `->*` versions must have been added manually.
* Same question for `IVecImpl`.
* The clj syms were all calculated from the analysis of `clojure-lsp`, which uses Clojure 1.11. I didn't re-calculate the syms for ClojureScript. I could do that, but the ClojureScript [changelog](https://github.com/clojure/clojurescript/blob/master/changes.md) doesn't suggest anything has changed recently. Up to you.

- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
