### PR TITLE
Add `external?` to analysis for better performance all over the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Fix completion performance regression from previous release.
   - Consider `.bb` and `.cljd` files on watched file changes. #906
   - Bump to clojure 1.11.0
+  - Improve analysis query performance as a whole for lots of features. #916
 
 - Editor
   - Introduce ALPHA move-form command. #566

--- a/lib/src/clojure_lsp/crawler.clj
+++ b/lib/src/clojure_lsp/crawler.clj
@@ -28,7 +28,7 @@
                  (str startup-logger-tag " Project only paths analyzed, took %s")
                  (lsp.kondo/run-kondo-on-paths! paths false db*))
         analysis (->> (:analysis result)
-                      lsp.kondo/normalize-analysis
+                      (lsp.kondo/normalize-analysis false)
                       (group-by :filename))]
     (swap! db* (fn [state-db]
                  (-> state-db
@@ -56,7 +56,7 @@
                            (dissoc :namespace-usages :var-usages)
                            (update :var-definitions (fn [usages] (remove :private usages))))
         analysis (->> kondo-analysis
-                      lsp.kondo/normalize-analysis
+                      (lsp.kondo/normalize-analysis true)
                       (group-by :filename))]
     (swap! db* assoc :kondo-config (:config result))
     analysis))
@@ -64,7 +64,7 @@
 (defn analyze-reference-filenames! [filenames db*]
   (let [result (lsp.kondo/run-kondo-on-reference-filenames! filenames db*)
         analysis (->> (:analysis result)
-                      lsp.kondo/normalize-analysis
+                      (lsp.kondo/normalize-analysis false)
                       (group-by :filename))
         empty-findings (reduce (fn [map filename] (assoc map filename [])) {} filenames)
         new-findings (merge empty-findings (group-by :filename (:findings result)))]

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -19,7 +19,7 @@
 (defonce created-watched-files-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 1)
+(def version 2)
 
 (defn ^:private sqlite-db-file [project-root]
   (io/file (str project-root) ".lsp" ".cache" "sqlite.db"))

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -312,8 +312,8 @@
                                                     (->> vs
                                                          (map first)
                                                          frequencies
-                                                         (sort-by val)
-                                                         reverse
+                                                         (sort-by (fn [[ns freq]]
+                                                                    [(- freq) ns]))
                                                          (into (array-map))))))
         namespaces->aliases (->> ns-alias-pairs
                                  (group-by first)
@@ -322,8 +322,8 @@
                                                          (map second)
                                                          (remove nil?)
                                                          frequencies
-                                                         (sort-by val)
-                                                         reverse
+                                                         (sort-by (fn [[alias freq]]
+                                                                    [(- freq) alias]))
                                                          (into (array-map))))))
         alias-namespaces (get aliases->namespaces cursor-namespace-str)
         namespace-aliases (get namespaces->aliases cursor-namespace-str)

