### PR TITLE
Fix drag for calva

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Editor
   - Support `workspace/willRenameFiles`, renaming namespaces and all its references when a file is renamed.
   - Don't save cache when classpath lookup failed.
+  - Wait for editor to apply edits before requesting cursor re-positioning. Fixes cursor positioning after drag in Calva.
+  - drag: Request edit only of changed clauses, not entire parent, reducing flicker.
 
 - CLI/API
   - Bump lsp4clj to `0.3.0`.

--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -49,13 +49,16 @@
             (colored color (str "Client " client-id " " msg))
             (colored :yellow params))))
 
+(def ^:private wire-lock (Object.))
+
 (defn wire-send [server-in params]
   (let [content (json/generate-string params)]
     (binding [*out* server-in]
-      (println (str "Content-Length: " (content-length content)))
-      (println "")
-      (println content)
-      (flush))))
+      (locking wire-lock
+        (println (str "Content-Length: " (content-length content)))
+        (println "")
+        (println content)
+        (flush)))))
 
 (defn ^:private lsp-rpc [{:keys [request-id]} method params]
   {:jsonrpc "2.0"

--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -1,0 +1,192 @@
+(ns integration.client
+  (:require
+   [cheshire.core :as json]
+   [integration.helper :as h])
+  (:import
+   [java.time LocalDateTime]
+   [java.time.format DateTimeFormatter]))
+
+(def ^:private ESC \u001b)
+
+(def ^:private colors
+  {:black     (str ESC "[30m")
+   :red-bg    (str ESC "[41m")
+   :red       (str ESC "[31m")
+   :green     (str ESC "[32m")
+   :yellow    (str ESC "[33m")
+   :blue      (str ESC "[34m")
+   :magenta   (str ESC "[35m")
+   :cyan      (str ESC "[36m")
+   :white     (str ESC "[37m")
+   :underline (str ESC "[4m")
+   :reset     (str ESC "[m")})
+
+(defn ^:private colored [color string]
+  (str (get colors color) string (:reset colors)))
+
+(defn ^:private content-length [json]
+  (+ 1 (.length json)))
+
+(def ^:private ld-formatter DateTimeFormatter/ISO_LOCAL_DATE_TIME)
+(defn ^:private local-datetime-str [] (.format ld-formatter (LocalDateTime/now)))
+
+(defprotocol IClient
+  (start [this])
+  (shutdown [this])
+  (exit [this])
+  (send-request [this method body])
+  (send-notification [this method body])
+  (receive-response [this resp])
+  (receive-request [this req])
+  (receive-notification [this notif]))
+
+(defprotocol IMockClient
+  (mock-response [this method body]))
+
+(defn ^:private log
+  ([{:keys [client-id]} color msg params]
+   (println (local-datetime-str)
+            (colored color (str "Client " client-id " " msg))
+            (colored :yellow params))))
+
+(defn wire-send [server-in params]
+  (let [content (json/generate-string params)]
+    (binding [*out* server-in]
+      (println (str "Content-Length: " (content-length content)))
+      (println "")
+      (println content)
+      (flush))))
+
+(defn ^:private lsp-rpc [{:keys [request-id]} method params]
+  {:jsonrpc "2.0"
+   :method method
+   :params params
+   :id (swap! request-id inc)})
+
+(defn ^:private listen! [server-out client]
+  (try
+    (binding [*in* server-out]
+      (loop []
+          ;; Block, waiting for next Content-Length line, then discard it. If
+          ;; the server output stream is closed, also close the client by
+          ;; exiting this loop.
+        (if-let [_content-length (read-line)]
+          (let [{:keys [id method] :as json} (cheshire.core/parse-stream *in* true)]
+            (cond
+              (and id method) (receive-request client json)
+              id              (receive-response client json)
+              :else           (receive-notification client json))
+            (recur))
+          (do
+            (log client :red "listener closed:" "server closed")
+            (flush)))))
+    (catch Throwable e
+      (log client :red "listener closed:" "exception")
+      (println e)
+      (throw e))))
+
+(defrecord Client [client-id
+                   server-in server-out
+                   listener
+                   request-id sent-requests
+                   received-requests received-notifications
+                   mock-responses]
+  IClient
+  (start [this]
+    (reset! listener (future (listen! server-out this))))
+  (shutdown [_this] ;; simulate client closing
+    (.close server-in))
+  (exit [_this] ;; wait for shutdown of server to propagate to listener
+    @@listener)
+  (send-request [this method body]
+    (let [req (lsp-rpc this method body)]
+      (log this :cyan "sending request:" req)
+      (wire-send server-in req)
+      (let [p (promise)]
+        (swap! sent-requests assoc (:id req) p)
+        p)))
+  (send-notification [this method body]
+    (let [notif (lsp-rpc this method body)]
+      (log this :blue "sending notification:" notif)
+      (wire-send server-in notif)))
+  (receive-response [this {:keys [id] :as resp}]
+    (if-let [request (get @sent-requests id)]
+      (do (log this :green "received reponse:" resp)
+          (swap! sent-requests dissoc id)
+          (deliver request (if (:error resp)
+                             resp
+                             (:result resp))))
+      ;; TODO: if we don't have a request, this will return nil, which will get
+      ;; derefed, which will throw an error. Better to use promesa, and return a
+      ;; rejected promise? Promesa has the benefit of using CompletableFuture,
+      ;; making it more like what a lsp4j server expects.
+      (log this :red "received response for unmatched request:" resp)))
+  (receive-request [this {:keys [id method] :as req}]
+    (log this :magenta "received request:" req)
+    (swap! received-requests conj req)
+    (when-let [mock-resp (get @mock-responses (keyword method))]
+      (let [resp {:id id
+                  :result mock-resp}]
+        (log this :magenta "sending mock response:" resp)
+        (wire-send server-in resp))))
+  (receive-notification [this notif]
+    (log this :blue "received notification:" notif)
+    (swap! received-notifications conj notif))
+  IMockClient
+  (mock-response [_this method body]
+    (swap! mock-responses assoc method body)))
+
+(defonce client-id (atom 0))
+
+(defn client [server-in server-out]
+  (map->Client
+    {:client-id (swap! client-id inc)
+     :server-in server-in
+     :server-out server-out
+     :request-id (atom 0)
+     :sent-requests (atom {})
+     :received-requests (atom [])
+     :received-notifications (atom [])
+     :mock-responses (atom {})
+     :listener (atom nil)}))
+
+(defn ^:private keyname [key] (str (namespace key) "/" (name key)))
+
+(defn ^:private await-first-and-remove! [client pred coll-type]
+  (let [coll* (coll-type client)]
+    (loop [tries 0]
+      (if (< tries 20)
+        (if-let [elem (first (filter pred @coll*))]
+          (do
+            (swap! coll* #(->> % (remove #{elem}) vec))
+            elem)
+          (do
+            (Thread/sleep 500)
+            (recur (inc tries))))
+        (do
+          (log client :red "timeout waiting:" coll-type)
+          (throw (ex-info "timeout waiting for client to receive req/notif" {:coll-type coll-type})))))))
+
+(defn await-server-diagnostics [client path]
+  (let [file (h/source-path->file path)
+        uri (h/file->uri file)
+        method-str (keyname :textDocument/publishDiagnostics)
+        notification (await-first-and-remove! client
+                                              #(and (= method-str (:method %))
+                                                    (= uri (-> % :params :uri)))
+                                              :received-notifications)]
+    (-> notification :params :diagnostics)))
+
+(defn await-server-notification [client method]
+  (let [method-str (keyname method)
+        notification (await-first-and-remove! client
+                                              #(= method-str (:method %))
+                                              :received-notifications)]
+    (:params notification)))
+
+(defn await-server-request [client method]
+  (let [method-str (keyname method)
+        msg (await-first-and-remove! client
+                                     #(= method-str (:method %))
+                                     :received-requests)]
+    (:params msg)))

--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -67,9 +67,9 @@
   (try
     (binding [*in* server-out]
       (loop []
-          ;; Block, waiting for next Content-Length line, then discard it. If
-          ;; the server output stream is closed, also close the client by
-          ;; exiting this loop.
+        ;; Block, waiting for next Content-Length line, then discard it. If
+        ;; the server output stream is closed, also close the client by
+        ;; exiting this loop.
         (if-let [_content-length (read-line)]
           (let [{:keys [id method] :as json} (cheshire.core/parse-stream *in* true)]
             (cond

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -48,6 +48,9 @@
         :kind "source.organizeImports"}]
       (lsp/request! (fixture/code-action-request sample-file-name 5 4)))
 
+    (lsp/mock-response :workspace/applyEdit {:applied true})
+    (lsp/mock-response :window/showDocument {:success true})
+
     (lsp/request! (fixture/execute-command-request "drag-forward"
                                                    (h/source-path->uri sample-file-name)
                                                    5 4))
@@ -61,7 +64,7 @@
                                     "   ;; b comment"
                                     "   :b 2 ;; 2 comment"
                                     "   :d 4}")}]}]
