### PR TITLE
Avoid processing duplicate alias/ns completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - General
   - Bump clj-kondo to `2022.04.25`.
+  - Improve speed of alias/ns completions.
+  - Change alias/ns completions to return a label that matches the input.
 
 - Editor
   - Support `workspace/willRenameFiles`, renaming namespaces and all its references when a file is renamed.

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -166,7 +166,7 @@
         detail (when (not definition?)
                  (cond
                    (identical? :namespace-alias bucket)
-                   (some-> element :to name)
+                   (some->> element :to name (str "alias to: "))
 
                    :else
                    (string/join

--- a/lib/test/clojure_lsp/features/completion_test.clj
+++ b/lib/test/clojure_lsp/features/completion_test.clj
@@ -45,9 +45,9 @@
   (testing "complete-alp"
     (h/assert-submaps
       [{:label "alpha" :kind :variable}
-       {:label "alpaca" :kind :property :detail "alpaca.ns"}
-       {:label "alpaca" :kind :property :detail "user"}
-       {:label "ba" :detail "alpaca.ns"}]
+       {:label "alpaca" :kind :property :detail "alias to: alpaca.ns"}
+       {:label "alpaca" :kind :property :detail "alias to: user"}
+       {:label "alpaca.ns" :detail ":as ba"}]
       (f.completion/completion (h/file-uri "file:///b.clj") 3 3 @db/db*)))
   (testing "complete-ba"
     (h/assert-submaps


### PR DESCRIPTION
In metabase/metabase, I was getting very slow completion times.
When profiling, I had a mean time of around 2500ms when completing `meta`

With this change I'm getting a mean time around 350ms. The biggest
culprit was doing `add-known-aliases` multiple times for the same
`alias/to` tuples.

This also revealed a bug where the completion-item was returning labels
that didn't match the input, this caused coc to throw them away.

So I kept the information I needed and distinct the alias/to tuple. Then
depending on which matched, show a different label/detail than
completion-item (which was pretty aenemic for these cases anyways). This
did throw away the `:data` portion but the source namespace for an alias
is actually unwanted here as it causes duplication in completions.

before:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/105012/165646127-a351d3b4-327b-4044-9186-da736921c429.png">

after:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/105012/165646214-d8513888-f41d-41bf-a58c-31de05d7af94.png">