--- a/lib/src/clojure_lsp/feature/call_hierarchy.clj
+++ b/lib/src/clojure_lsp/feature/call_hierarchy.clj
@@ -58,7 +58,7 @@
 
 (defn ^:private element->outgoing-usage-by-uri
   [db element]
-  (when-let [definition (q/find-definition (:analysis db) element db)]
+  (when-let [definition (q/find-definition (:analysis db) element)]
     (let [def-filename (:filename definition)
           definition-uri (if (shared/plain-uri? def-filename)
                            def-filename
@@ -68,7 +68,7 @@
        :parent-element definition})))
 
 (defn incoming [uri row col db*]
-  (->> (q/find-references-from-cursor (:analysis @db*) (shared/uri->filename uri) row col false @db*)
+  (->> (q/find-references-from-cursor (:analysis @db*) (shared/uri->filename uri) row col false)
        (map (partial element->incoming-usage-by-uri db*))
        (remove nil?)
        (mapv (fn [element-by-uri]

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -264,7 +264,7 @@
         allow-drag-backward?* (future (f.drag/can-drag-backward? zloc uri db))
         allow-drag-forward?* (future (f.drag/can-drag-forward? zloc uri db))
         can-cycle-fn-literal?* (future (r.transform/can-cycle-fn-literal? zloc))
-        definition (q/find-definition-from-cursor (:analysis db) (shared/uri->filename uri) row col db)
+        definition (q/find-definition-from-cursor (:analysis db) (shared/uri->filename uri) row col)
         inline-symbol?* (future (r.transform/inline-symbol? definition db))
         can-add-let? (or (z/skip-whitespace z/right zloc)
                          (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))]

--- a/lib/src/clojure_lsp/feature/code_lens.clj
+++ b/lib/src/clojure_lsp/feature/code_lens.clj
@@ -49,7 +49,7 @@
 (defn resolve-code-lens [uri row col range db]
   (let [filename (shared/uri->filename uri)
         segregate-lens? (settings/get db [:code-lens :segregate-test-references] true)
-        references (q/find-references-from-cursor (:analysis db) filename row col false db)]
+        references (q/find-references-from-cursor (:analysis db) filename row col false)]
     (if segregate-lens?
       (let [source-path (->> (settings/get db [:source-paths])
                              (filter #(string/starts-with? filename %))

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -206,7 +206,7 @@
 (defn ^:private with-elements-from-alias [cursor-loc cursor-alias cursor-value matches-fn db]
   (when-let [aliases (seq (into []
                                 (comp
-                                  (q/filter-project-analysis-xf)
+                                  q/filter-project-analysis-xf
                                   (mapcat val)
                                   (filter #(identical? :namespace-alias (:bucket %))))
                                 (:analysis db)))]

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -241,7 +241,7 @@
                               (contains? alias-namespaces (:ns %))
                               (or (simple-ident? cursor-value) (matches-fn (:name %))))
                      [(:ns %) (element->completion-item % cursor-alias :unrequired-alias)]))
-                distinct
+                (distinct)
                 (map
                   (fn [[element-ns completion-item]]
                     (let [require-edit (some-> cursor-loc

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -232,7 +232,7 @@
                            (cond-> (element->completion-item element nil :required-alias)
                              (seq require-edit) (assoc :additional-text-edits (mapv #(update % :range shared/->range) require-edit)))))))
                 aliases))
-        (into #{}
+        (into []
               (comp
                 (mapcat val)
                 (keep
@@ -241,6 +241,7 @@
                               (contains? alias-namespaces (:ns %))
                               (or (simple-ident? cursor-value) (matches-fn (:name %))))
                      [(:ns %) (element->completion-item % cursor-alias :unrequired-alias)]))
+                distinct
                 (map
                   (fn [[element-ns completion-item]]
                     (let [require-edit (some-> cursor-loc

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -175,9 +175,9 @@
 (def ^:private all-kw-definitions q/find-all-keyword-definitions)
 
 (defn custom-lint-project!
-  [new-analysis kondo-ctx db]
+  [new-analysis kondo-ctx]
   (let [project-analysis (into {}
-                               (q/filter-project-analysis-xf db)
+                               (q/filter-project-analysis-xf)
                                new-analysis)]
     (shared/logging-time
       "Linting whole project for unused-public-var took %s"
@@ -186,9 +186,9 @@
                   project-analysis kondo-ctx))))
 
 (defn custom-lint-files!
-  [filenames new-analysis kondo-ctx db]
+  [filenames new-analysis kondo-ctx]
   (let [project-analysis (into {}
-                               (q/filter-project-analysis-xf db)
+                               (q/filter-project-analysis-xf)
                                new-analysis)
         file-analyses (select-keys project-analysis filenames)]
     (lint-defs! (all-var-definitions file-analyses)
@@ -196,9 +196,9 @@
                 project-analysis kondo-ctx)))
 
 (defn custom-lint-file!
-  [filename analysis kondo-ctx db]
+  [filename analysis kondo-ctx]
   (let [project-analysis (into {}
-                               (q/filter-project-analysis-xf db)
+                               (q/filter-project-analysis-xf)
                                analysis)]
     (lint-defs! (file-var-definitions project-analysis filename)
                 (file-kw-definitions project-analysis filename)
@@ -206,7 +206,7 @@
 
 (defn custom-lint-file-merging-findings!
   [filename analysis kondo-ctx db]
-  (let [kondo-findings (-> (custom-lint-file! filename analysis kondo-ctx db)
+  (let [kondo-findings (-> (custom-lint-file! filename analysis kondo-ctx)
                            (get filename))
         cur-findings (get-in db [:findings filename])]
     (->> cur-findings

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -177,7 +177,7 @@
 (defn custom-lint-project!
   [new-analysis kondo-ctx]
   (let [project-analysis (into {}
-                               (q/filter-project-analysis-xf)
+                               q/filter-project-analysis-xf
                                new-analysis)]
     (shared/logging-time
       "Linting whole project for unused-public-var took %s"
@@ -188,7 +188,7 @@
 (defn custom-lint-files!
   [filenames new-analysis kondo-ctx]
   (let [project-analysis (into {}
-                               (q/filter-project-analysis-xf)
+                               q/filter-project-analysis-xf
                                new-analysis)
         file-analyses (select-keys project-analysis filenames)]
     (lint-defs! (all-var-definitions file-analyses)
@@ -198,7 +198,7 @@
 (defn custom-lint-file!
   [filename analysis kondo-ctx]
   (let [project-analysis (into {}
-                               (q/filter-project-analysis-xf)
+                               q/filter-project-analysis-xf
                                analysis)]
     (lint-defs! (file-var-definitions project-analysis filename)
                 (file-kw-definitions project-analysis filename)

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -95,7 +95,7 @@
   (let [changed-var-definitions (find-changed-var-definitions old-local-analysis new-local-analysis)
         changed-var-usages (find-changed-var-usages old-local-analysis new-local-analysis)
         project-analysis (into {}
-                               (q/filter-project-analysis-xf)
+                               q/filter-project-analysis-xf
                                (dissoc (:analysis db) filename)) ;; don't notify self
         incoming-filenames (when (seq changed-var-definitions)
                              (let [def-signs (->> changed-var-definitions

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -19,7 +19,10 @@
 (set! *warn-on-reflection* true)
 
 (defn ^:private update-analysis [db uri new-analysis]
-  (assoc-in db [:analysis (shared/uri->filename uri)] (lsp.kondo/normalize-analysis new-analysis)))
+  (let [filename (shared/uri->filename uri)
+        source-paths (settings/get db [:source-paths])
+        external-filename? (shared/external-filename? filename source-paths)]
+    (assoc-in db [:analysis filename] (lsp.kondo/normalize-analysis external-filename? new-analysis))))
 
 (defn ^:private update-findings [db uri new-findings]
   (assoc-in db [:findings (shared/uri->filename uri)] new-findings))
@@ -92,7 +95,7 @@
   (let [changed-var-definitions (find-changed-var-definitions old-local-analysis new-local-analysis)
         changed-var-usages (find-changed-var-usages old-local-analysis new-local-analysis)
         project-analysis (into {}
-                               (q/filter-project-analysis-xf db)
+                               (q/filter-project-analysis-xf)
                                (dissoc (:analysis db) filename)) ;; don't notify self
         incoming-filenames (when (seq changed-var-definitions)
                              (let [def-signs (->> changed-var-definitions
@@ -225,7 +228,7 @@
                    "Created watched files analyzed, took %s"
                    (lsp.kondo/run-kondo-on-paths! filenames false db*))
           analysis (->> (:analysis result)
-                        lsp.kondo/normalize-analysis
+                        (lsp.kondo/normalize-analysis false)
                         (group-by :filename))]
       (swap! db* (fn [state-db]
                    (-> state-db

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -116,7 +116,7 @@
                     usage
                     (when (pos? try-column)
                       (recur (dec try-column)))))
-        definition (when element (q/find-definition analysis element db))]
+        definition (when element (q/find-definition analysis element))]
     (cond
       definition
       {:range (shared/->range element)

--- a/lib/src/clojure_lsp/feature/java_interop.clj
+++ b/lib/src/clojure_lsp/feature/java_interop.clj
@@ -136,7 +136,7 @@
                  (lsp.kondo/run-kondo-on-jdk-source! path))
         kondo-analysis (select-keys (:analysis result) [:java-class-definitions])
         analysis (->> kondo-analysis
-                      lsp.kondo/normalize-analysis
+                      (lsp.kondo/normalize-analysis true)
                       (group-by :filename))]
     (loop [state-db @db*]
       (when-not (compare-and-set! db* state-db (update state-db :analysis merge analysis))

--- a/lib/src/clojure_lsp/feature/linked_editing_range.clj
+++ b/lib/src/clojure_lsp/feature/linked_editing_range.clj
@@ -7,7 +7,7 @@
 
 (defn ranges [uri row col db]
   (let [filename (shared/uri->filename uri)
-        elements (q/find-references-from-cursor (:analysis db) filename row col true db)
+        elements (q/find-references-from-cursor (:analysis db) filename row col true)
         same-file-references-only? (= 1 (count (keys (group-by :filename elements))))]
     (if same-file-references-only?
       {:ranges (->> elements

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -103,9 +103,9 @@
         form-loc (edit/to-top zloc)
         analysis (:analysis db)
         source-filename (shared/uri->filename uri)
-        source-ns (:name (q/find-namespace-definition-by-filename analysis source-filename db))
+        source-ns (:name (q/find-namespace-definition-by-filename analysis source-filename))
         dest-filename (shared/absolute-path dest-filename db)
-        dest-ns (:name (q/find-namespace-definition-by-filename analysis dest-filename db))
+        dest-ns (:name (q/find-namespace-definition-by-filename analysis dest-filename))
         inner-usages (var-usages-within zloc uri db)
         ;; if source-ns things are used within the form
         ;; we can't move it
@@ -122,7 +122,7 @@
                        multiple-defs?)]
     (when can-move?
       (let [def-to-move (first defs)
-            refs (q/find-references analysis def-to-move false db)
+            refs (q/find-references analysis def-to-move false)
             dest-refs (filter (comp #(= % dest-filename) :filename) refs)
             per-file-usages (group-by (comp #(shared/filename->uri % db) :filename) refs)
             dest-uri (shared/filename->uri dest-filename db)

--- a/lib/src/clojure_lsp/feature/rename.clj
+++ b/lib/src/clojure_lsp/feature/rename.clj
@@ -185,8 +185,8 @@
         element (q/find-element-under-cursor (:analysis db) filename row col)]
     (if-not element
       error-no-element
-      (let [references (q/find-references (:analysis db) element true db)
-            definition (q/find-definition (:analysis db) element db)
+      (let [references (q/find-references (:analysis db) element true)
+            definition (q/find-definition (:analysis db) element)
             source-paths (settings/get db [:source-paths])
             client-capabilities (:client-capabilities db)
             {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
@@ -201,8 +201,8 @@
         element (q/find-element-under-cursor (:analysis db) filename row col)]
     (if-not element
       error-no-element
-      (let [references (q/find-references (:analysis db) element true db)
-            definition (q/find-definition (:analysis db) element db)
+      (let [references (q/find-references (:analysis db) element true)
+            definition (q/find-definition (:analysis db) element)
             source-paths (settings/get db [:source-paths])
             client-capabilities (:client-capabilities db)
             {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]

--- a/lib/src/clojure_lsp/feature/signature_help.clj
+++ b/lib/src/clojure_lsp/feature/signature_help.clj
@@ -85,7 +85,7 @@
       (let [db @db*
             arglist-nodes (function-loc->arglist-nodes function-loc)
             function-meta (meta (z/node function-loc))
-            definition (q/find-definition-from-cursor (:analysis db) filename (:row function-meta) (:col function-meta) db)
+            definition (q/find-definition-from-cursor (:analysis db) filename (:row function-meta) (:col function-meta))
             signatures (definition->signature-informations definition)
             active-signature (get-active-signature-index definition arglist-nodes)]
         (when (seq signatures)

--- a/lib/src/clojure_lsp/feature/stubs.clj
+++ b/lib/src/clojure_lsp/feature/stubs.clj
@@ -51,7 +51,7 @@
         kondo-analysis (-> (:analysis result)
                            (dissoc :namespace-usages :var-usages))
         analysis (->> kondo-analysis
-                      lsp.kondo/normalize-analysis
+                      (lsp.kondo/normalize-analysis true)
                       (group-by :filename))]
     (loop [state-db @db*]
       (when-not (compare-and-set! db* state-db (update state-db :analysis merge analysis))

--- a/lib/src/clojure_lsp/feature/test_tree.clj
+++ b/lib/src/clojure_lsp/feature/test_tree.clj
@@ -34,7 +34,7 @@
 
 (defn tree [uri db]
   (let [filename (shared/uri->filename uri)
-        ns-element (q/find-namespace-definition-by-filename (:analysis db) filename db)
+        ns-element (q/find-namespace-definition-by-filename (:analysis db) filename)
         local-analysis (get-in db [:analysis filename])
         deftests (into []
                        (filter #(and (identical? :var-definitions (:bucket %))

--- a/lib/src/clojure_lsp/feature/workspace_symbols.clj
+++ b/lib/src/clojure_lsp/feature/workspace_symbols.clj
@@ -48,7 +48,7 @@
   ;; TODO refactor to be a complete transducer
   (->> (into {}
              (comp
-               (q/filter-project-analysis-xf db))
+               (q/filter-project-analysis-xf))
              (:analysis db))
        vals
        flatten

--- a/lib/src/clojure_lsp/feature/workspace_symbols.clj
+++ b/lib/src/clojure_lsp/feature/workspace_symbols.clj
@@ -48,7 +48,7 @@
   ;; TODO refactor to be a complete transducer
   (->> (into {}
              (comp
-               (q/filter-project-analysis-xf))
+               q/filter-project-analysis-xf)
              (:analysis db))
        vals
        flatten

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -75,7 +75,7 @@
   (let [db @db*
         project-files (into #{}
                             (comp
-                              (q/filter-project-analysis-xf)
+                              q/filter-project-analysis-xf
                               (map key))
                             (:analysis db))]
     (->> project-files

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -75,7 +75,7 @@
   (let [db @db*
         project-files (into #{}
                             (comp
-                              (q/filter-project-analysis-xf db)
+                              (q/filter-project-analysis-xf)
                               (map key))
                             (:analysis db))]
     (->> project-files
@@ -162,7 +162,7 @@
                         (shared/filename->uri db)
                         (f.java-interop/uri->translated-uri db))
                :range (shared/->range reference)})
-            (q/find-references-from-cursor (:analysis db) (shared/uri->filename textDocument) row col (:includeDeclaration context) db)))))
+            (q/find-references-from-cursor (:analysis db) (shared/uri->filename textDocument) row col (:includeDeclaration context))))))
 
 (defn completion-resolve-item [item {:keys [db*]}]
   (shared/logging-task
@@ -186,7 +186,7 @@
     :definition
     (let [db @db*
           [line column] (shared/position->line-column position)]
-      (when-let [definition (q/find-definition-from-cursor (:analysis db) (shared/uri->filename textDocument) line column db)]
+      (when-let [definition (q/find-definition-from-cursor (:analysis db) (shared/uri->filename textDocument) line column)]
         {:uri (-> (:filename definition)
                   (shared/filename->uri db)
                   (f.java-interop/uri->translated-uri db))
@@ -197,7 +197,7 @@
     :declaration
     (let [db @db*
           [line column] (shared/position->line-column position)]
-      (when-let [declaration (q/find-declaration-from-cursor (:analysis db) (shared/uri->filename textDocument) line column db)]
+      (when-let [declaration (q/find-declaration-from-cursor (:analysis db) (shared/uri->filename textDocument) line column)]
         {:uri (-> (:filename declaration)
                   (shared/filename->uri db)
                   (f.java-interop/uri->translated-uri db))
@@ -213,7 +213,7 @@
                         (shared/filename->uri db)
                         (f.java-interop/uri->translated-uri db))
                :range (shared/->range implementation)})
-            (q/find-implementations-from-cursor (:analysis db) (shared/uri->filename textDocument) row col db)))))
+            (q/find-implementations-from-cursor (:analysis db) (shared/uri->filename textDocument) row col)))))
 
 (defn document-symbol [{:keys [textDocument]}]
   (shared/logging-task
@@ -250,7 +250,7 @@
           column (-> position :character inc)
           filename (shared/uri->filename textDocument)
           scoped-analysis (select-keys (:analysis db) [filename])
-          references (q/find-references-from-cursor scoped-analysis filename line column true db)]
+          references (q/find-references-from-cursor scoped-analysis filename line column true)]
       (mapv (fn [reference]
               {:range (shared/->range reference)})
             references))))
@@ -295,7 +295,7 @@
                        :elements (mapv (fn [e]
                                          (shared/assoc-some
                                            {:element e}
-                                           :definition (q/find-definition analysis e db)
+                                           :definition (q/find-definition analysis e)
                                            :semantic-tokens (f.semantic-tokens/element->token-type e)))
                                        elements))))
 

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -258,7 +258,7 @@
            seq)
       (into #{}
             (comp
-              (q/filter-project-analysis-xf)
+              q/filter-project-analysis-xf
               (q/find-all-ns-definition-names-xf)
               (remove (partial exclude-ns? options)))
             (:analysis db))))
@@ -380,7 +380,7 @@
         from-ns (if ns-only?
                   from
                   (symbol (namespace from)))
-        project-analysis (into {} (q/filter-project-analysis-xf) (:analysis db))]
+        project-analysis (into {} q/filter-project-analysis-xf (:analysis db))]
     (if-let [from-element (if ns-only?
                             (q/find-namespace-definition-by-namespace project-analysis from-ns)
                             (q/find-element-by-full-name project-analysis from-name from-ns))]

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -193,7 +193,7 @@
     (analyze! options components)))
 
 (defn ^:private ns->ns+uri [namespace db]
-  (if-let [filename (:filename (q/find-namespace-definition-by-namespace (:analysis db) namespace db))]
+  (if-let [filename (:filename (q/find-namespace-definition-by-namespace (:analysis db) namespace))]
     {:namespace namespace
      :uri (shared/filename->uri filename db)}
     {:namespace namespace}))
@@ -258,7 +258,7 @@
            seq)
       (into #{}
             (comp
-              (q/filter-project-analysis-xf db)
+              (q/filter-project-analysis-xf)
               (q/find-all-ns-definition-names-xf)
               (remove (partial exclude-ns? options)))
             (:analysis db))))
@@ -380,10 +380,10 @@
         from-ns (if ns-only?
                   from
                   (symbol (namespace from)))
-        project-analysis (into {} (q/filter-project-analysis-xf db) (:analysis db))]
+        project-analysis (into {} (q/filter-project-analysis-xf) (:analysis db))]
     (if-let [from-element (if ns-only?
-                            (q/find-namespace-definition-by-namespace project-analysis from-ns db)
-                            (q/find-element-by-full-name project-analysis from-name from-ns db))]
+                            (q/find-namespace-definition-by-namespace project-analysis from-ns)
+                            (q/find-element-by-full-name project-analysis from-name from-ns))]
       (let [uri (shared/filename->uri (:filename from-element) db)]
         (open-file! {:uri uri :namespace from-ns} components)
         (let [{:keys [error document-changes]} (f.rename/rename uri (str to) (:name-row from-element) (:name-col from-element) db*)]

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -23,22 +23,28 @@
     nil
     coll))
 
-(defn filter-project-analysis-xf []
-  (remove (comp :external? first second)))
+(def filter-project-analysis-xf
+  "Filter only project elements from analysis.
+  Checking if the first value is `external?`, we infer all elements
+  for that filename are too."
+  (remove (comp :external? first val)))
 
-(defn filter-external-analysis-xf []
-  (filter (comp :external? first second)))
+(def filter-external-analysis-xf
+  "Filter only external elements from analysis.
+  Checking if the first value is not `external?`, we infer all elements
+  for that filename are not too."
+  (filter (comp :external? first val)))
 
 (defn ^:private find-last-order-by-project-analysis [pred? analysis]
   (or (peek (into []
                   (comp
-                    (filter-project-analysis-xf)
+                    filter-project-analysis-xf
                     (mapcat val)
                     (filter pred?))
                   analysis))
       (peek (into []
                   (comp
-                    (filter-external-analysis-xf)
+                    filter-external-analysis-xf
                     (mapcat val)
                     (filter pred?))
                   analysis))))
@@ -360,7 +366,7 @@
   [analysis {:keys [ns name] :as _element} include-declaration?]
   (into []
         (comp
-          (filter-project-analysis-xf)
+          filter-project-analysis-xf
           (mapcat val)
           (filter #(identical? :keywords (:bucket %)))
           (filter #(safe-equal? name (:name %)))
@@ -511,7 +517,7 @@
   (let [langs (shared/uri->available-langs uri)]
     (into #{}
           (comp
-            (filter-project-analysis-xf)
+            filter-project-analysis-xf
             (mapcat val)
             (filter #(identical? :namespace-alias (:bucket %)))
             (filter :alias)

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.queries
   (:require
-   [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
    [clojure.set :as set]
    [clojure.string :as string]
@@ -24,24 +23,22 @@
     nil
     coll))
 
-(defn filter-project-analysis-xf [db]
-  (let [source-paths (settings/get db [:source-paths])]
-    (remove #(shared/external-filename? (first %) source-paths))))
+(defn filter-project-analysis-xf []
+  (remove (comp :external? first second)))
 
-(defn filter-external-analysis-xf [db]
-  (let [source-paths (settings/get db [:source-paths])]
-    (filter #(shared/external-filename? (first %) source-paths))))
+(defn filter-external-analysis-xf []
+  (filter (comp :external? first second)))
 
-(defn ^:private find-last-order-by-project-analysis [pred? analysis db]
+(defn ^:private find-last-order-by-project-analysis [pred? analysis]
   (or (peek (into []
                   (comp
-                    (filter-project-analysis-xf db)
+                    (filter-project-analysis-xf)
                     (mapcat val)
                     (filter pred?))
                   analysis))
       (peek (into []
                   (comp
-                    (filter-external-analysis-xf db)
+                    (filter-external-analysis-xf)
                     (mapcat val)
                     (filter pred?))
                   analysis))))
@@ -105,79 +102,73 @@
             local-analysis)))
 
 (defmulti find-definition
-  (fn [_analysis element _db]
+  (fn [_analysis element]
     (:bucket element)))
 
 (defmethod find-definition :namespace-alias
-  [analysis element db]
+  [analysis element]
   (find-last-order-by-project-analysis
     #(and (identical? :namespace-definitions (:bucket %))
           (= (:name %) (:to element))
           (match-file-lang % element))
-    analysis
-    db))
+    analysis))
 
 (defmethod find-definition :namespace-usages
-  [analysis element db]
+  [analysis element]
   (find-last-order-by-project-analysis
     #(and (identical? :namespace-definitions (:bucket %))
           (= (:name %) (:name element))
           (match-file-lang % element))
-    analysis
-    db))
+    analysis))
 
 (defmethod find-definition :var-usages
-  [analysis element db]
+  [analysis element]
   (find-last-order-by-project-analysis
     #(and (identical? :var-definitions (:bucket %))
           (= (:name %) (:name element))
           (not (= (:defined-by %) 'clojure.core/declare))
           (= (:ns %) (:to element))
           (match-file-lang % element))
-    analysis
-    db))
+    analysis))
 
 (defmethod find-definition :local-usages
-  [analysis {:keys [id filename] :as _element} _db]
+  [analysis {:keys [id filename] :as _element}]
   (find-first #(and (= :locals (:bucket %)) (= (:id %) id))
               (get analysis filename)))
 
 (defmethod find-definition :keywords
-  [analysis element db]
+  [analysis element]
   (or (when (:ns element)
         (find-last-order-by-project-analysis
           #(and (identical? :keywords (:bucket %))
                 (= (:name %) (:name element))
                 (:reg %)
                 (= (:ns %) (:ns element)))
-          analysis
-          db))
+          analysis))
       element))
 
 (defmethod find-definition :var-definitions
-  [analysis element db]
+  [analysis element]
   (if (= 'potemkin/import-vars (:defined-by element))
     (find-last-order-by-project-analysis
       #(and (identical? :var-definitions (:bucket %))
             (= (:name %) (:name element))
             (not= 'potemkin/import-vars (:defined-by %))
             (match-file-lang % element))
-      analysis
-      db)
+      analysis)
     element))
 
 (defmethod find-definition :protocol-impls
-  [analysis element db]
+  [analysis element]
   (find-last-order-by-project-analysis
     #(and (identical? :var-definitions (:bucket %))
           (= (:name %) (:method-name element))
           (= (:ns %) (:protocol-ns element))
           (match-file-lang % element))
-    analysis
-    db))
+    analysis))
 
 (defmethod find-definition :java-class-usages
-  [analysis element _db]
+  [analysis element]
   (->> analysis
        (into []
              (comp
@@ -188,15 +179,15 @@
        first))
 
 (defmethod find-definition :default
-  [_analysis element _db]
+  [_analysis element]
   element)
 
 (defmulti find-declaration
-  (fn [_analysis element _db]
+  (fn [_analysis element]
     (:bucket element)))
 
 (defmethod find-declaration :var-usages
-  [analysis element db]
+  [analysis element]
   (when-not (identical? :clj-kondo/unknown-namespace (:to element))
     (if (:alias element)
       (find-last-order-by-project-analysis
@@ -205,8 +196,7 @@
               (= (:alias element) (:alias %))
               (= (:filename element) (:filename %))
               (match-file-lang % element))
-        analysis
-        db)
+        analysis)
       (find-last-order-by-project-analysis
         #(if (:refer %)
            (and (identical? :var-usages (:bucket %))
@@ -217,17 +207,16 @@
                 (= (:to element) (:name %))
                 (= (:filename element) (:filename %))
                 (match-file-lang % element)))
-        analysis
-        db))))
+        analysis))))
 
-(defmethod find-declaration :default [_ _ _] nil)
+(defmethod find-declaration :default [_ _] nil)
 
 (defmulti find-implementations
-  (fn [_analysis element _db]
+  (fn [_analysis element]
     (:bucket element)))
 
 (defmethod find-implementations :var-definitions
-  [analysis element _db]
+  [analysis element]
   (into []
         (comp
           (mapcat val)
@@ -259,7 +248,7 @@
         analysis))
 
 (defmethod find-implementations :var-usages
-  [analysis element _db]
+  [analysis element]
   (if (= (:to element) :clj-kondo/unknown-namespace)
     []
     (into []
@@ -286,17 +275,17 @@
             (medley/distinct-by (juxt :filename :name :row :col)))
           analysis)))
 
-(defmethod find-implementations :default [_ _ _] [])
+(defmethod find-implementations :default [_ _] [])
 
 (defmulti find-references
-  (fn [_analysis element _include-declaration? _db]
+  (fn [_analysis element _include-declaration?]
     (case (:bucket element)
       :locals :local
       :local-usages :local
       (:bucket element))))
 
 (defmethod find-references :namespace-definitions
-  [analysis {:keys [name] :as element} include-declaration? _db]
+  [analysis {:keys [name] :as element} include-declaration?]
   (concat
     (when include-declaration?
       [element])
@@ -312,7 +301,7 @@
           analysis)))
 
 (defmethod find-references :namespace-usages
-  [analysis {:keys [name] :as element} include-declaration? _db]
+  [analysis {:keys [name] :as element} include-declaration?]
   (concat
     (when include-declaration?
       [element])
@@ -328,7 +317,7 @@
           analysis)))
 
 (defmethod find-references :namespace-alias
-  [analysis {:keys [alias filename] :as element} include-declaration? _db]
+  [analysis {:keys [alias filename] :as element} include-declaration?]
   (concat
     (when include-declaration?
       [element])
@@ -342,16 +331,16 @@
           (get analysis filename))))
 
 (defmethod find-references :var-usages
-  [analysis element include-declaration? _db]
+  [analysis element include-declaration?]
   (if (= (:to element) :clj-kondo/unknown-namespace)
     [element]
     (let [var-definition {:ns (:to element)
                           :name (:name element)
                           :bucket :var-definitions}]
-      (find-references analysis var-definition include-declaration? _db))))
+      (find-references analysis var-definition include-declaration?))))
 
 (defmethod find-references :var-definitions
-  [analysis element include-declaration? _db]
+  [analysis element include-declaration?]
   (let [names (var-definition-names element)
         exclude-declaration? (not include-declaration?)]
     (into []
@@ -368,10 +357,10 @@
           analysis)))
 
 (defmethod find-references :keywords
-  [analysis {:keys [ns name] :as _element} include-declaration? db]
+  [analysis {:keys [ns name] :as _element} include-declaration?]
   (into []
         (comp
-          (filter-project-analysis-xf db)
+          (filter-project-analysis-xf)
           (mapcat val)
           (filter #(identical? :keywords (:bucket %)))
           (filter #(safe-equal? name (:name %)))
@@ -385,7 +374,7 @@
         analysis))
 
 (defmethod find-references :local
-  [analysis {:keys [id name filename] :as element} include-declaration? _db]
+  [analysis {:keys [id name filename] :as element} include-declaration?]
   (if (or id name)
     (filter #(and (= (:id %) id)
                   (or include-declaration?
@@ -394,7 +383,7 @@
     [element]))
 
 (defmethod find-references :protocol-impls
-  [analysis element include-declaration? _db]
+  [analysis element include-declaration?]
   (concat
     (when include-declaration?
       [element])
@@ -408,7 +397,7 @@
           analysis)))
 
 (defmethod find-references :default
-  [_analysis element _ _]
+  [_analysis element _]
   [element])
 
 (defn find-element-under-cursor
@@ -427,31 +416,31 @@
                  (<= name-col column name-end-col)))
           (get analysis filename)))
 
-(defn find-definition-from-cursor [analysis filename line column db]
+(defn find-definition-from-cursor [analysis filename line column]
   (try
     (when-let [element (find-element-under-cursor analysis filename line column)]
-      (find-definition analysis element db))
+      (find-definition analysis element))
     (catch Throwable e
       (logger/error e "can't find definition"))))
 
-(defn find-declaration-from-cursor [analysis filename line column db]
+(defn find-declaration-from-cursor [analysis filename line column]
   (try
     (when-let [element (find-element-under-cursor analysis filename line column)]
-      (find-declaration analysis element db))
+      (find-declaration analysis element))
     (catch Throwable e
       (logger/error e "can't find declaration"))))
 
-(defn find-implementations-from-cursor [analysis filename line column db]
+(defn find-implementations-from-cursor [analysis filename line column]
   (try
     (when-let [element (find-element-under-cursor analysis filename line column)]
-      (find-implementations analysis element db))
+      (find-implementations analysis element))
     (catch Throwable e
       (logger/error e "can't find implementation"))))
 
-(defn find-references-from-cursor [analysis filename line column include-declaration? db]
+(defn find-references-from-cursor [analysis filename line column include-declaration?]
   (try
     (when-let [element (find-element-under-cursor analysis filename line column)]
-      (find-references analysis element include-declaration? db))
+      (find-references analysis element include-declaration?))
     (catch Throwable e
       (logger/error e "can't find references"))))
 
@@ -522,7 +511,7 @@
   (let [langs (shared/uri->available-langs uri)]
     (into #{}
           (comp
-            (filter-project-analysis-xf db)
+            (filter-project-analysis-xf)
             (mapcat val)
             (filter #(identical? :namespace-alias (:bucket %)))
             (filter :alias)
@@ -595,19 +584,17 @@
           (filter #(identical? :namespace-definitions (:bucket %))))
         analysis))
 
-(defn find-namespace-definition-by-namespace [analysis namespace db]
+(defn find-namespace-definition-by-namespace [analysis namespace]
   (find-last-order-by-project-analysis
     #(and (identical? :namespace-definitions (:bucket %))
           (= (:name %) namespace))
-    analysis
-    db))
+    analysis))
 
-(defn find-namespace-definition-by-filename [analysis filename db]
+(defn find-namespace-definition-by-filename [analysis filename]
   (find-last-order-by-project-analysis
     #(and (identical? :namespace-definitions (:bucket %))
           (= (:filename %) filename))
-    analysis
-    db))
+    analysis))
 
 (defn find-namespace-usage-by-alias [analysis filename alias]
   (->> (get analysis filename)
@@ -615,13 +602,12 @@
                      (= alias (:alias %))))
        last))
 
-(defn find-element-by-full-name [analysis name ns db]
+(defn find-element-by-full-name [analysis name ns]
   (find-last-order-by-project-analysis
     #(and (identical? :var-definitions (:bucket %))
           (= ns (:ns %))
           (= name (:name %)))
-    analysis
-    db))
+    analysis))
 
 (def default-public-vars-defined-by-to-exclude
   '#{clojure.test/deftest

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -194,10 +194,11 @@
       false)))
 
 (defn external-filename? [filename source-paths]
-  (and filename
-       (or (-> filename name jar-file?)
-           (and (seq source-paths)
-                (not-any? #(string/starts-with? filename %) source-paths)))))
+  (boolean
+    (and filename
+         (or (-> filename name jar-file?)
+             (and (seq source-paths)
+                  (not-any? #(string/starts-with? filename %) source-paths))))))
 
 (def ^:private jar-file-with-filename-regex #"^(.*\.jar):(.*)")
 

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -4,8 +4,7 @@
    [clojure-lsp.feature.drag :as f.drag]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]
-   [rewrite-clj.zip :as z]
-   [clojure-lsp.shared :as shared]))
+   [rewrite-clj.zip :as z]))
 
 (h/reset-db-after-test)
 

--- a/lib/test/clojure_lsp/feature/move_form_test.clj
+++ b/lib/test/clojure_lsp/feature/move_form_test.clj
@@ -51,9 +51,9 @@
           _ (h/load-code-and-locs (h/code "(ns eater (:require [apple :as a] [crumb :as c]))"
                                           "(a/bar 2)"
                                           "(c/c 3)") e-uri)
-          _ (h/load-code-and-locs (h/code "(ns fruit (:require [apple :as a] [bread :as br]))"
+          _ (h/load-code-and-locs (h/code "(ns fruit (:require [apple :as a] [bread :as b]))"
                                           "(a/bar 2)"
-                                          "(br/foo 3)") f-uri)
+                                          "(b/foo 3)") f-uri)
           results (:changes-by-uri (move-form/move-form zloc a-uri db/db* "/b.clj"))
           a-results (h/changes-by-uri->code results a-uri @db/db*)
           b-results (h/changes-by-uri->code results b-uri @db/db*)
@@ -73,26 +73,26 @@
                      "(def bar foo)")
              b-results))
       (is (= (h/code "(ns crumb (:require"
-                     "           [bread :as br :refer [bar]]))"
+                     "           [bread :as b :refer [bar]]))"
                      "(bar 1)"
-                     "(br/bar 2)"
-                     "(br/bar 3)")
+                     "(b/bar 2)"
+                     "(b/bar 3)")
              c-results))
       (is (= (h/code "(ns diner (:require"
                      "           [apple :as a]"
-                     "           [bread :as br :refer [bar]]))"
+                     "           [bread :as b :refer [bar]]))"
                      "(a/qux 1)"
                      "(apple/foo 1)"
                      "(bar 2)")
              d-results))
       (is (= (h/code "(ns eater (:require"
-                     "           [bread :as br]"
+                     "           [bread :as b]"
                      "           [crumb :as c]))"
-                     "(br/bar 2)"
+                     "(b/bar 2)"
                      "(c/c 3)")
              e-results))
       (is (= (h/code "(ns fruit (:require"
-                     "           [bread :as br]))"
-                     "(br/bar 2)"
-                     "(br/foo 3)")
+                     "           [bread :as b]))"
+                     "(b/bar 2)"
+                     "(b/foo 3)")
              f-results)))))

--- a/lib/test/clojure_lsp/feature/move_form_test.clj
+++ b/lib/test/clojure_lsp/feature/move_form_test.clj
@@ -73,22 +73,22 @@
                      "(def bar foo)")
              b-results))
       (is (= (h/code "(ns crumb (:require"
-                     "           [bread :as b :refer [bar]]))"
+                     "           [bread :as br :refer [bar]]))"
                      "(bar 1)"
-                     "(b/bar 2)"
-                     "(b/bar 3)")
+                     "(br/bar 2)"
+                     "(br/bar 3)")
              c-results))
       (is (= (h/code "(ns diner (:require"
                      "           [apple :as a]"
-                     "           [bread :as b :refer [bar]]))"
+                     "           [bread :as br :refer [bar]]))"
                      "(a/qux 1)"
                      "(apple/foo 1)"
                      "(bar 2)")
              d-results))
       (is (= (h/code "(ns eater (:require"
-                     "           [bread :as b]"
+                     "           [bread :as br]"
                      "           [crumb :as c]))"
-                     "(b/bar 2)"
+                     "(br/bar 2)"
                      "(c/c 3)")
              e-results))
       (is (= (h/code "(ns fruit (:require"

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -23,8 +23,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:level :info}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:level :info}}}})
     (h/assert-submaps
       [{:filename "/a.clj"
         :level :info
@@ -41,8 +40,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:level :warning}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:level :warning}}}})
     (h/assert-submaps
       [{:filename "/a.clj"
         :level :warning
@@ -59,8 +57,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:level :error}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:level :error}}}})
     (h/assert-submaps
       [{:filename "/a.clj"
         :level :error
@@ -77,8 +74,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:level :off}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:level :off}}}})
     (h/assert-submaps
       [{:filename "/a.clj"
         :level :off
@@ -95,8 +91,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {}}
-      @db/db*)
+       :config {}})
     (h/assert-submaps
       [{:filename "/a.clj"
         :level :info
@@ -113,8 +108,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns}}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns}}}}})
     (h/assert-submaps
       []
       @findings))
@@ -124,8 +118,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'foo}}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'foo}}}}})
     (h/assert-submaps
       []
       @findings))
@@ -135,8 +128,7 @@
       "/a.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns/foo}}}}}
-      @db/db*)
+       :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns/foo}}}}})
     (h/assert-submaps
       []
       @findings))
