### PR TITLE
Fix drag in 'are' when clojure.test is aliased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Editor
+  - Fix drag in `are` when `clojure.test` is aliased. #967
+
 ## 2022.05.03-12.35.40
 
 - General

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -471,7 +471,23 @@
     (assert-drag-backward (h/code "(are [expected x] (= expected x) |3 4 1 2)")
                           (h/code "(are [expected x] (= expected x) 1 2 |3 4)"))
     (assert-drag-backward (h/code "(are [expected x] (= expected x) |3 4 1 2)")
-                          (h/code "(are [expected x] (= expected x) 1 2 3 |4)")))
+                          (h/code "(are [expected x] (= expected x) 1 2 3 |4)"))
+    (assert-drag-backward (h/code
+                            "(ns my-test-ns"
+                            "  (:require [clojure.test :as test]))"
+                            ""
+                            "(deftest my-test"
+                            "  (test/are [x y z] (= x y z)"
+                            "    |4 4 4"
+                            "    1 2 3))")
+                          (h/code
+                            "(ns my-test-ns"
+                            "  (:require [clojure.test :as test]))"
+                            ""
+                            "(deftest my-test"
+                            "  (test/are [x y z] (= x y z)"
+                            "    1 2 3"
+                            "    |4 4 4))")))
   (testing "with destructuring"
     (assert-drag-backward (h/code "(let [{:keys [a |c b d]} x])")
                           (h/code "(let [{:keys [a b |c d]} x])"))


### PR DESCRIPTION
If clojure.test was aliased, for example to `test`, dragging within `test/are` didn't behave as expected.

There were two possible fixes...

1. Look at the name of the symbol, not the whole thing.
2. Use the clj-kondo analysis to check whether the call site actually uses `clojure.test/are`.

The second option is technically more correct, but I picked the first. The first option is (very slightly) faster, but that wasn't my main motivator. Instead, I kind of like that we look only at the symbol for `are`, along with `cond`, `case`, and other special functions, as well as the binding forms `let`, etc. This means that other libraries that define functions with these same names get treated the same. The argument is that if a library author names a var `let`, its parameters should have the same structure as `clojure.core/let`'s.

Fixes #967.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #967
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
