### PR TITLE
Add tools for profiling clojure-lsp

### DIFF
--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,3 +1,4 @@
 {:clean {:ns-inner-blocks-indentation :next-line}
  :linters {:clj-kondo {:ns-exclude-regex "sample-test.*"}}
+ :source-aliases #{:dev :test :debug}
  :use-metadata-for-privacy? true}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: debug-cli
 #
 # Older versions of the clojure launcher script may not work with this Makefile
 #
-# If you see errors (e.g. file not found errors) please download and install 
+# If you see errors (e.g. file not found errors) please download and install
 # the latest version of the clojure launcher script for your platform from
 #
 # https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools
@@ -44,9 +44,6 @@ cli-jar-for-native:
 
 debug-cli:
 	cd cli && clojure -T:build debug-cli
-	mv cli/clojure-lsp .
-debug-perf-cli:
-	cd cli && clojure -T:build debug-perf-cli
 	mv cli/clojure-lsp .
 prod-cli:
 	cd cli && clojure -T:build prod-cli

--- a/cli/build.clj
+++ b/cli/build.clj
@@ -75,10 +75,6 @@
 
 (defn debug-cli [opts]
   (uber-aot (merge opts {:extra-aliases [:debug]}))
-  (bin {}))
-
-(defn debug-perf-cli [opts]
-  (uber-aot (merge opts {:extra-aliases [:debug :performance]}))
   (bin {:jvm-opts ["-Djdk.attach.allowAttachSelf=true"]}))
 
 (defn prod-cli [opts]

--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -33,12 +33,13 @@
                    :ns-default build}
            :run {:main-opts ["-m" "clojure-lsp.main"]
                  :jvm-opts ["-Xmx2g" "-server"]}