@@ -146,8 +138,7 @@
       "/b.clj"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {}}
-      @db/db*)
+       :config {}})
     (h/assert-submaps
       []
       @findings))
@@ -157,8 +148,7 @@
       "/c.cljs"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {}}
-      @db/db*)
+       :config {}})
     (h/assert-submaps
       [{:filename "/c.cljs"
         :level :info
@@ -183,8 +173,7 @@
       "/d.cljs"
       (:analysis @db/db*)
       {:reg-finding! #(swap! findings conj %)
-       :config {}}
-      @db/db*)
+       :config {}})
     (h/assert-submaps [] @findings)))
 
 (deftest lint-clj-kondo-findings
@@ -197,8 +186,8 @@
   (testing "when linter level is not :off but has matching :ns-exclude-regex"
     (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///project/src/some_ns.clj"))
     (swap! db/db* merge {:project-root-uri (h/file-uri "file:///project")
-                        :settings {:source-paths ["/project/src"]
-                                   :linters {:clj-kondo {:ns-exclude-regex "some-ns.*"}}}})
+                         :settings {:source-paths ["/project/src"]
+                                    :linters {:clj-kondo {:ns-exclude-regex "some-ns.*"}}}})
     (is (= []
            (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/some_ns.clj") @db/db*))))
   (testing "when linter level is not :off"
@@ -231,7 +220,7 @@
   (testing "when file is external"
     (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///some/place.jar:some/file.clj"))
     (swap! db/db* merge {:project-root-uri (h/file-uri "file:///project")
-                        :settings {:source-paths ["/project/src"]}})
+                         :settings {:source-paths ["/project/src"]}})
     (is (= []
            (f.diagnostic/find-diagnostics (h/file-uri "file:///some/place.jar:some/file.clj") @db/db*)))))
 

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -15,7 +15,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 2 (count (into {}
-                          (q/filter-project-analysis-xf @db/db*)
+                          (q/filter-project-analysis-xf)
                           (:analysis @db/db*))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db* shared/deep-merge {:settings {:dependency-scheme "jar"}})
@@ -23,7 +23,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 2 (count (into {}
-                          (q/filter-project-analysis-xf @db/db*)
+                          (q/filter-project-analysis-xf)
                           (:analysis @db/db*)))))))
 
 (deftest external-analysis
@@ -33,7 +33,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (into {}
-                          (q/filter-external-analysis-xf @db/db*)
+                          (q/filter-external-analysis-xf)
                           (:analysis @db/db*))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db* shared/deep-merge {:settings {:dependency-scheme "jar"}})
