### PR TITLE
Add github action to update deps-lock.json

### DIFF
--- a/.github/workflows/update_deps-lock.yml
+++ b/.github/workflows/update_deps-lock.yml
@@ -1,0 +1,24 @@
+name: "Update deps-lock.json"
+on:
+  push:
+    paths:
+      - "**/deps.edn"
+
+jobs:
+  update-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v17
+
+      - name: Update deps-lock
+        run: "nix run github:jlesquembre/clj-nix#deps-lock"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          commit-message: Update deps-lock.json
+          title: Update deps-lock.json
+          branch: update-deps-lock


### PR DESCRIPTION
As discussed on #999, a github action to automatically update the deps-lock.json.

I tested it on my dummy clj project: https://github.com/jlesquembre/clj-demo-project/actions

It's just a suggestion, feel free to close this PR if you have other ideas about it.