### PR TITLE
Optimize semantic tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Editor
   - Fix drag in `are` when `clojure.test` is aliased. #967
+  - Reduce time to calculate semantic tokens, reducing CPU usage in large files. #970
 
 ## 2022.05.03-12.35.40
 

--- a/lib/src/clojure_lsp/feature/semantic_tokens.clj
+++ b/lib/src/clojure_lsp/feature/semantic_tokens.clj
@@ -217,7 +217,8 @@
         absolute-tokens (elements->absolute-tokens elements)]
     (->> absolute-tokens
          (map-indexed (partial absolute-token->relative-token absolute-tokens))
-         flatten)))
+         flatten
+         doall)))
 
 (defn range-tokens
   [uri range db]
@@ -226,7 +227,8 @@
         absolute-tokens (elements->absolute-tokens range-elements)]
     (->> absolute-tokens
          (map-indexed (partial absolute-token->relative-token absolute-tokens))
-         flatten)))
+         flatten
+         doall)))
 
 (defn element->token-type [element]
   (->> [element]

--- a/lib/test/clojure_lsp/features/semantic_tokens_test.clj
+++ b/lib/test/clojure_lsp/features/semantic_tokens_test.clj
@@ -33,14 +33,6 @@
    :name-end-col 6
    :bucket :locals})
 
-(def refered-usages
-  [refered-usage-a
-   refered-usage-b
-   refered-usage-c])
-
-(def refered-tokens
-  (map #(->token % :function) refered-usages))
-
 (defn code [& strings] (string/join "\n" strings))
 
 (deftest usage->absolute-token
@@ -51,20 +43,17 @@
 (deftest absolute-token->relative-token
   (testing "without previous token"
     (is (= [6 3 3 2 0]
-           (#'semantic-tokens/absolute-token->relative-token refered-tokens
-                                                             0
-                                                             (->token refered-usage-a :function)))))
+           (#'semantic-tokens/absolute-token->relative-token [nil
+                                                              (->token refered-usage-a :function)]))))
   (testing "same line token"
     (is (= [0 7 3 2 0]
-           (#'semantic-tokens/absolute-token->relative-token refered-tokens
-                                                             1
-                                                             (->token refered-usage-b :function)))))
+           (#'semantic-tokens/absolute-token->relative-token [(->token refered-usage-a :function)
+                                                              (->token refered-usage-b :function)]))))
 
   (testing "other line token"
     (is (= [2 2 3 2 0]
-           (#'semantic-tokens/absolute-token->relative-token refered-tokens
-                                                             2
-                                                             (->token refered-usage-c :function))))))
+           (#'semantic-tokens/absolute-token->relative-token [(->token refered-usage-b :function)
+                                                              (->token refered-usage-c :function)])))))
 
 (deftest full-tokens
   (testing "tokens order"


### PR DESCRIPTION
This replaces a quadratic algorithm with a linear algorithm when calculating semantic tokens.

To find the prior token (while converting absolute tokens to relative), the system was using `nth` on a seq, which is a linear time operation (as opposed to on a vector, where it would be a constant time operation). Since it was doing this in a loop, semantic token calculation was a quadratic time operation overall.

This switches from `nth` to `(partition 2 1)`, creating tuples of the previous and subsequent token. This brings semantic token calculation back to a linear time operation.

In `clojure.core` this reduces the time to calculate the full semantic tokens from 7s to 0.3s, a 95% reduction in time. There's a corresponding reduction in CPU usage. There isn't a noticeable change in range semantic tokens, because they're a much smaller list.

This also ensures that the logs report the full time to calculate semantic tokens. Before they were logging the time it took to prepare a lazy sequence that would eventually be realized into the full list of semantic tokens.

Fixes #970.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #970
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