@@ -41,7 +41,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (into {}
-                          (q/filter-external-analysis-xf @db/db*)
+                          (q/filter-external-analysis-xf)
                           (:analysis @db/db*)))))))
 
 (deftest find-last-order-by-project-analysis
@@ -49,14 +49,14 @@
     (h/clean-db!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
-    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db*) @db/db*)]
+    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db*))]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (h/clean-db!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
-    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db*) @db/db*)]
+    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) (:analysis @db/db*))]
       (is (= (h/file-path "/b.clj") (:filename element))))))
 
 (deftest find-element-under-cursor
@@ -107,30 +107,30 @@
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") x-r x-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.clj") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") param-r param-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.clj") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") alias-r alias-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.clj") alias-r alias-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-foo-kw-r :name-col a-foo-kw-c}
        {:name "foo-kw" :name-row b-foo-kw-r :name-col b-foo-kw-c}
        {:name "foo-kw" :name-row d-foo-kw-r :name-col d-foo-kw-c}
        {:name "foo-kw" :name-row c-foo-kw-r :name-col c-foo-kw-c}]
-      (q/find-references-from-cursor ana (h/file-path "/c.clj") b-foo-kw-r b-foo-kw-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/c.clj") b-foo-kw-r b-foo-kw-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-baz-kw-r :name-col a-baz-kw-c :ns :clj-kondo/unknown-namespace}]
-      (q/find-references-from-cursor ana (h/file-path "/baz.clj") a-baz-kw-r a-baz-kw-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/baz.clj") a-baz-kw-r a-baz-kw-c true))
     (h/assert-submaps
       [{:name "baz-kw" :name-row b-baz-kw-r :name-col b-baz-kw-c :ns 'baz}]
-      (q/find-references-from-cursor ana (h/file-path "/baz.clj") b-baz-kw-r b-baz-kw-c true @db/db*))))
+      (q/find-references-from-cursor ana (h/file-path "/baz.clj") b-baz-kw-r b-baz-kw-c true))))
 
 (deftest find-references-from-cursor-cljc
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -147,18 +147,18 @@
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") x-r x-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") param-r param-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") unknown-r unknown-c true @db/db*))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") alias-r alias-c true @db/db*))))
+      (q/find-references-from-cursor ana (h/file-path "/a.cljc") alias-r alias-c true))))
 
 (deftest find-references-from-defrecord
   (let [code (str "(defrecord |MyRecord [])\n"
@@ -174,7 +174,7 @@
       [{:name 'MyRecord :bucket :var-usages :name-row raw-r :name-col raw-c}
        {:name '->MyRecord :bucket :var-usages :name-row to-r :name-col to-c}
        {:name 'map->MyRecord :bucket :var-usages :name-row map-to-r :name-col map-to-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") def-r def-c false @db/db*))))
+      (q/find-references-from-cursor ana (h/file-path "/a.clj") def-r def-c false))))
 
 (deftest find-references-excluding-function-different-arity
   (let [a-code (h/code "(ns a)"
@@ -204,7 +204,7 @@
            :from b
            :name-col 4
            :from-var bar}]
-        (q/find-references-from-cursor ana (h/file-path "/a.clj") bar-def-r bar-def-c false @db/db*)))
+        (q/find-references-from-cursor ana (h/file-path "/a.clj") bar-def-r bar-def-c false)))
     (testing "from usage"
       (h/assert-submaps
         '[{:name-row 6
@@ -218,7 +218,7 @@
            :from b
            :name-col 4
            :from-var bar}]
-        (q/find-references-from-cursor ana (h/file-path "/a.clj") bar-usa-r bar-usa-c false @db/db*)))
+        (q/find-references-from-cursor ana (h/file-path "/a.clj") bar-usa-r bar-usa-c false)))
     (testing "from other ns"
       (h/assert-submaps
         '[{:name-row 6
@@ -232,7 +232,7 @@
            :from b
            :name-col 4
            :from-var bar}]