-        (:documentChanges (:edit (lsp/await-client-request :workspace/applyEdit)))))
+        (:documentChanges (:edit (lsp/client-awaits-server-request :workspace/applyEdit)))))
     (testing "the cursor is repositioned"
       (h/assert-submap
         {:takeFocus true
@@ -70,4 +73,4 @@
                              :character 3}
                      :end   {:line      5
                              :character 3}}}
-        (lsp/await-client-request :window/showDocument)))))
+        (lsp/client-awaits-server-request :window/showDocument)))))

--- a/cli/integration-test/integration/code_action_test.clj
+++ b/cli/integration-test/integration/code_action_test.clj
@@ -57,13 +57,11 @@
 
     (testing "the code action edit is applied asynchronously"
       (h/assert-submaps
-        [{:edits [{:range   {:start {:line 3, :character 2},
-                             :end   {:line 7, :character 8}},
-                   :newText (h/code "{:a 1"
-                                    "   :c 3"
+        [{:edits [{:range {:start {:line 4, :character 3},
+                           :end {:line 6, :character 7}},
+                   :newText (h/code ":c 3"
                                     "   ;; b comment"
-                                    "   :b 2 ;; 2 comment"
-                                    "   :d 4}")}]}]
+                                    "   :b 2 ;; 2 comment")}]}]
         (:documentChanges (:edit (lsp/client-awaits-server-request :workspace/applyEdit)))))
     (testing "the cursor is repositioned"
       (h/assert-submap

--- a/cli/integration-test/integration/diagnostics_test.clj
+++ b/cli/integration-test/integration/diagnostics_test.clj
@@ -29,7 +29,7 @@
         :source "clojure-lsp"
         :message "Unused public var 'sample-test.diagnostics.unused-public-var/bar'"
         :tags [1]}]
