### PR TITLE
Avoid finding clj def from cljs usage

### DIFF
--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -420,9 +420,7 @@
       {:name 'bar :filename (h/file-path "/a.clj")}
       (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
 
-(deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
-  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
-  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
+(defn assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs []
   (testing "when on a clj file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.clj"))
@@ -465,6 +463,16 @@
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some/foo.clj")}
         (q/find-definition-from-cursor ana (h/file-path "/a.cljs") bar-r bar-c)))))
+
+(deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
+  (assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs))
+
+(deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs-in-other-load-order
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
+  (assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs))
 
 (deftest find-definition-from-cursor-when-declared
   (let [[[bar-r bar-c]] (h/load-code-and-locs


### PR DESCRIPTION
```clojure
;; a.cljs
(ns a)
(def f)

;; a.clj
(ns a)
(def f)

;; b.cljs
(ns b
  (:require [a]))
|a/f
```

In the above code, find-definition should always go to `a.cljs`, but it could go to `a.clj`. Which one it picked was arbitrary, because both definitions match.

This bug was accidentally introduced in d5e1ef39bc17cd8bb7f94bf6c9f611335dd6b2af, which was developed to fix https://github.com/clojure-lsp/clojure-lsp/issues/980. It might have been caught earlier because there are tests around this. Unfortunately, the tests only fail if the cljs file is loaded before the clj file, which isn't how they were written originally.

This patch also addresses #980, but avoids the incorrect navigation.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