-           :debug {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}
-                                cider/cider-nrepl {:mvn/version "0.28.3"}}}
-           :performance {:extra-deps {criterium/criterium {:mvn/version "0.4.6"}
-                                      com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.1.3"}
-                                      com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}}
-                         :jvm-opts   ["-Djdk.attach.allowAttachSelf"]}
+           :debug {:extra-paths ["dev"]
+                   :extra-deps {cider/cider-nrepl {:mvn/version "0.28.3"}
+                                com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}
+                                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.1.3"}
+                                criterium/criterium {:mvn/version "0.4.6"}
+                                nrepl/nrepl {:mvn/version "0.9.0"}}
+                   :jvm-opts   ["-Djdk.attach.allowAttachSelf"]}
            :native {:jvm-opts ["-Xmx2g"
                                "-server"
                                "-Dborkdude.dynaload.aot=true"

--- a/cli/dev/clojure_lsp/debug.clj
+++ b/cli/dev/clojure_lsp/debug.clj
@@ -10,14 +10,19 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.completion :as f.completion]
    [clojure.java.shell :as sh]
-   [criterium.core :as bench]))
+   [criterium.core :as bench]
+   [clojure-lsp.shared :as shared]))
 
 (defn uri-in-project [filepath]
-  (str (:project-root-uri @db/db*) "/" filepath))
+  (let [db @db/db*]
+    (-> filepath
+        (shared/absolute-path db)
+        (shared/filename->uri db))))
 
 (defn open-file
   "Opens a `file` by shelling out to `open`."
   [file]
+  ;; TODO: xdg-open for Linux; start for Windows
   (sh/sh "open" (str file)))
 
 (defmacro profile-times

--- a/cli/dev/clojure_lsp/debug.clj
+++ b/cli/dev/clojure_lsp/debug.clj
@@ -1,0 +1,107 @@
+(ns clojure-lsp.debug
+  "This namespace is for debugging clojure-lsp during development.
+
+  It provides a few examples of how to conduct performance analysis.
+
+  It's on the classpath when building with `make` (or `make debug-cli`) so don't
+  leave any clutter that would break the build."
+  (:require [clojure-lsp.feature.completion :as f.completion]
+            [clojure-lsp.db :as db]
+            [clojure.java.io :as io]
+            [clj-async-profiler.core :as profiler]
+            [criterium.core :as bench]))
+
+(defn uri-in-project [filepath]
+  (str (:project-root-uri @db/db*) "/" filepath))
+
+(defn open-file
+  "Opens a `file` by shelling out to `open`."
+  [file]
+  (clojure.java.shell/sh "open" (str file)))
+
+(defmacro profile-times
+  "Profiles the `body` by running it in a loop `n` times, returning the
+  flamegraph file."
+  [n body]
+  `(let [n# ~n]
+     (println "profiling" n# "iterations")
+     (let [time-start# (System/nanoTime)
+           result# (profiler/profile {:min-width 5
+                                      :return-file true}
+                                     (dotimes [_n# n#] ~body))
+           elapsed-s# (/ (- (System/nanoTime) time-start#) 1e9)]
+       (println "Profiled for" elapsed-s# "seconds. (Should be 5-10 seconds to have enough samples.)")
+       result#)))
+
+(defmacro profile-by-runtime
+  "A tool to get a flamegraph of `body`. Uses the `:est-runtime-in-ms` in the
+  `opts` to calculates how many times it needs to execute `body` to run for
+  about 10 seconds. This should get a reasonable number of samples. See
+  http://clojure-goes-fast.com/blog/clj-async-profiler-tips/#make-sure-you-have-enough-samples
+
+  If opts includes `:open? true`, will [open][open-fg] the generated flamegraph."
+  [opts body]
+  `(let [opts# ~opts
+         n# (int (/ 10e3 (:est-runtime-in-ms opts#)))
+         flamegraph-file# (profile-times n# ~body)]
+     (when (:open? opts#) (open-file flamegraph-file#))
+     flamegraph-file#))
+
+(defn estimate-runtime-ms-naive* [f]
+  (let [time-start (System/nanoTime)]
+    (f)
+    (let [est-ms (/ (- (System/nanoTime) time-start) 1e6)]
+      (println "mean runtime" est-ms "ms")
+      est-ms)))
+
+(defmacro estimate-runtime-ms-naive [body]
+  `(estimate-runtime-ms-naive* (fn [] ~body)))
+
+(defn estimate-runtime-ms-quick-bench* [f]
+  (let [results (bench/quick-benchmark* f {})]
+    (bench/report-point-estimate "mean runtime" (:mean results))
+    (bench/report-point-estimate-sqrt "std-deviation" (:variance results))
+    (* 1e3 (first (:mean results)))))
+
+(defmacro estimate-runtime-ms-quick-bench [body]
+  `(estimate-runtime-ms-quick-bench* (fn [] ~body)))
+
+(defmacro auto-profile
+  "Generate a flamegraph of `body`. Estimates the runtime of the body, then
+  delegates to [[profile-by-runtime]] to get a reasonable number of samples.
+
+  To estimate the runtime of the body by running it once, choose
+  `:estimate-strategy :naive` (default).
+
+  For a more rigorous estimate delegate to criterium by choosing
+  `:estimate-strategy :quick-bench`.
+
+  To [[open-file]] the generated flamegraph, add `:open? true`.
+
+  If you already know the mean runtime of the `body`, use [[profile-by-runtime]]
+  or [[profile-times]] to avoid extraneous runtime estimates.
+
+  One way you might know the runtime of the `body` is by inspecting the *stdout*
+  of this command. It will report its estimate and how many iterations it
+  intends to do."
+  [opts body]
+  `(let [opts# ~opts
+         estimate-strategy# (:estimate-strategy opts# :naive)]
+     (println "estimating runtime via" estimate-strategy# "strategy")
+     (let [est-ms# (case estimate-strategy#
+                     :naive       (estimate-runtime-ms-naive ~body)
+                     :quick-bench (estimate-runtime-ms-quick-bench ~body))
+           opts# (assoc opts# :est-runtime-in-ms est-ms#)]
+       (profile-by-runtime opts# ~body))))
+
+(comment
+
+  (do
+    (println "\nProfiling completion in queries.clj")
+    (auto-profile
+      {:open? true
+       ;; :estimate-strategy :quick-bench
+       }
+      (f.completion/completion (uri-in-project "lib/src/clojure_lsp/queries.clj") 24 8 @db/db*)))
+
+  #_())

--- a/cli/dev/clojure_lsp/debug.clj
+++ b/cli/dev/clojure_lsp/debug.clj
@@ -34,9 +34,9 @@
        result#)))
 
 (defmacro profile-by-runtime
-  "A tool to get a flamegraph of `body`. Uses the `:est-runtime-in-ms` in the
-  `opts` to calculates how many times it needs to execute `body` to run for
-  about 10 seconds. This should get a reasonable number of samples. See
+  "Generate a flamegraph of `body`. Uses the `:est-runtime-in-ms` in the `opts`
+  to calculate how many times it needs to execute `body` for the profiling to
+  run for about 10 seconds. This should get a reasonable number of samples. See
   http://clojure-goes-fast.com/blog/clj-async-profiler-tips/#make-sure-you-have-enough-samples
 
   If opts includes `:open? true`, will [open][open-fg] the generated flamegraph."
@@ -73,7 +73,7 @@
   To estimate the runtime of the body by running it once, choose
   `:estimate-strategy :naive` (default).
 
-  For a more rigorous estimate delegate to criterium by choosing
+  For a more rigorous estimate, delegate to criterium by choosing
   `:estimate-strategy :quick-bench`.
 
   To [[open-file]] the generated flamegraph, add `:open? true`.

--- a/cli/dev/clojure_lsp/debug.clj
+++ b/cli/dev/clojure_lsp/debug.clj
@@ -10,20 +10,18 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.completion :as f.completion]
    [clojure.java.shell :as sh]
+   [clojure.java.io :as io]
    [criterium.core :as bench]
    [clojure-lsp.shared :as shared]))
 
 (defn uri-in-project [filepath]
   (let [db @db/db*]
-    (-> filepath
-        (shared/absolute-path db)
-        (shared/filename->uri db))))
+    (shared/filename->uri (shared/absolute-path filepath db) db)))
 
 (defn open-file
-  "Opens a `file` by shelling out to `open`."
+  "Opens a `file` with its default application."
   [file]
-  ;; TODO: xdg-open for Linux; start for Windows
-  (sh/sh "open" (str file)))
+  (.open (java.awt.Desktop/getDesktop) file))
 
 (defmacro profile-times
   "Profiles the `body` by running it in a loop `n` times, returning the
@@ -109,5 +107,6 @@
        ;; :estimate-strategy :quick-bench
        }
       (f.completion/completion (uri-in-project "lib/src/clojure_lsp/queries.clj") 24 8 @db/db*)))
+
 
   #_())

--- a/cli/dev/clojure_lsp/debug.clj
+++ b/cli/dev/clojure_lsp/debug.clj
@@ -5,11 +5,12 @@
 
   It's on the classpath when building with `make` (or `make debug-cli`) so don't
   leave any clutter that would break the build."
-  (:require [clojure-lsp.feature.completion :as f.completion]
-            [clojure-lsp.db :as db]
-            [clojure.java.io :as io]
-            [clj-async-profiler.core :as profiler]
-            [criterium.core :as bench]))
+  (:require
+   [clj-async-profiler.core :as profiler]
+   [clojure-lsp.db :as db]
+   [clojure-lsp.feature.completion :as f.completion]
+   [clojure.java.shell :as sh]
+   [criterium.core :as bench]))
 
 (defn uri-in-project [filepath]
   (str (:project-root-uri @db/db*) "/" filepath))
@@ -17,7 +18,7 @@
 (defn open-file
   "Opens a `file` by shelling out to `open`."
   [file]
-  (clojure.java.shell/sh "open" (str file)))
+  (sh/sh "open" (str file)))
 
 (defmacro profile-times
   "Profiles the `body` by running it in a loop `n` times, returning the

--- a/docs/development.md
+++ b/docs/development.md
@@ -86,30 +86,10 @@ nnoremap <silent> crsp :execute 'Connect' CocRequest('clojure-lsp', 'clojure/ser
 
 TBD. PR welcome.
 
-## Profiling
+## Debugging & Profiling
 
-To make a build with profiling and benchmarking tools available, in addition to an nREPL, add the following requires to the namespace you want to profile.
+The nREPL includes tools for debugging and profiling clojure-lsp. See `cli/dev/clojure_lsp/debug.clj`.
 
-```clojure
-(:require
-  ,,,
-  [clj-async-profiler.core :as profiler]
-  [criterium.core :as bench])
-```
+If you're interested in using the profiling tools in that file, you'll need to be familiar with [criterium](https://github.com/hugoduncan/criterium) and [clj-async-profiler](http://clojure-goes-fast.com/blog/profiling-tool-async-profiler/).
 
-Also add an (unused) function
-
-```clojure
-(defn stub []
-  (bench/quick-bench (* 2 3))
-  (profiler/profile
-    {:min-width 5}
-    (dotimes [_ 500]
-      (* 2 3))))
-```
-
-Then run `make debug-perf-cli`. When the build has completed, follow the above steps to connect to an nREPL.
-
-Execute profiling code within a rich comment block, using the code from the stub function as a guideline. You'll need to be familiar with [criterium](https://github.com/hugoduncan/criterium) and [clj-async-profiler](http://clojure-goes-fast.com/blog/profiling-tool-async-profiler/) to interpret the results.
-
-Note that it is often important to do profiling with this kind of nREPL, because in a regular REPL the analysis database starts off nearly empty. With a fuller database, profiling is more accurate. That said, if you do want to profile in a regular REPL, you can—start it with the `:performance` alias.
+Note that the performance of clojure-lsp is highly dependent on the size of its db. If you load a repl with `-A:build`, you'll have access to the debugging tools, but the db will be nearly empty. Follow the [steps][#the-clojure-way] above to connect to an nREPL which has a populated db.


### PR DESCRIPTION
This moves the criterium and clj-async-profiler deps into the main `debug` build for clojure-lsp development. It also adds a file with some profiling utilities I wish were built into those tools: `cli/dev/clojure_lsp/debug.clj`. See, in particular `auto-profile`.

I went with the generic name `clojure-lsp.debug` as @snoe suggested because I figure it'll be a good scratchpad for other kinds of debugging.

One thing I wasn't able to figure out is how to tell clojure-lsp to analyze that file. It feels strange to work on clojure-lsp without being able to use clojure-lsp. Any suggestions?

Context from Slack:

> [snoe](https://app.slack.com/team/U0BUV7XSA)  [1 day ago](https://clojurians.slack.com/archives/CPABC1H61/p1649184644366569?thread_ts=1649055048.585809&cid=CPABC1H61)
[@jacob.maine](https://clojurians.slack.com/team/U07M2C8TT) thanks for the debug-perf-cli build, I wonder if there's a reason to keep it separate from debug. I also think it might be nice to have a ./dev/clojure-lsp/debug.clj file with snippets and instructions to run a profile or a criterium.

> [ericdallo](https://app.slack.com/team/UKFSJSM38):clojure-lsp:  [1 day ago](https://clojurians.slack.com/archives/CPABC1H61/p1649184717049139?thread_ts=1649055048.585809&cid=CPABC1H61)
Yeah, both ideas sounds good to me, usually there are user.clj namespaces on lein projects, maybe we could have a performance one or something

> [jacob.maine](https://app.slack.com/team/U07M2C8TT)  [1 day ago](https://clojurians.slack.com/archives/CPABC1H61/p1649184785970549?thread_ts=1649055048.585809&cid=CPABC1H61)
Yeah, agreed. [@ericdallo](https://clojurians.slack.com/team/UKFSJSM38) I think you suggested merging the perf deps into the main debug build when I first proposed it. I can’t remember why I was hesitant then. In retrospect, it doesn’t seem like it would hurt
