### PR TITLE
Skip var bodies when analyzing deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - General
-  - Bump clj-kondo to `2022.04.25`.
+  - Bump clj-kondo to `2022.04.26-20220429.192438-2`.
+  - Decrease uncached startup time by 60-70%, by instructing clj-kondo to skip var definition bodies when analyzing deps. [#1674](https://github.com/clj-kondo/clj-kondo/pull/1674)
   - Improve speed of alias/ns completions.
   - Change alias/ns completions to return a label that matches the input.
 

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -8,7 +8,7 @@
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
         medley/medley {:mvn/version "1.4.0"}
         anonimitoraf/clj-flx {:mvn/version "1.2.0"}
-        clj-kondo/clj-kondo {:mvn/version "2022.04.25"
+        clj-kondo/clj-kondo {:mvn/version "2022.04.26-20220429.192438-2"
                              :exclude [com.cognitect/transit-clj
                                        babashka/fs]}
         com.cognitect/transit-clj {:mvn/version "1.0.329"}

--- a/lib/src/clojure_lsp/crawler.clj
+++ b/lib/src/clojure_lsp/crawler.clj
@@ -51,7 +51,7 @@
             normalization-config {:external? true
                                   :filter-analysis (fn [analysis]
                                                      (-> analysis
-                                                         (dissoc :namespace-usages :var-usages)
+                                                         (dissoc :namespace-usages)
                                                          (update :var-definitions #(remove :private %))))}
             kondo-result (shared/logging-time
                            "External classpath paths analyzed, took %s"

--- a/lib/src/clojure_lsp/feature/stubs.clj
+++ b/lib/src/clojure_lsp/feature/stubs.clj
@@ -46,7 +46,7 @@
 (defn ^:private analyze-stubs!
   [dirs db*]
   (let [normalization-config {:external? true
-                              :filter-analysis #(dissoc % :namespace-usages :var-usages)}
+                              :filter-analysis #(dissoc % :namespace-usages)}
         result (shared/logging-time
                  "Stubs analyzed, took %s."
                  (lsp.kondo/run-kondo-on-paths! dirs db* normalization-config))]

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -189,6 +189,16 @@
                   (f.diagnostic/sync-publish-diagnostics! uri @db*))))))
         (f.diagnostic/custom-lint-file! filename updated-analysis kondo-ctx)))))
 
+(def ^:private config-for-internal-analysis
+  {:arglists true
+   :locals true
+   :keywords true
+   :protocol-impls true
+   :java-class-definitions true
+   :java-class-usages true
+   :context [:clojure.test
+             :re-frame.core]})
+
 (defn ^:private config-for-paths [paths db]
   (-> {:cache true
        :parallel true
@@ -200,13 +210,7 @@
 (defn ^:private config-for-internal-paths [paths db custom-lint-fn]
   (-> (config-for-paths paths db)
       (assoc :custom-lint-fn custom-lint-fn)
-      (assoc-in [:config :analysis]
-                {:arglists true
-                 :locals false
-                 :keywords true
-                 :protocol-impls true
-                 :java-class-usages true
-                 :java-class-definitions true})))
+      (assoc-in [:config :analysis] config-for-internal-analysis)))
 
 (defn ^:private config-for-external-paths [paths db]
   (-> (config-for-paths paths db)
@@ -244,14 +248,7 @@
          :config-dir (project-config-dir (:project-root-uri db))
          :custom-lint-fn custom-lint-fn
          :config {:output {:canonical-paths true}
-                  :analysis {:arglists true
-                             :locals true
-                             :keywords true
-                             :protocol-impls true
-                             :java-class-definitions true
-                             :java-class-usages true
-                             :context [:clojure.test
-                                       :re-frame.core]}}}
+                  :analysis config-for-internal-analysis}}
         (with-additional-config (settings/all db)))))
 
 (defn ^:private run-kondo! [config err-hint]

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -16,7 +16,7 @@
 (defn clj-kondo-version []
   (string/trim (slurp (io/resource "CLJ_KONDO_VERSION"))))
 
-(def clj-kondo-analysis-batch-size 50)
+(def clj-kondo-analysis-batch-size 150)
 
 (defn ^:private project-config-dir [project-root-uri]
   (when project-root-uri
@@ -194,13 +194,30 @@
        :parallel true
        :copy-configs (settings/get db [:copy-kondo-configs?] true)
        :lint [(string/join (System/getProperty "path.separator") paths)]
-       :config {:output {:analysis {:arglists true
-                                    :locals false
-                                    :keywords true
-                                    :protocol-impls true
-                                    :java-class-definitions true}
-                         :canonical-paths true}}}
+       :config {:output {:canonical-paths true}}}
       (with-additional-config (settings/all db))))
