### PR TITLE
Support string config for :linters to support lsp clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - General
   - Allow specify how many classes clojure-lsp should check before moving sorted package imported classes to next line. #966
+  - Allow `:linters` to be configured by LSP clients passing string keys/values. #977
 
 - Editor
   - Fix drag in `are` when `clojure.test` is aliased. #967

--- a/lib/src/clojure_lsp/settings.clj
+++ b/lib/src/clojure_lsp/settings.clj
@@ -23,6 +23,11 @@
                            (symbol %)))
        (medley/map-vals typify-json)))
 
+(defn- clean-keys-map [m]
+  (->> (or m {})
+       (medley/map-keys keyword)
+       (medley/map-vals typify-json)))
+
 (defn parse-source-paths [paths]
   (when (seq paths)
     (->> paths
@@ -57,7 +62,9 @@
         (update :project-specs #(->> % (mapv kwd-keys) not-empty))
         (update :cljfmt-config-path #(or % ".cljfmt.edn"))
         (update :cljfmt kwd-keys)
+        (update :linters kwd-keys)
         (medley/update-existing-in [:cljfmt :indents] clean-symbol-map)
+        (medley/update-existing-in [:linters] clean-keys-map)
         (update :document-formatting? (fnil identity true))
         (update :document-range-formatting? (fnil identity true)))))
 

--- a/lib/test/clojure_lsp/settings_test.clj
+++ b/lib/test/clojure_lsp/settings_test.clj
@@ -46,3 +46,19 @@
   (is (= {:c 2} (settings/get @db/db* [:a :b])))
   (is (= {:b {:c 2}} (settings/get @db/db* [:a])))
   (is (= 10 (settings/get @db/db* [:d] 10))))
+
+(deftest clean-client-settings-test
+  (let [raw-settings {"linters"
+                      {"clojure-lsp/unused-public-var"
+                       {"level" "off"}}
+
+                      "cljfmt"
+                      {"indentation?" false}}
+        cleaned (-> raw-settings
+                    shared/keywordize-first-depth
+                    settings/clean-client-settings)]
+    (is (= {:level :off}
+           (get-in cleaned [:linters :clojure-lsp/unused-public-var])))
+
+    (is (= {:indentation? false}
+           (:cljfmt cleaned)))))


### PR DESCRIPTION
If not using a file for global config, and instead using non-clojure
language clients (eg: neovim's native LSP in lua) there's no way to
provide keywordized keys for the `:linters` config. This PR updates the
settings "cleaning" to process the `:linters` config similarly to how we
do for `:cljfmt` to support such clients.

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