-        (q/find-references-from-cursor ana (h/file-path "/b.clj") bar-usa-b-r bar-usa-b-c false @db/db*)))))
+        (q/find-references-from-cursor ana (h/file-path "/b.clj") bar-usa-b-r bar-usa-b-c false)))))
 
 (deftest find-references-from-protocol-impl
   (h/load-code-and-locs (h/code "(ns a)"
@@ -265,7 +265,7 @@
          :row 9 :col 1 :end-row 9 :end-col 27
          :bucket :var-usages
          :to a}]
-      (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 7 9 false @db/db*))))
+      (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 7 9 false))))
 
 (deftest find-references-for-defmulti
   (let [[[defmulti-r defmulti-c]]
@@ -301,15 +301,15 @@
     (testing "from defmulti method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") defmulti-r defmulti-c false @db/db*)))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") defmulti-r defmulti-c false)))
     (testing "from defmethod method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") defmethod-r defmethod-c false @db/db*)))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") defmethod-r defmethod-c false)))
     (testing "from usage name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") usage-r usage-c false @db/db*)))))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") usage-r usage-c false)))))
 
 (deftest find-references-for-defmulti-without-usages
   (let [[[defmulti-r defmulti-c]]
@@ -333,11 +333,11 @@
     (testing "from defmulti method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") defmulti-r defmulti-c false @db/db*)))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") defmulti-r defmulti-c false)))
     (testing "from defmethod method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") defmethod-r defmethod-c false @db/db*)))))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") defmethod-r defmethod-c false)))))
 
 (deftest find-references-from-declare
   (let [[[declare-r declare-c]
@@ -357,15 +357,15 @@
     (testing "from declare"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") declare-r declare-c false @db/db*)))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") declare-r declare-c false)))
     (testing "from def"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") def-r def-c false @db/db*)))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") def-r def-c false)))
     (testing "from usage name"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") usage-r usage-c false @db/db*)))))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") usage-r usage-c false)))))
 
 (deftest find-references-from-declare-without-usages
   (let [[[declare-r declare-c]
@@ -376,11 +376,11 @@
     (testing "from declare"
       (h/assert-submaps
         '[]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") declare-r declare-c false @db/db*)))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") declare-r declare-c false)))
     (testing "from def"
       (h/assert-submaps
         '[]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") def-r def-c false @db/db*)))))
+        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") def-r def-c false)))))
 
 (deftest find-definition-from-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -397,18 +397,18 @@
         ana (:analysis @db/db*)]
     (h/assert-submap
       {:name 'x :name-row x-r :name-col x-c}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") x-use-r x-use-c @db/db*))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") x-use-r x-use-c))
     (h/assert-submap
       {:name 'filename :name-row param-r :name-col param-c}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") param-use-r param-use-c @db/db*))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") param-use-r param-use-c))
     (is (= nil
-           (q/find-definition-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c @db/db*)))
+           (q/find-definition-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c)))
     (h/assert-submap
       {:name 'foo :filename (h/file-path "/b.clj") :ns 'd.e.f}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-use-r alias-use-c @db/db*))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-use-r alias-use-c))
     (h/assert-submap
       {:name 'd.e.f :bucket :namespace-definitions}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-r alias-c @db/db*))))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-r alias-c))))
 
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
   (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
@@ -418,7 +418,7 @@
         ana (:analysis @db/db*)]
     (h/assert-submap
       {:name 'bar :filename (h/file-path "/a.clj")}
-      (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c @db/db*))))
+      (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
 
 (deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
   (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
@@ -429,21 +429,21 @@
           ana (:analysis @db/db*)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c @db/db*))))
+        (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
   (testing "when on a cljs file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.cljs"))
           ana (:analysis @db/db*)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljs") bar-r bar-c @db/db*))))
+        (q/find-definition-from-cursor ana (h/file-path "/b.cljs") bar-r bar-c))))
   (testing "when on a cljc file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.cljc"))
           ana (:analysis @db/db*)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r bar-c @db/db*))))
