### PR TITLE
Gather ns filenames in fewer number of passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   - drag: Fix to drag element-wise in destructured keys, not pair-wise. #927
   - test-tree: reduce CPU usage, especially during startup
 
+- CLI
+  - Reduce CPU and wall-clock time in cli commands clean-ns and diagnostics
+
 ## 2022.03.31-20.00.20
 
 - Fix URI resolver on java JDK logic.


### PR DESCRIPTION
This reduces time, both CPU and wall-clock time, for a few CLI commands. It gathers filenames from namespace names in a constant number of passes over the clj-kondo analysis, instead of a number proportional to the number of namespaces.

The fix is applied to clean-ns, format and diagnostics. It reduces time in clean-ns and diagnostics, but interestingly, doesn't improve format time, though I'm not sure why.

```
before
make lint-clean         99.48s user 2.78s system 283% cpu 36.057 total
make lint-diagnostics  156.10s user 3.73s system 284% cpu 56.189 total
make lint-format        96.43s user 2.50s system 312% cpu 31.646 total

after
make lint-clean         81.54s user 2.41s system 294% cpu 28.529 total
make lint-diagnostics   70.63s user 2.09s system 300% cpu 24.164 total
make lint-format        96.60s user 2.60s system 307% cpu 32.220 total
```

- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
