### PR TITLE
Exclude processing time from wait time in logs

### DIFF
--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -67,7 +67,9 @@
                   `(logger/info
                      (if (= backoff-start ~backoff-sym)
                        (format ~process-msg (shared/start-time->end-time-ms ~waiting-start-sym))
-                       (format ~wait-and-process-msg (shared/start-time->end-time-ms ~start-sym) (shared/start-time->end-time-ms ~waiting-start-sym))))
+                       (format ~wait-and-process-msg
+                               (shared/start-time->end-time-ms ~start-sym)
+                               (shared/format-time-delta-ms ~waiting-start-sym ~start-sym))))
                   (meta &form))
                result#)))))))
 

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -383,8 +383,11 @@
 (defn clojure-lsp-version []
   (string/trim (slurp (io/resource "CLOJURE_LSP_VERSION"))))
 
+(defn format-time-delta-ms [start-time end-time]
+  (format "%.0fms" (float (/ (- end-time start-time) 1000000))))
+
 (defn start-time->end-time-ms [start-time]
-  (format "%.0fms" (float (/ (- (System/nanoTime) start-time) 1000000))))
+  (format-time-delta-ms start-time (System/nanoTime)))
 
 (defmacro logging-time
   "Executes `body` logging `message` formatted with the time spent


### PR DESCRIPTION
Tasks that wait for changes to be processed log how much time they spent processing and how much time they spent waiting. The processing time was included in the wait time. This patch fixes that.

I thought this was part of the original feature, but either I'm mis-remembering or it was lost in a merge.