+        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r bar-c))))
   (testing "when on a cljc file with multiple langs available"
     (let [[[bar-r-clj bar-c-clj]
            [bar-r-cljs bar-c-cljs]] (h/load-code-and-locs (h/code "(ns baz #?(:clj (:require [foo :as fc]) :cljs (:require [foo :as fs])))"
@@ -452,10 +452,10 @@
           ana (:analysis @db/db*)]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r-clj bar-c-clj @db/db*))
+        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r-clj bar-c-clj))
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r-cljs bar-c-cljs @db/db*)))))
+        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r-cljs bar-c-cljs)))))
 
 (deftest find-definition-from-cursor-when-declared
   (let [[[bar-r bar-c]] (h/load-code-and-locs
@@ -466,7 +466,7 @@
         ana (:analysis @db/db*)]
     (h/assert-submap
       {:name 'bar :filename (h/file-path "/a.clj") :defined-by 'clojure.core/defn :row 4}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c @db/db*))))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c))))
 
 (deftest find-definition-from-namespace-alias
   (h/load-code-and-locs (h/code "(ns foo.bar) (def a 1)") (h/file-uri "file:///a.clj"))
@@ -474,7 +474,7 @@
         ana (:analysis @db/db*)]
     (h/assert-submap
       {:name-end-col 12 :name-end-row 1 :name-row 1 :name 'foo.bar :filename "/a.clj" :col 1 :name-col 5 :bucket :namespace-definitions :row 1}
-      (q/find-definition-from-cursor ana (h/file-path "/b.clj") foob-r foob-c @db/db*))))
+      (q/find-definition-from-cursor ana (h/file-path "/b.clj") foob-r foob-c))))
 
 (deftest find-definition-from-cursor-when-on-potemkin
   (h/load-code-and-locs (h/code "(ns foo.impl) (def bar)") (h/file-uri "file:///b.clj"))
@@ -486,7 +486,7 @@
         ana (:analysis @db/db*)]
     (h/assert-submap
       {:name 'bar :filename (h/file-path "/b.clj") :defined-by 'clojure.core/def :row 1 :col 15}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c @db/db*))))
