### PR TITLE
Make the debug ns require-able

### DIFF
--- a/cli/build.clj
+++ b/cli/build.clj
@@ -48,11 +48,12 @@
   (clean opts)
   (javac opts)
   (println "Building uberjar...")
-  (let [basis (b/create-basis (update basis :aliases concat (:extra-aliases opts)))]
-    (b/copy-dir {:src-dirs ["src" "resources"]
+  (let [basis (b/create-basis (update basis :aliases concat (:extra-aliases opts)))
+        src-dirs (into ["src" "resources"] (:extra-dirs opts))]
+    (b/copy-dir {:src-dirs src-dirs
                  :target-dir class-dir})
     (b/compile-clj {:basis basis
-                    :src-dirs ["src" "resources"]
+                    :src-dirs src-dirs
                     :java-opts ["-Xmx2g" "-server"]
                     :class-dir class-dir})
     (b/uber {:class-dir class-dir
@@ -74,7 +75,8 @@
   (uber-aot (merge opts {:extra-aliases [:native]})))
 
 (defn debug-cli [opts]
-  (uber-aot (merge opts {:extra-aliases [:debug]}))
+  (uber-aot (merge opts {:extra-aliases [:debug]
+                         :extra-dirs ["dev"]}))
   (bin {:jvm-opts ["-Djdk.attach.allowAttachSelf=true"]}))
 
 (defn prod-cli [opts]


### PR DESCRIPTION
If you connect to the debug build, you couldn't `require` the `cloure-lsp.debug` namespace (though you could evaluate the buffer). This fixes that, making it available from other namespaces, or when loaded from within a project besides clojure-lsp.

See https://clojurians.slack.com/archives/CPABC1H61/p1651098504625839 and surrounding discussion.

@ericdallo I'm not sure it's correct to include the extra path in both `b/copy-dir` and `b/compile-clj`, so please advise.
