### PR TITLE
Optimize finding ns def by filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - demote-fn: Demote a fn to a literal #()
   - *breaking* remove cycle-fn-literal, since the same refactorings can be performed with the more clearly named promote-fn and demote-fn
   - drag: Fix to drag element-wise in destructured keys, not pair-wise. #927
+  - test-tree: reduce CPU usage, especially during startup
 
 ## 2022.03.31-20.00.20
 

--- a/lib/src/clojure_lsp/feature/test_tree.clj
+++ b/lib/src/clojure_lsp/feature/test_tree.clj
@@ -16,8 +16,9 @@
                                                  (not= testing root-testing)))
                                           testings)]
               (shared/assoc-some
-                {:name (or (-> root-testing :context :clojure.test :testing-str)
-                           "")
+                {:name (str
+                         (or (-> root-testing :context :clojure.test :testing-str) ;; not always a string
+                             ""))
                  :range (shared/->scope-range root-testing)
                  :name-range (shared/->range root-testing)
                  :kind :testing}

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -590,11 +590,8 @@
 
 (defn find-namespace-definitions [analysis filename]
   (into []
-        (comp
-          (mapcat val)
-          (filter #(safe-equal? (:filename %) filename))
-          (filter #(identical? :namespace-definitions (:bucket %))))
-        analysis))
+        (filter #(identical? :namespace-definitions (:bucket %)))
+        (get analysis filename)))
 
 (defn find-namespace-definition-by-namespace [analysis namespace]
   (find-last-order-by-project-analysis
@@ -603,10 +600,7 @@
     analysis))
 
 (defn find-namespace-definition-by-filename [analysis filename]
-  (find-last-order-by-project-analysis
-    #(and (identical? :namespace-definitions (:bucket %))
-          (= (:filename %) filename))
-    analysis))
+  (peek (find-namespace-definitions analysis filename)))
 
 (defn find-namespace-usage-by-alias [analysis filename alias]
   (->> (get analysis filename)

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -421,8 +421,9 @@
        result#)))
 
 (defmacro logging-task [task-id & body]
-  (let [msg (str task-id " %s")]
-    (with-meta `(logging-time ~msg ~@body) (meta &form))))
+  (with-meta `(let [msg# (str ~task-id " %s")]
+                (logging-time msg# ~@body))
+             (meta &form)))
 
 (defn ->range [{:keys [name-row name-end-row name-col name-end-col row end-row col end-col] :as element}]
   (when element


### PR DESCRIPTION
Reduces CPU usage of refresh-test-tree and probably code-lens by querying for a file in the analysis before searching for its ns definitions, rather than finding all ns definitions and then filtering them by filename. More noticeable on startup, where we refresh the test tree of each project file individually.

refresh-test-tree can still take several seconds at startup, but now the majority of that time appears to be in `(.publishTestTree client tree)`, which is something to research later (it doesn't seem like it should be slow).

In clj-kondo this patch cuts the initial refresh-test-tree time down from about 4-5 seconds to 2 or less.

Also, fix exception when testing label isn't a string.

The first argument to clojure.test/testing is a string, but it can be constructed via `(str "test thing " thing)`, or similar. The test-tree code parses these nodes as sexps, but assumes that they're strings, causing an exception. This fixes the exception.


- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