-      (lsp/await-diagnostics "diagnostics/unused_public_var.clj"))))
+      (lsp/client-awaits-server-diagnostics "diagnostics/unused_public_var.clj"))))
 
 (deftest report-duplicates-enabled
   (lsp/start-process!)
@@ -57,7 +57,7 @@
         :source "clj-kondo"
         :message "Unresolved symbol: bar"
         :tags []}]
-      (lsp/await-diagnostics "diagnostics/kondo.clj"))))
+      (lsp/client-awaits-server-diagnostics "diagnostics/kondo.clj"))))
 
 (deftest report-duplicates-disabled
   (lsp/start-process!)
@@ -82,4 +82,4 @@
         :source "clj-kondo"
         :message "Unresolved symbol: bar"
         :tags []}]
-      (lsp/await-diagnostics "diagnostics/kondo.clj"))))
+      (lsp/client-awaits-server-diagnostics "diagnostics/kondo.clj"))))

--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -1,14 +1,7 @@
 (ns integration.fixture
   (:require
    [clojure.java.io :as io]
-   [integration.helper :as h]
-   [integration.lsp :as lsp]))
-
-(defn ^:private lsp-rpc [method params]
-  {:jsonrpc "2.0"
-   :method method
-   :params params
-   :id (lsp/inc-request-id)})
+   [integration.helper :as h]))
 
 (def default-init-options {:lint-project-files-after-startup? false
                            :java false})
