### PR TITLE
Fix suggesting alias to wrong lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Editor
   - Add support to rename namespace of namespaced keywords like re-frame events/subs. #978
   - Improve performance of find-declaration feature. #1021
+  - Fix to avoid suggesting an alias from a clj file to a cljs file. #1024
 
 ## 2022.05.31-17.35.50
 

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -440,7 +440,8 @@
                                    (name cursor-value)
                                    (str cursor-value)))
             cursor-full-ns? (when cursor-value-or-ns
-                              (contains? (q/find-all-ns-definition-names analysis) (symbol cursor-value-or-ns)))
+                              (contains? (q/find-all-ns-definition-names analysis)
+                                         (symbol cursor-value-or-ns)))
             items (cond
                     inside-refer?
                     (with-refer-elements matches-fn cursor-loc all-other-ns-elements)

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -162,7 +162,7 @@
                                                                             local-analysis))
                                                 namespace-suggestions (f.add-missing-libspec/find-namespace-suggestions
                                                                         (str dest-ns)
-                                                                        (f.add-missing-libspec/find-alias-ns-pairs analysis uri db))
+                                                                        (f.add-missing-libspec/find-alias-ns-pairs analysis uri))
                                                 suggestion (if dest-require
                                                              {:alias (str (:alias dest-require))}
                                                              (first namespace-suggestions))

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -286,7 +286,7 @@
       (into #{}
             (comp
               q/filter-project-analysis-xf
-              (q/find-all-ns-definition-names-xf)
+              q/find-all-ns-definition-names-xf
               (remove (partial exclude-ns? options)))
             (:analysis db))))
 

--- a/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
+++ b/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
@@ -211,6 +211,7 @@
     (testing "Do not add from wrong language"
       (h/clean-db!)
       (h/load-code-and-locs "(ns a (:require [foo.s :as s]))" "file:///b.cljs")
+      (h/load-code-and-locs "(ns foo.s)" "file:///c.cljs")
       (is (= nil
              (-> "(ns foo) |s/thing"
                  add-missing-libspec))))


### PR DESCRIPTION
This prevents `add-missing-libspec` from suggesting an alias to a file in the the wrong language.

```clojure
;; foo/s.cljs
(ns foo.s)
;; a.cljs
(ns a (:require [foo.s :as s]))
;; b.clj
(ns b)
|s/thing
```

This would suggest `(:require [foo.s :as s])` even though `foo.s` isn't a clj namespace.

Fixes #1024

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #1024
- [X] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