+      (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c))))
 
 ;; Uncoment after clj-kondo solves https://github.com/clj-kondo/clj-kondo/issues/1632
 #_(deftest find-definition-form-java-class-usage
@@ -518,14 +518,14 @@
          :bucket
          :namespace-alias
          :to 'foo.bar}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") something-r something-c @db/db*)))
+        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") something-r something-c)))
     (testing "from usage with refer all"
       (h/assert-submap
         {:from 'sample
          :bucket
          :namespace-usages
          :name 'foo.baz}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") other-r other-c @db/db*)))))
+        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") other-r other-c)))))
 
 (deftest find-implementations-from-cursor-protocols
   (h/load-code-and-locs (h/code "(ns a)"
@@ -566,7 +566,7 @@
          :from-var make-foo
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 2 16 @db/db*)))
+      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 2 16)))
   (testing "from protocol method definitions"
     (h/assert-submaps
       [{:impl-ns 'b
@@ -594,7 +594,7 @@
         :protocol-name 'Foo
         :filename "/b.clj"
         :bucket :protocol-impls}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 3 4 @db/db*)))
+      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 3 4)))
   (testing "from implementation usage"
     (h/assert-submaps
       [{:impl-ns 'b
@@ -622,7 +622,7 @@
         :protocol-name 'Foo
         :filename "/b.clj"
         :bucket :protocol-impls}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 9 2 @db/db*))))