@@ -17,99 +10,99 @@
   ([]
    (initialize-request {:initializationOptions default-init-options}))
   ([params]
-   (lsp-rpc :initialize
-            (merge {:rootUri (h/file->uri (io/file h/root-project-path))}
-                   params))))
+   [:initialize
+    (merge {:rootUri (h/file->uri (io/file h/root-project-path))}
+           params)]))
 
 (defn completion-request [path row col]
-  (lsp-rpc :textDocument/completion
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/completion
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn definition-request [path row col]
-  (lsp-rpc :textDocument/definition
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/definition
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn declaration-request [path row col]
-  (lsp-rpc :textDocument/declaration
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/declaration
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn implementation-request [path row col]
-  (lsp-rpc :textDocument/implementation
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/implementation
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn formatting-full-request [path]
-  (lsp-rpc :textDocument/formatting
-           {:textDocument {:uri (h/source-path->uri path)}
-            :options {:tabSize 2
-                      :insertSpaces true}}))
+  [:textDocument/formatting
+   {:textDocument {:uri (h/source-path->uri path)}
+    :options {:tabSize 2
+              :insertSpaces true}}])
 
 (defn prepare-rename-request [path row col]
-  (lsp-rpc :textDocument/prepareRename
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/prepareRename
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn rename-request [path new-name row col]
-  (lsp-rpc :textDocument/rename
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}
-            :newName new-name}))
+  [:textDocument/rename
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}
+    :newName new-name}])
 
 (defn formatting-range-request [path start-row start-col end-row end-col]
-  (lsp-rpc :textDocument/rangeFormatting
-           {:textDocument {:uri (h/source-path->uri path)}
-            :options {:tabSize 2
-                      :insertSpaces true}
-            :range {:start {:line start-row :character start-col}
-                    :end {:line end-row :character end-col}}}))
+  [:textDocument/rangeFormatting
+   {:textDocument {:uri (h/source-path->uri path)}
+    :options {:tabSize 2
+              :insertSpaces true}
+    :range {:start {:line start-row :character start-col}
+            :end {:line end-row :character end-col}}}])
 
 (defn document-symbol-request [path]
-  (lsp-rpc :textDocument/documentSymbol
-           {:textDocument {:uri (h/source-path->uri path)}}))
+  [:textDocument/documentSymbol
+   {:textDocument {:uri (h/source-path->uri path)}}])
 
 (defn document-highlight-request [path row col]
-  (lsp-rpc :textDocument/documentHighlight
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/documentHighlight
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn linked-editing-range-request [path row col]
-  (lsp-rpc :textDocument/linkedEditingRange
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  [:textDocument/linkedEditingRange
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn code-action-request [path row col]
-  (lsp-rpc :textDocument/codeAction
-           {:textDocument {:uri (h/source-path->uri path)}
-            :context      {:diagnostics []}
-            :range        {:start {:line row :character col}}}))
+  [:textDocument/codeAction
+   {:textDocument {:uri (h/source-path->uri path)}
+    :context      {:diagnostics []}
+    :range        {:start {:line row :character col}}}])
 
 (defn execute-command-request [command & args]
-  (lsp-rpc :workspace/executeCommand
-           {:command   command
-            :arguments args}))
+  [:workspace/executeCommand
+   {:command   command
+    :arguments args}])
 
 (defn cursor-info-raw-request [path row col]
-  (lsp-rpc "clojure/cursorInfo/raw"
-           {:textDocument {:uri (h/source-path->uri path)}
-            :position {:line row :character col}}))
+  ["clojure/cursorInfo/raw"
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position {:line row :character col}}])
 
 (defn clojure-dependency-contents-request [uri]
-  (lsp-rpc "clojure/dependencyContents"
-           {:uri uri}))
+  ["clojure/dependencyContents"
+   {:uri uri}])
 
 (defn initialized-notification []
-  (lsp-rpc :initialized {}))
+  [:initialized {}])
 
 (defn did-open-notification [path]
   (let [file (h/source-path->file path)
         uri (h/file->uri file)
         text (slurp (.getAbsolutePath file))]
-    (lsp-rpc :textDocument/didOpen
-             {:textDocument
-              {:uri uri
-               :languageId "clojure"
-               :version 0
-               :text text}})))
+    [:textDocument/didOpen
+     {:textDocument
+      {:uri uri
+       :languageId "clojure"
+       :version 0
+       :text text}}]))