+
+(defn ^:private config-for-internal-paths [paths db custom-lint-fn]
+  (-> (config-for-paths paths db)
+      (assoc :custom-lint-fn custom-lint-fn)
+      (assoc-in [:config :analysis]
+                {:arglists true
+                 :locals false
+                 :keywords true
+                 :protocol-impls true
+                 :java-class-usages true
+                 :java-class-definitions true})))
+
+(defn ^:private config-for-external-paths [paths db]
+  (-> (config-for-paths paths db)
+      (assoc :skip-lint true)
+      (assoc-in [:config :analysis]
+                {:arglists true
+                 :keywords true
+                 :protocol-impls true
+                 :java-class-definitions true
+                 :var-usages false
+                 :var-definitions {:shallow true}})))
 
 (defn ^:private config-for-copy-configs [paths db]
   {:cache true
@@ -212,8 +229,8 @@
 
 (defn ^:private config-for-jdk-source [paths]
   {:lint paths
-   :config {:output {:analysis {:java-class-definitions true}
-                     :canonical-paths true}}})
+   :config {:output {:canonical-paths true}
+            :analysis {:java-class-definitions true}}})
 
 (defn ^:private config-for-single-file [uri db*]
   (let [db @db*
@@ -226,15 +243,15 @@
          :filename filename
          :config-dir (project-config-dir (:project-root-uri db))
          :custom-lint-fn custom-lint-fn
-         :config {:output {:analysis {:arglists true
-                                      :locals true
-                                      :keywords true
-                                      :protocol-impls true
-                                      :java-class-definitions true
-                                      :java-class-usages true
-                                      :context [:clojure.test
-                                                :re-frame.core]}
-                           :canonical-paths true}}}
+         :config {:output {:canonical-paths true}
+                  :analysis {:arglists true
+                             :locals true
+                             :keywords true
+                             :protocol-impls true
+                             :java-class-definitions true
+                             :java-class-usages true
+                             :context [:clojure.test
+                                       :re-frame.core]}}}
         (with-additional-config (settings/all db)))))
 
 (defn ^:private run-kondo! [config err-hint]
@@ -254,12 +271,11 @@
 
 (defn run-kondo-on-paths! [paths db* {:keys [external?] :as normalization-config}]
   (let [db @db*
-        internal? (not external?)
-        custom-lint-fn (when internal?
-                         #(custom-lint-project! (normalize % normalization-config)))]
-    (-> (config-for-paths paths db)
-        (assoc-in [:config :output :analysis :java-class-usages] internal?)
-        (shared/assoc-in-some [:custom-lint-fn] custom-lint-fn)
+        config (if external?
+                 (config-for-external-paths paths db)
+                 (config-for-internal-paths paths db
+                                            #(custom-lint-project! (normalize % normalization-config))))]
+    (-> config
         (run-kondo! (str "paths " (string/join ", " paths)))
         (normalize normalization-config))))
 
@@ -294,9 +310,7 @@
         normalization-config {:external? false
                               :ensure-filenames filenames}
         custom-lint-fn #(custom-lint-files! filenames @db* (normalize % normalization-config))]
-    (-> (config-for-paths filenames db)
-        (assoc-in [:config :output :analysis :java-class-usages] true)
-        (assoc :custom-lint-fn custom-lint-fn)
+    (-> (config-for-internal-paths filenames db custom-lint-fn)
         (run-kondo! (str "files " (string/join ", " filenames)))
         (normalize normalization-config))))
 


### PR DESCRIPTION
This decreases un-cached startup time by 60-70%. See https://github.com/clj-kondo/clj-kondo/pull/1674.

This also triples the batch size of the dep analysis, since clj-kondo seems to analyze about 3 times as many files in the same amount of time now. I don't have numbers on how much memory was being saved by batching analysis, so that needs to be double-checked. @ericdallo can you do that or give some guidance on what to look for?

This also skips all linting, and analysis of var-usages for deps since we don't use those. The performance gain is almost exclusively from skipping var bodies, however, so that's the interesting part.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. See https://github.com/clj-kondo/clj-kondo/pull/1674
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