+      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 9 2))))
 
 (deftest find-implementations-from-cursor-defmulti
   (h/load-code-and-locs (h/code "(ns a)"
@@ -654,7 +654,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 2 12 @db/db*)))
+      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 2 12)))
   (testing "from defmethod declaration"
     (h/assert-submaps
       '[{:name foo
@@ -673,7 +673,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 2 13 @db/db*)))
+      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 2 13)))
   (testing "from defmethod usage"
     (h/assert-submaps
       '[{:name foo
@@ -692,7 +692,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 8 2 @db/db*))))
+      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 8 2))))
 
 (deftest find-unused-aliases
   (testing "clj"

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -15,7 +15,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 2 (count (into {}
-                          (q/filter-project-analysis-xf)
+                          q/filter-project-analysis-xf
                           (:analysis @db/db*))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db* shared/deep-merge {:settings {:dependency-scheme "jar"}})
@@ -23,7 +23,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 2 (count (into {}
-                          (q/filter-project-analysis-xf)
+                          q/filter-project-analysis-xf
                           (:analysis @db/db*)))))))
 
 (deftest external-analysis
@@ -33,7 +33,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (into {}
-                          (q/filter-external-analysis-xf)
+                          q/filter-external-analysis-xf
                           (:analysis @db/db*))))))
   (testing "when dependency-scheme is jar"
     (swap! db/db* shared/deep-merge {:settings {:dependency-scheme "jar"}})
@@ -41,7 +41,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (is (= 1 (count (into {}
-                          (q/filter-external-analysis-xf)
+                          q/filter-external-analysis-xf
                           (:analysis @db/db*)))))))
 
 (deftest find-last-order-by-project-analysis


### PR DESCRIPTION
Talking with @mainej we noticed we could improve `q/filter-project-analysis-xf` and `q/filter-external-analysis-xt` if we could easily/faster know an element is external or not instead of checking filename, this PR makes that possible as a first step, adding the `:external?` keyword to all possible elements during the kondo analysis normalization.

This basically solves all performance issues with those 2 functions that are used on most queries and all over clojure-lsp, completion for example improved performance by **50%** on most cases!

I didn't test other features yet, and intend to do that tomorrow bringing more data about performance improvements