--- a/cli/integration-test/integration/initialize_test.clj
+++ b/cli/integration-test/integration/initialize_test.clj
@@ -99,10 +99,10 @@
      :value {:kind "begin"
              :title "clojure-lsp"
              :percentage 0}}
-    (lsp/await-notification :$/progress))
+    (lsp/client-awaits-server-notification :$/progress))
 
   (testing "initialized notification"
     (lsp/notify! (fixture/initialized-notification))
     (h/assert-submaps
       [{:registerOptions {:watchers [{:globPattern "**/*.{clj,cljs,cljc,cljd,edn,bb}"}]}}]
-      (:registrations (lsp/await-client-request :client/registerCapability)))))
+      (:registrations (lsp/client-awaits-server-request :client/registerCapability)))))

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -1,178 +1,58 @@
 (ns integration.lsp
   (:require
    [babashka.process :as p]
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.test :refer [use-fixtures]]
-   [integration.helper :as h])
-  (:import
-   [java.time.format DateTimeFormatter]
-   [java.time LocalDateTime]))
+   [integration.client :as client]))
 
 (def ^:dynamic *clojure-lsp-process* nil)
-(def ^:dynamic *clojure-lsp-listener* nil)
-(def ^:dynamic *server-in* nil)
-(def ^:dynamic *server-out* nil)
+(def ^:dynamic *mock-client* nil)
 
