### PR TITLE
Bump rewrite-clj and apply fixes for correct end of root node

### DIFF
--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -1,5 +1,5 @@
 {:deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}
+        rewrite-clj/rewrite-clj {:mvn/version "1.0.767-alpha"}
         borkdude/rewrite-edn {:mvn/version "0.1.0" :exclusions [rewrite-clj/rewrite-clj]}
         org.clojure/core.async {:mvn/version "1.5.648"}
         cljfmt/cljfmt {:mvn/version "0.8.0"

--- a/lib/src/clojure_lsp/feature/drag.clj
+++ b/lib/src/clojure_lsp/feature/drag.clj
@@ -494,11 +494,7 @@
                                     :take-focus? true
                                     :range       (assoc position :end-row (:row position) :end-col (:col position))}
          :changes-by-uri {uri
-                          [{:range (if (= :forms (z/tag parent-zloc))
-                                     ;; work around for https://github.com/clj-commons/rewrite-clj/issues/173
-                                     ;; when that's fixed, revert to else-clause: (z-cursor-position parent-loc)
-                                     shared/full-file-position
-                                     (z-cursor-position parent-zloc))
+                          [{:range (z-cursor-position parent-zloc)
                             :loc   parent-zloc}]}}))))
 
 (defn drag-backward [zloc uri db] (drag zloc :backward uri db))

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -45,7 +45,7 @@
         new-text (cljfmt/reformat-string text cljfmt-settings)]
     (if (= new-text text)
       []
-      [{:range (shared/full-file-range)
+      [{:range shared/full-file-range
         :new-text new-text}])))
 
 (defn range-formatting [doc-id format-pos db]

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -226,10 +226,10 @@
       [{:name (or (some-> namespace-definition :name name)
                   filename)
         :kind (f.document-symbol/element->symbol-kind namespace-definition)
-        :range (shared/full-file-range)
+        :range shared/full-file-range
         :selection-range (if namespace-definition
                            (shared/->scope-range namespace-definition)
-                           (shared/full-file-range))
+                           shared/full-file-range)
         :children (->> (q/find-var-definitions analysis filename true)
                        (mapv (fn [e]
                                (shared/assoc-some
@@ -355,7 +355,7 @@
         (producer/publish-workspace-edit producer edit)
         (when show-document-after-edit
           (->> (update show-document-after-edit :range #(or (some-> % shared/->range)
-                                                            (shared/full-file-range)))
+                                                            shared/full-file-range))
                (producer/show-document-request producer)))
         edit))))
 

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -426,8 +426,5 @@
     {:start {:line (max 0 (dec (or row name-row))) :character (max 0 (dec (or col name-col)))}
      :end {:line (max 0 (dec (or end-row name-end-row))) :character (max 0 (dec (or end-col name-end-col)))}}))
 
-(def full-file-position
-  {:row 1 :col 1 :end-row 1000000 :end-col 1000000})
-
-(defn full-file-range []
-  (->range full-file-position))
+(def full-file-range
+  (->range {:row 1 :col 1 :end-row 1000000 :end-col 1000000}))

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -340,13 +340,11 @@
                           (h/code "(def a) |(def b)"))
     (assert-drag-backward (h/code "|(def b) (def a) (def c)")
                           (h/code "(def a) |(def b) (def c)"))
-    (is (= ;; preferrably would be:
-          #_{:row 1 :col 1
-             :end-row 2 :end-col 8}
-          shared/full-file-position
-          (as-range
-            (drag-code-backward (h/code "(def a)"
-                                        "|(def b)"))))))
+    (is (= {:row 1 :col 1
+            :end-row 2 :end-col 8}
+           (as-range
+             (drag-code-backward (h/code "(def a)"
+                                         "|(def b)"))))))
   (testing "within special functions"
     (assert-drag-backward (h/code "(cond |b 2 a 1)")
                           (h/code "(cond a 1 |b 2)"))
@@ -732,13 +730,11 @@
                          (h/code "|(def a) (def b)"))
     (assert-drag-forward (h/code "(def a) (def c) |(def b)")
                          (h/code "(def a) |(def b) (def c)"))
-    (is (= ;; preferrably would be:
-          #_{:row 1 :col 1
-             :end-row 2 :end-col 8}
-          shared/full-file-position
-          (as-range
-            (drag-code-forward (h/code "|(def a)"
-                                       "(def b)"))))))
+    (is (= {:row 1 :col 1
+            :end-row 2 :end-col 8}
+           (as-range
+             (drag-code-forward (h/code "|(def a)"
+                                        "(def b)"))))))
   (testing "within special functions"
     (assert-drag-forward (h/code "(cond b 2 |a 1)")
                          (h/code "(cond |a 1 b 2)"))

--- a/lib/test/clojure_lsp/refactor/transform_test.clj
+++ b/lib/test/clojure_lsp/refactor/transform_test.clj
@@ -800,7 +800,7 @@
                           "(deftest foo-test"
                           "  (is (= true"
                           "         (subject/foo))))"),
-             :range {:row 1 :col 1 :end-row 4 :end-col 27}}]}
+             :range {:row 1 :col 1 :end-row 8 :end-col 26}}]}
           results-to-assert)))
     (testing "when the test file doesn't exists for cljs file"
       (swap! db/db* shared/deep-merge {:settings {:source-paths #{(h/file-path "/project/src") (h/file-path "/project/test")}}
@@ -824,7 +824,7 @@
                           "(deftest foo-test"
                           "  (is (= true"
                           "         (subject/foo))))"),
-             :range {:row 1 :col 1 :end-row 4 :end-col 27}}]}
+             :range {:row 1 :col 1 :end-row 8 :end-col 26}}]}
           results-to-assert)))
     (testing "when the test file exists for clj file"
       (swap! db/db* shared/deep-merge {:settings {:source-paths #{(h/file-path "/project/src")


### PR DESCRIPTION
`rewrite-clj 1.0.767-alpha` includes a fix that corrects the end position of the root node, a fix which we requested. That lets us avoid a workaround when dragging top-level expressions.

This also fixes the end position when creating new test files. I doubt any editors care about the end position when populating new files, so I believe this change is inconsequential.

- [x] This is follow-up for #893