-(defonce server-responses (atom {}))
-(defonce server-requests (atom []))
-(defonce server-notifications (atom []))
-(defonce client-id (atom 0))
-(defonce client-request-id (atom 0))
-
-(defn inc-request-id []
-  (swap! client-request-id inc))
-
-(def ^:private ESC \u001b)
-
-(def ^:private colors
-  {:black     (str ESC "[30m")
-   :red-bg    (str ESC "[41m")
-   :red       (str ESC "[31m")
-   :green     (str ESC "[32m")
-   :yellow    (str ESC "[33m")
-   :blue      (str ESC "[34m")
-   :magenta   (str ESC "[35m")
-   :cyan      (str ESC "[36m")
-   :white     (str ESC "[37m")
-   :underline (str ESC "[4m")
-   :reset     (str ESC "[m")})
-
-(defn ^:private colored [color string]
-  (str (get colors color) string (:reset colors)))
-
-(defn ^:private content-length [json]
-  (+ 1 (.length json)))
-
-(defn ^:private keyname [key] (str (namespace key) "/" (name key)))
-
-(def ^:private ld-formatter DateTimeFormatter/ISO_LOCAL_DATE_TIME)
-(defn ld-str [] (.format ld-formatter (LocalDateTime/now)))
-
-(defn client-log
-  ([color msg params]
-   (client-log @client-id color msg params))
-  ([client-id color msg params]
-   (println (ld-str) (colored color (str "Client " client-id " " msg)) (colored :yellow params))))
-
-(defn ^:private listen-output! []
-  (let [client-id (swap! client-id inc)]
-    (future
-      (try
-        (binding [*in* *server-out*]
-          (loop []
-            ;; Block, waiting for next Content-Length line, then discard it. If
-            ;; the server output stream is closed, also close the client by
-            ;; exiting this loop.
-            (if-let [_content-length (read-line)]
-              (let [{:keys [id method] :as json} (cheshire.core/parse-stream *in* true)]
-                (cond
-                  (and id method)
-                  (do
-                    (client-log client-id :magenta "received request:" json)
-                    (swap! server-requests conj json))
-
-                  id
-                  (do
-                    (client-log client-id :green "received reponse:" json)
-                    (swap! server-responses assoc id json))
-
-                  :else
-                  (do
-                    (client-log client-id :blue "received notification:" json)
-                    (swap! server-notifications conj json)))
-                (recur))
-              (do
-                (client-log client-id :red "closed:" "server closed")
-                (flush)))))
-        (catch Throwable e
-          (client-log client-id :red "closed:" "exception")
-          (println e)
-          (throw e))))))
+(defn start-server
+  ([binary]
+   (start-server binary []))
+  ([binary args]
+   (p/process (into [(.getCanonicalPath (io/file binary))] args)
+              {:dir "integration-test/sample-test/"})))
 
 (defn start-process! []
-  (let [clojure-lsp-binary (first *command-line-args*)]
-    (alter-var-root #'*clojure-lsp-process* (constantly (p/process [(.getCanonicalPath (io/file clojure-lsp-binary))] {:dir "integration-test/sample-test/"})))
-    (alter-var-root #'*server-in* (constantly (io/writer (:in *clojure-lsp-process*))))
-    (alter-var-root #'*server-out* (constantly (io/reader (:out *clojure-lsp-process*))))
-    (alter-var-root #'*clojure-lsp-listener* (constantly (listen-output!)))))
+  (let [server (start-server (first *command-line-args*))
+        client (client/client (io/writer (:in server)) (io/reader (:out server)))]
+    (client/start client)
+    (alter-var-root #'*clojure-lsp-process* (constantly server))
+    (alter-var-root #'*mock-client* (constantly client))))
 
 (defn cli! [& args]
-  (let [clojure-lsp-binary (first *command-line-args*)]
-    (alter-var-root #'*clojure-lsp-process* (constantly (p/process (into [(.getCanonicalPath (io/file clojure-lsp-binary))] args) {:dir "integration-test/sample-test/"})))
-    (io/reader (:out *clojure-lsp-process*))))
+  (let [server (start-server (first *command-line-args*) args)]
+    (alter-var-root #'*clojure-lsp-process* (constantly server))
+    (io/reader (:out server))))
 
 (defn clean! []
-  (reset! server-requests [])
-  (reset! server-responses {})
-  (reset! server-notifications [])
-  (reset! client-request-id 0)
   (flush)
-  (when *clojure-lsp-process*
-    (.close *server-in*) ;; simulate client closing
-    (deref *clojure-lsp-process*) ;; wait for close of client to shutdown server
-    (alter-var-root #'*clojure-lsp-process* (constantly nil)))
-  (when *clojure-lsp-listener*
-    (deref *clojure-lsp-listener*) ;; wait for shutdown of server to propagate to listener
-    (alter-var-root #'*clojure-lsp-listener* (constantly nil))))
+  (some-> *mock-client* client/shutdown)
+  (some-> *clojure-lsp-process* deref) ;; wait for shutdown of client to shutdown server
+  (some-> *mock-client* client/exit)
+  (alter-var-root #'*clojure-lsp-process* (constantly nil))
+  (alter-var-root #'*mock-client* (constantly nil)))
 
 (defn clean-after-test []
   (use-fixtures :each (fn [f] (clean!) (f)))
   (use-fixtures :once (fn [f] (f) (clean!))))
 
-(defn client-send [params]
-  (let [content (json/generate-string params)]
-    (binding [*out* *server-in*]
-      (println (str "Content-Length: " (content-length content)))
-      (println "")
-      (println content)
-      (flush))))
+(defn notify! [[method body]]
+  (client/send-notification *mock-client* method body))
 
-(defn notify! [params]
-  (client-log :blue "sending notification:" params)
-  (client-send params))
+(defn request! [[method body]]
+  @(client/send-request *mock-client* method body))
 
-(defn request! [params]
-  (client-log :cyan "sending request:" params)
-  (client-send params)
-  (loop []
-    (if-let [response (get @server-responses (:id params))]
-      (do
-        (swap! server-responses dissoc (:id params))
-        (if (:error response)
-          response
-          (:result response)))
-      (do
-        (Thread/sleep 500)
-        (recur)))))
+(defn client-awaits-server-diagnostics [path]
+  (client/await-server-diagnostics *mock-client* path))
 
-(defn await-first-and-remove! [pred coll*]
-  (loop []
-    (if-let [elem (first (filter pred @coll*))]
-      (do
-        (swap! coll* #(->> % (remove #{elem}) vec))
-        elem)
-      (do
-        (Thread/sleep 500)
-        (recur)))))
+(defn client-awaits-server-notification [method]
+  (client/await-server-notification *mock-client* method))
 
-(defn await-diagnostics [path]
-  (let [file (h/source-path->file path)
-        uri (h/file->uri file)
-        method-str (keyname :textDocument/publishDiagnostics)
-        notification (await-first-and-remove! #(and (= method-str (:method %))
-                                                    (= uri (-> % :params :uri)))
-                                              server-notifications)]
-    (-> notification :params :diagnostics)))
+(defn client-awaits-server-request [method]
+  (client/await-server-request *mock-client* method))
 
-(defn await-notification [method]
-  (let [method-str (keyname method)
-        notification (await-first-and-remove! #(= method-str (:method %))
-                                              server-notifications)]
-    (:params notification)))
-
-(defn await-client-request [method]
-  (let [method-str (keyname method)
-        msg (await-first-and-remove! #(= method-str (:method %))
-                                     server-requests)]
-    (:params msg)))
+(defn mock-response [method resp]
+  (client/mock-response *mock-client* method resp))

--- a/cli/integration-test/integration/settings_change_test.clj
+++ b/cli/integration-test/integration/settings_change_test.clj
@@ -45,7 +45,7 @@
         :source "clojure-lsp"
         :message "Unused public var 'sample-test.diagnostics.unused-public-var/bar'"
         :tags [1]}]
-      (lsp/await-diagnostics "diagnostics/unused_public_var.clj")))
+      (lsp/client-awaits-server-diagnostics "diagnostics/unused_public_var.clj")))
 
   (with-revised-lsp-config-content
     new-lsp-config-content
@@ -57,4 +57,4 @@
       (testing "Config has changed"
         (h/assert-submaps
           []
-          (lsp/await-diagnostics "diagnostics/unused_public_var.clj"))))))
+          (lsp/client-awaits-server-diagnostics "diagnostics/unused_public_var.clj"))))))

--- a/cli/integration-test/integration/stubs_test.clj
+++ b/cli/integration-test/integration/stubs_test.clj
@@ -26,6 +26,6 @@
         :source "clj-kondo"
         :message "datomic.api/create-database is called with 0 args but expects 1"
         :tags []}]
-      (lsp/await-diagnostics "stubs/a.clj"))
+      (lsp/client-awaits-server-diagnostics "stubs/a.clj"))
 
     (h/delete-project-file "../../.lsp/.cache/stubs")))

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -88,7 +88,8 @@
   (refresh-code-lens [_this]
     (producer/refresh-code-lens lsp-producer))
   (publish-workspace-edit [_this edit]
-    (producer/publish-workspace-edit lsp-producer edit))
+    (some-> (producer/publish-workspace-edit lsp-producer edit)
+            deref))
   (show-document-request [_this document-request]
     (producer/show-document-request lsp-producer document-request))
   (publish-progress [_this percentage message progress-token]

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -236,7 +236,7 @@
 
 (defn changes->code
   ([changes db]
-   (changes->code changes "file:///a.clj" db))
+   (changes->code changes default-uri db))
   ([changes uri db]
    (let [doc (get-in db [:documents uri :text])]
      (results->doc doc (vec (with-strings changes))))))

--- a/lib/src/clojure_lsp/feature/drag.clj
+++ b/lib/src/clojure_lsp/feature/drag.clj
@@ -283,7 +283,8 @@
      :col bottom-col}))
 
 (defn ^:private final-position [dir earlier-clause interstitial later-clause]
-  (let [top-position (meta (first (:nodes (first earlier-clause))))]
+  (let [top-position (select-keys (meta (first (:nodes (first earlier-clause))))
+                                  [:row :col])]
     (case dir
       :backward top-position
       :forward (bottom-position top-position (concat later-clause interstitial)))))

--- a/lib/src/clojure_lsp/feature/drag.clj
+++ b/lib/src/clojure_lsp/feature/drag.clj
@@ -91,9 +91,6 @@
       (recur (z/right* zloc) (conj satisfies zloc))
       [satisfies zloc])))
 
-(defn ^:private z-cursor-position [zloc]
-  (meta (z/node zloc)))
-
 ;;;; Main algorithm for moving a clause
 
 (defn ^:private seq-elems

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -360,9 +360,8 @@
       :execute-command
       ;; TODO move components upper to a common place
       (when-let [{:keys [edit show-document-after-edit]} (refactor command arguments components)]
-        (some-> (producer/publish-workspace-edit producer edit)
-                ;; wait for client to apply edit before showing doc/moving cursor
-                deref)
+        ;; waits for client to apply edit before showing doc/moving cursor
+        (producer/publish-workspace-edit producer edit)
         (when show-document-after-edit
           (->> (update show-document-after-edit :range #(or (some-> % shared/->range)
                                                             shared/full-file-range))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -360,7 +360,9 @@
       :execute-command
       ;; TODO move components upper to a common place
       (when-let [{:keys [edit show-document-after-edit]} (refactor command arguments components)]
-        (producer/publish-workspace-edit producer edit)
+        (some-> (producer/publish-workspace-edit producer edit)
+                ;; wait for client to apply edit before showing doc/moving cursor
+                deref)
         (when show-document-after-edit
           (->> (update show-document-after-edit :range #(or (some-> % shared/->range)
                                                             shared/full-file-range))

--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -241,9 +241,12 @@
           z/sexpr
           str))
 
+(defn marked? [loc marker]
+  (contains? (get (z/node loc) ::markers) marker))
+
 (defn back-to-mark-or-nil
   [zloc marker]
-  (z/find zloc z/prev (fn [loc] (contains? (get (z/node loc) ::markers) marker))))
+  (z/find zloc z/prev (fn [loc] (marked? loc marker))))
 
 (defn mark-position
   [zloc marker]

--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -241,8 +241,11 @@
           z/sexpr
           str))
 
+(defn node-marked? [node marker]
+  (contains? (get node ::markers) marker))
+
 (defn marked? [loc marker]
-  (contains? (get (z/node loc) ::markers) marker))
+  (node-marked? (z/node loc) marker))
 
 (defn back-to-mark-or-nil
   [zloc marker]

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -225,9 +225,7 @@
   (some-> change
           :changes-by-uri
           (get h/default-uri)
-          first
-          :loc
-          z/root-string))
+          (h/changes->code @db/db*)))
 
 (defn- as-range [change]
   (some-> change
@@ -1047,7 +1045,7 @@
   (testing "from comment after first element"
     (assert-no-erroneous-backwards (h/code "[:a |;; a comment"
                                            "]"))
-    (assert-no-erroneous-backwards (h/code "{:a 1 |;; one comment"
+    (assert-no-erroneous-backwards (h/code "{ka 1 |;; one comment"
                                            "}"))
     (assert-no-erroneous-backwards (h/code "(case a"
                                            "   1 :first |;; one comment"

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -1045,7 +1045,7 @@
   (testing "from comment after first element"
     (assert-no-erroneous-backwards (h/code "[:a |;; a comment"
                                            "]"))
-    (assert-no-erroneous-backwards (h/code "{ka 1 |;; one comment"
+    (assert-no-erroneous-backwards (h/code "{:a 1 |;; one comment"
                                            "}"))
     (assert-no-erroneous-backwards (h/code "(case a"
                                            "   1 :first |;; one comment"

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -3,8 +3,7 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.drag :as f.drag]
    [clojure-lsp.test-helper :as h]
-   [clojure.test :refer [deftest is testing]]
-   [rewrite-clj.zip :as z]))
+   [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
 


### PR DESCRIPTION
Two improvements to drag, noticed while working on exposing drag to Calva.

1. Wait for editor to apply edits before requesting cursor re-positioning. Fixes out-of-order handling of these two requests.
2. Request edit only of changed clauses, not entire parent, reducing flicker.


- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
