### PR TITLE
refactor: Query signatures

### DIFF
--- a/lib/src/clojure_lsp/crawler.clj
+++ b/lib/src/clojure_lsp/crawler.clj
@@ -100,7 +100,7 @@
                      (-> state-db
                          (merge (select-keys db-cache [:classpath :analysis-checksums :project-hash
                                                        :kondo-config-hash :stubs-generation-namespaces]))
-                         (update :analysis merge (:analysis db-cache)))))))))
+                         (lsp.kondo/db-with-analysis (:analysis db-cache)))))))))
 
 (defn ^:private build-db-cache [db]
   (-> db

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -398,7 +398,7 @@
                           (if-let [common-refer (get common-sym/common-refers->info (symbol cursor-name-str))]
                             [{:ns (name common-refer)
                               :refer cursor-name-str}]
-                            (->> (q/find-all-var-definitions analysis)
+                            (->> (q/find-all-var-definitions db)
                                  (filter #(= cursor-name-str (str (:name %))))
                                  (map (fn [element]
                                         {:ns (str (:ns element))

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -48,7 +48,7 @@
 
 (defn ^:private find-missing-ns-alias-require [zloc uri db]
   (let [require-alias (some-> zloc safe-sym namespace symbol)
-        alias->info (->> (q/find-all-aliases-for-langs (:analysis db)
+        alias->info (->> (q/find-all-aliases-for-langs db
                                                        (shared/uri->available-langs uri))
                          (group-by :alias))
         possibilities (or (some->> (get alias->info require-alias)
@@ -376,21 +376,20 @@
       :else
       (resolve-best-namespaces-suggestions cursor-namespace-str aliases->namespaces namespaces->aliases))))
 
-(defn find-alias-ns-pairs [analysis uri]
+(defn find-alias-ns-pairs [db uri]
   (let [langs (shared/uri->available-langs uri)]
-    (concat (->> (q/find-all-aliases-for-langs analysis langs)
+    (concat (->> (q/find-all-aliases-for-langs db langs)
                  (map (juxt (comp str :to) (comp str :alias))))
-            (->> (q/find-all-ns-definitions-for-langs analysis langs)
+            (->> (q/find-all-ns-definitions-for-langs db langs)
                  (map (juxt (comp str :name) (constantly nil)))))))
 
 (defn find-require-suggestions [zloc uri db]
   (when-let [cursor-sym (safe-sym zloc)]
     (let [cursor-namespace-str (namespace cursor-sym)
           cursor-name-str (name cursor-sym)
-          analysis (:analysis db)
           namespace-suggestions (find-namespace-suggestions
                                   (or cursor-namespace-str cursor-name-str)
-                                  (find-alias-ns-pairs analysis uri))
+                                  (find-alias-ns-pairs db uri))
           suggestions (if (namespace cursor-sym)
                         namespace-suggestions
                         (concat

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -409,16 +409,14 @@
   (let [settings (settings/all db)
         ;; TODO: use parser?
         safe-loc (or zloc (z/of-string (get-in db [:documents uri :text])))
-        ns-loc (edit/find-namespace safe-loc)
-        analysis (:analysis db)
-        findings (:findings db)]
+        ns-loc (edit/find-namespace safe-loc)]
     (when ns-loc
       (let [ns-inner-blocks-indentation (resolve-ns-inner-blocks-identation db)
             filename (shared/uri->filename uri)
-            unused-aliases* (future (q/find-unused-aliases analysis findings filename))
-            unused-refers* (future (q/find-unused-refers analysis findings filename))
-            unused-imports* (future (q/find-unused-imports analysis findings filename))
-            duplicate-requires* (future (q/find-duplicate-requires findings filename))
+            unused-aliases* (future (q/find-unused-aliases db filename))
+            unused-refers* (future (q/find-unused-refers db filename))
+            unused-imports* (future (q/find-unused-imports db filename))
+            duplicate-requires* (future (q/find-duplicate-requires db filename))
             clean-ctx {:db db
                        :old-ns-loc ns-loc
                        :filename filename

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -275,7 +275,7 @@
         allow-drag-forward?* (future (f.drag/can-drag-forward? zloc uri db))
         can-promote-fn?* (future (r.transform/can-promote-fn? zloc))
         can-demote-fn?* (future (r.transform/can-demote-fn? zloc))
-        definition (q/find-definition-from-cursor (:analysis db) (shared/uri->filename uri) row col)
+        definition (q/find-definition-from-cursor db (shared/uri->filename uri) row col)
         inline-symbol?* (future (r.transform/inline-symbol? definition db))
         can-add-let? (or (z/skip-whitespace z/right zloc)
                          (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))]

--- a/lib/src/clojure_lsp/feature/code_lens.clj
+++ b/lib/src/clojure_lsp/feature/code_lens.clj
@@ -20,26 +20,25 @@
 (defn ^:private test-references->string [references]
   (references->string references " test"))
 
-(defn ^:private var-definitions-lens [filename kondo-config analysis]
-  (->> (q/find-var-definitions analysis filename true)
-       (remove (partial q/exclude-public-definition? kondo-config))))
+(defn ^:private var-definitions-lens [filename db]
+  (->> (q/find-var-definitions db filename true)
+       (remove (partial q/exclude-public-definition? (:kondo-config db)))))
 
 (defn ^:private keyword-definitions-lens
-  [filename kondo-config analysis]
-  (->> (q/find-keyword-definitions analysis filename)
-       (remove (partial q/exclude-public-definition? kondo-config))))
+  [filename db]
+  (->> (q/find-keyword-definitions db filename)
+       (remove (partial q/exclude-public-definition? (:kondo-config db)))))
 
 (defn reference-code-lens [uri db]
   (let [analysis (:analysis db)
-        kondo-config (:kondo-config db)
         filename (shared/uri->filename uri)]
     (into []
           (map (fn [element]
                  {:range (shared/->range element)
                   :data  [uri (:name-row element) (:name-col element)]}))
           (concat (q/find-namespace-definitions analysis filename)
-                  (var-definitions-lens filename kondo-config analysis)
-                  (keyword-definitions-lens filename kondo-config analysis)))))
+                  (var-definitions-lens filename db)
+                  (keyword-definitions-lens filename db)))))
 
 (defn test-reference? [source-path {:keys [filename]}]
   (and source-path

--- a/lib/src/clojure_lsp/feature/code_lens.clj
+++ b/lib/src/clojure_lsp/feature/code_lens.clj
@@ -30,13 +30,12 @@
        (remove (partial q/exclude-public-definition? (:kondo-config db)))))
 
 (defn reference-code-lens [uri db]
-  (let [analysis (:analysis db)
-        filename (shared/uri->filename uri)]
+  (let [filename (shared/uri->filename uri)]
     (into []
           (map (fn [element]
                  {:range (shared/->range element)
                   :data  [uri (:name-row element) (:name-col element)]}))
-          (concat (q/find-namespace-definitions analysis filename)
+          (concat (q/find-namespace-definitions db filename)
                   (var-definitions-lens filename db)
                   (keyword-definitions-lens filename db)))))
 

--- a/lib/src/clojure_lsp/feature/code_lens.clj
+++ b/lib/src/clojure_lsp/feature/code_lens.clj
@@ -49,7 +49,7 @@
 (defn resolve-code-lens [uri row col range db]
   (let [filename (shared/uri->filename uri)
         segregate-lens? (settings/get db [:code-lens :segregate-test-references] true)
-        references (q/find-references-from-cursor (:analysis db) filename row col false)]
+        references (q/find-references-from-cursor db filename row col false)]
     (if segregate-lens?
       (let [source-path (->> (settings/get db [:source-paths])
                              (filter #(string/starts-with? filename %))

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -492,23 +492,18 @@
                                           :name (symbol name)
                                           :to (symbol ns)
                                           :bucket :var-usages})]
-    (if definition
-      (-> item
-          (assoc :documentation (f.hover/hover-documentation definition db*)))
-      item)))
+    (cond-> item
+      definition (assoc :documentation (f.hover/hover-documentation definition db*)))))
 
 (defn ^:private resolve-item-by-definition
   [{{:keys [name filename name-row name-col]} :data :as item} db*]
   (let [db @db*
-        local-analysis (get-in db [:analysis filename])
-        definition (q/find-first #(and (identical? :var-definitions (:bucket %))
-                                       (= name (str (:name %)))
-                                       (= name-row (:name-row %))
-                                       (= name-col (:name-col %))) local-analysis)]
-    (if definition
-      (-> item
-          (assoc :documentation (f.hover/hover-documentation definition db*)))
-      item)))
+        element (q/find-element-under-cursor db filename name-row name-col)
+        definition (when (and (identical? :var-definitions (:bucket element))
+                              (= name (str (:name element))))
+                     element)]
+    (cond-> item
+      definition (assoc :documentation (f.hover/hover-documentation definition db*)))))
 
 (defn resolve-item [{{:keys [ns]} :data :as item} db*]
   (let [item (shared/assoc-some item

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -440,7 +440,7 @@
                                    (name cursor-value)
                                    (str cursor-value)))
             cursor-full-ns? (when cursor-value-or-ns
-                              (contains? (q/find-all-ns-definition-names analysis)
+                              (contains? (q/find-all-ns-definition-names db)
                                          (symbol cursor-value-or-ns)))
             items (cond
                     inside-refer?

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -11,7 +11,6 @@
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
    [clojure.string :as string]
-   [clojure.walk :as walk]
    [medley.core :as medley]
    [rewrite-clj.zip :as z]))
 
@@ -177,10 +176,10 @@
                        arglist-strs (conj (string/join " " arglist-strs))))))]
     (cond-> {:label (element->label element cursor-alias priority)
              :priority (generic-priority->specific-priority element priority)
-             :data (walk/stringify-keys {:name (-> element :name str)
-                                         :filename (:filename element)
-                                         :name-row (:name-row element)
-                                         :name-col (:name-col element)})}
+             :data {"name" (-> element :name str)
+                    "filename" (:filename element)
+                    "name-row" (:name-row element)
+                    "name-col" (:name-col element)}}
       deprecated (assoc :tags [1])
       kind (assoc :kind kind)
       detail (assoc :detail detail))))
@@ -210,11 +209,13 @@
 
 (defn ^:private with-refer-elements [matches-fn cursor-loc other-ns-elements]
   (let [refer-ns (z/sexpr (edit/find-refer-ns cursor-loc))]
-    (->> other-ns-elements
-         (filter #(and (identical? :var-definitions (:bucket %))
-                       (= refer-ns (:ns %))
-                       (matches-fn (:name %))))
-         (map #(element->completion-item % nil :refer)))))
+    (into []
+          (comp
+            (filter #(and (identical? :var-definitions (:bucket %))
+                          (= refer-ns (:ns %))
+                          (matches-fn (:name %))))
+            (map #(element->completion-item % nil :refer)))
+          other-ns-elements)))
 
 (defn ^:private with-elements-from-alias [cursor-loc cursor-alias cursor-value current-ns-elements matches-fn db]
   (let [current-ns-alias (->> current-ns-elements
@@ -283,19 +284,22 @@
                           (seq require-edit) (assoc :additional-text-edits (mapv #(update % :range shared/->range) require-edit)))))))
                 (:analysis db)))))))
 
-(defn ^:private with-elements-from-full-ns [full-ns analysis]
-  (->> (mapcat val analysis)
-       (filter #(and (identical? :var-definitions (:bucket %))
-                     (= (:ns %) (symbol full-ns))
-                     (not (:private %))))
-       (mapv #(element->completion-item % full-ns :ns-definition))))
+(defn ^:private with-elements-from-full-ns [db full-ns]
+  (into []
+        (comp
+          (mapcat val)
+          (filter #(and (identical? :var-definitions (:bucket %))
+                        (= (:ns %) (symbol full-ns))
+                        (not (:private %))))
+          (map #(element->completion-item % full-ns :ns-definition)))
+        (:analysis db)))
 
 (defn ^:private with-elements-from-aliased-keyword
-  [cursor-loc cursor-element analysis filename elements]
+  [cursor-loc cursor-element current-ns-elements elements]
   (let [alias (or (:alias cursor-element)
                   (-> cursor-loc z/sexpr namespace (subs 1)))
         ns (or (:ns cursor-element)
-               (->> (get analysis filename)
+               (->> current-ns-elements
                     (filter #(and (identical? :namespace-usages (:bucket %))
                                   (= alias (str (:alias %)))))
                     first
@@ -407,10 +411,9 @@
       []
       (let [filename (shared/uri->filename uri)
             settings (settings/all db)
-            analysis (:analysis db)
-            current-ns-elements (get analysis filename)
+            current-ns-elements (get-in db [:analysis filename])
             support-snippets? (get-in db [:client-capabilities :text-document :completion :completion-item :snippet-support] false)
-            all-other-ns-elements (mapcat val (dissoc analysis filename))
+            all-other-ns-elements (mapcat val (dissoc (:analysis db) filename))
             cursor-element (q/find-element-under-cursor db filename row col)
             cursor-value (if (= :vector (z/tag cursor-loc))
                            ""
@@ -453,12 +456,12 @@
                       (merging-snippets cursor-loc next-loc function-call? matches-fn settings))
 
                     aliased-keyword-value?
-                    (with-elements-from-aliased-keyword cursor-loc cursor-element analysis filename all-other-ns-elements)
+                    (with-elements-from-aliased-keyword cursor-loc cursor-element current-ns-elements all-other-ns-elements)
 
                     :else
                     (cond-> []
                       cursor-full-ns?
-                      (into (with-elements-from-full-ns cursor-value-or-ns analysis))
+                      (into (with-elements-from-full-ns db cursor-value-or-ns))
 
                       (and cursor-value-or-ns
                            (not keyword-value?))

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -196,9 +196,9 @@
 (defn custom-lint-files!
   [filenames db kondo-ctx]
   (let [project-db (q/db-with-project-analysis db)
-        file-db (update project-db :analysis select-keys filenames)]
-    (lint-defs! (all-var-definitions file-db)
-                (all-kw-definitions file-db)
+        files-db (update project-db :analysis select-keys filenames)]
+    (lint-defs! (all-var-definitions files-db)
+                (all-kw-definitions files-db)
                 project-db kondo-ctx)))
 
 (defn custom-lint-file!

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -154,14 +154,14 @@
                  :diagnostics []}))))
 
 (defn ^:private lint-defs!
-  [var-defs kw-defs project-analysis {:keys [config reg-finding!]}]
+  [var-defs kw-defs project-db {:keys [config reg-finding!]}]
   (let [var-definitions (remove (partial exclude-public-diagnostic-definition? config) var-defs)
         var-nses (set (map :ns var-definitions)) ;; optimization to limit usages to internal namespaces, or in the case of a single file, to its namespaces
         var-usages (into #{}
                          (comp
                            (q/xf-all-var-usages-to-namespaces var-nses)
                            (map q/var-usage-signature))
-                         project-analysis)
+                         (:analysis project-db))
         var-used? (fn [var-def]
                     (some var-usages (q/var-definition-signatures var-def)))
         kw-definitions (remove (partial exclude-public-diagnostic-definition? config) kw-defs)
@@ -169,7 +169,7 @@
                         (comp
                           q/xf-all-keyword-usages
                           (map q/kw-signature))
-                        project-analysis)
+                        (:analysis project-db))
         kw-used? (fn [kw-def]
                    (contains? kw-usages (q/kw-signature kw-def)))
         findings (->> (concat (remove var-used? var-definitions)
@@ -180,36 +180,30 @@
       (reg-finding! finding))
     (group-by :filename findings)))
 
-(defn ^:private file-var-definitions [project-analysis filename]
-  (q/find-var-definitions project-analysis filename false))
+(defn ^:private file-var-definitions [project-db filename]
+  (q/find-var-definitions project-db filename false))
 (def ^:private file-kw-definitions q/find-keyword-definitions)
 (def ^:private all-var-definitions q/find-all-var-definitions)
 (def ^:private all-kw-definitions q/find-all-keyword-definitions)
 
 (defn custom-lint-project!
-  [new-analysis kondo-ctx]
-  (let [project-analysis (into {}
-                               q/filter-project-analysis-xf
-                               new-analysis)]
-    (lint-defs! (all-var-definitions project-analysis)
-                (all-kw-definitions project-analysis)
-                project-analysis kondo-ctx)))
+  [db kondo-ctx]
+  (let [project-db (q/db-with-project-analysis db)]
+    (lint-defs! (all-var-definitions project-db)
+                (all-kw-definitions project-db)
+                project-db kondo-ctx)))
 
 (defn custom-lint-files!
-  [filenames new-analysis kondo-ctx]
-  (let [project-analysis (into {}
-                               q/filter-project-analysis-xf
-                               new-analysis)
-        file-analyses (select-keys project-analysis filenames)]
-    (lint-defs! (all-var-definitions file-analyses)
-                (all-kw-definitions file-analyses)
-                project-analysis kondo-ctx)))
+  [filenames db kondo-ctx]
+  (let [project-db (q/db-with-project-analysis db)
+        file-db (update project-db :analysis select-keys filenames)]
+    (lint-defs! (all-var-definitions file-db)
+                (all-kw-definitions file-db)
+                project-db kondo-ctx)))
 
 (defn custom-lint-file!
-  [filename analysis kondo-ctx]
-  (let [project-analysis (into {}
-                               q/filter-project-analysis-xf
-                               analysis)]
-    (lint-defs! (file-var-definitions project-analysis filename)
-                (file-kw-definitions project-analysis filename)
-                project-analysis kondo-ctx)))
+  [filename db kondo-ctx]
+  (let [project-db (q/db-with-project-analysis db)]
+    (lint-defs! (file-var-definitions project-db filename)
+                (file-kw-definitions project-db filename)
+                project-db kondo-ctx)))

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -80,12 +80,15 @@
         usage-signature (juxt :to :name)]
     (find-changed-elems-by usage-signature old-var-usages new-var-usages)))
 
-(defn reference-filenames [filename old-local-analysis new-local-analysis db]
-  (let [changed-var-definitions (find-changed-var-definitions old-local-analysis new-local-analysis)
+(defn reference-filenames [filename db-before db-after]
+  (let [old-local-analysis (get-in db-before [:analysis filename])
+        new-local-analysis (get-in db-after [:analysis filename])
+        changed-var-definitions (find-changed-var-definitions old-local-analysis new-local-analysis)
         changed-var-usages (find-changed-var-usages old-local-analysis new-local-analysis)
-        project-analysis (into {}
-                               q/filter-project-analysis-xf
-                               (dissoc (:analysis db) filename)) ;; don't notify self
+        project-db (-> db-after
+                       q/db-with-project-analysis
+                       ;; don't notify self
+                       (update :analysis dissoc filename))
         incoming-filenames (when (seq changed-var-definitions)
                              (let [def-signs (->> changed-var-definitions
                                                   (map q/var-definition-signatures)
@@ -96,7 +99,7 @@
                                        (filter #(identical? :var-usages (:bucket %)))
                                        (filter #(contains? def-signs (q/var-usage-signature %)))
                                        (map :filename))
-                                     project-analysis)))
+                                     (:analysis project-db))))
         outgoing-filenames (when (seq changed-var-usages)
                              ;; If definition is in both a clj and cljs file, and this is a clj
                              ;; usage, we are careful to notify only the clj file. But, it wouldn't
@@ -114,17 +117,17 @@
                                        (filter #(when-let [usage-langs (some usage-signs->langs (q/var-definition-signatures %))]
                                                   (some usage-langs (q/elem-langs %))))
                                        (map :filename))
-                                     project-analysis)))]
+                                     (:analysis project-db))))]
     (set/union (or incoming-filenames #{})
                (or outgoing-filenames #{}))))
 
-(defn ^:private notify-references [filename old-local-analysis new-local-analysis {:keys [db* producer]}]
+(defn ^:private notify-references [filename db-before db-after {:keys [db* producer]}]
   (async/go
     (shared/logging-task
       :notify-references
       (let [filenames (shared/logging-task
                         :reference-files/find
-                        (reference-filenames filename old-local-analysis new-local-analysis @db*))]
+                        (reference-filenames filename db-before db-after))]
         (when (seq filenames)
           (logger/debug "Analyzing references for files:" filenames)
           (shared/logging-task
@@ -183,7 +186,7 @@
                                 (str "changes analyzed by clj-kondo took %s")
                                 (lsp.kondo/run-kondo-on-text! text uri db*))]
         (let [filename (shared/uri->filename uri)
-              old-local-analysis (get-in @db* [:analysis filename])]
+              old-db @db*]
           (if (compare-and-set! db* state-db
                                 (-> state-db
                                     (lsp.kondo/db-with-results kondo-result)
@@ -191,7 +194,7 @@
             (let [db @db*]
               (f.diagnostic/sync-publish-diagnostics! uri db)
               (when (settings/get db [:notify-references-on-file-change] true)
-                (notify-references filename old-local-analysis (get-in db [:analysis filename]) components))
+                (notify-references filename old-db db components))
               (clojure-producer/refresh-test-tree producer [uri]))
             (recur @db*)))))))
 

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -258,12 +258,12 @@
   (swap! db* #(assoc-in % [:documents uri :saved-on-disk] true)))
 
 (defn will-rename-files [files db*]
-  (let [analysis (:analysis @db*)]
+  (let [db @db*]
     (->> files
          (keep (fn [{:keys [oldUri newUri]}]
                  (let [old-filename (shared/uri->filename oldUri)
-                       new-ns (shared/uri->namespace newUri @db*)
-                       ns-definition (q/find-namespace-definition-by-filename analysis old-filename)]
+                       new-ns (shared/uri->namespace newUri db)
+                       ns-definition (q/find-namespace-definition-by-filename db old-filename)]
                    (when ns-definition
                      (f.rename/rename-element oldUri new-ns db* old-filename ns-definition :rename-file)))))
          (reduce #(shared/deep-merge %1 %2) {:document-changes []}))))

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -114,7 +114,6 @@
 
 (defn hover [uri line column db*]
   (let [db @db*
-        analysis (:analysis db)
         filename (shared/uri->filename uri)
         zloc (some-> (f.file-management/force-get-document-text uri db*)
                      (parser/safe-zloc-of-string)
@@ -124,13 +123,13 @@
                                         z/node
                                         meta)
         element (if function-loc-row
-                  (q/find-element-under-cursor analysis filename function-loc-row function-loc-col)
+                  (q/find-element-under-cursor db filename function-loc-row function-loc-col)
                   (loop [try-column column]
-                    (if-let [usage (q/find-element-under-cursor analysis filename line try-column)]
+                    (if-let [usage (q/find-element-under-cursor db filename line try-column)]
                       usage
                       (when (pos? try-column)
                         (recur (dec try-column))))))
-        definition (when element (q/find-definition analysis element))]
+        definition (when element (q/find-definition db element))]
     (cond
       definition
       {:range (shared/->range element)

--- a/lib/src/clojure_lsp/feature/java_interop.clj
+++ b/lib/src/clojure_lsp/feature/java_interop.clj
@@ -250,7 +250,7 @@
       (= :jdk-already-installed result)
       (let [global-db (db/read-global-cache)]
         (swap! db* #(-> %
-                        (update :analysis merge (:analysis global-db))
+                        (lsp.kondo/db-with-analysis (:analysis global-db))
                         (update :analysis-checksums merge (:analysis-checksums global-db))))
         (logger/info java-logger-tag "JDK source cached loaded successfully."))
 

--- a/lib/src/clojure_lsp/feature/linked_editing_range.clj
+++ b/lib/src/clojure_lsp/feature/linked_editing_range.clj
@@ -7,7 +7,7 @@
 
 (defn ranges [uri row col db]
   (let [filename (shared/uri->filename uri)
-        elements (q/find-references-from-cursor (:analysis db) filename row col true)
+        elements (q/find-references-from-cursor db filename row col true)
         same-file-references-only? (= 1 (count (keys (group-by :filename elements))))]
     (if same-file-references-only?
       {:ranges (->> elements

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -98,9 +98,9 @@
         form-loc (edit/to-top zloc)
         analysis (:analysis db)
         source-filename (shared/uri->filename uri)
-        source-ns (:name (q/find-namespace-definition-by-filename analysis source-filename))
+        source-ns (:name (q/find-namespace-definition-by-filename db source-filename))
         dest-filename (shared/absolute-path dest-filename db)
-        dest-ns (:name (q/find-namespace-definition-by-filename analysis dest-filename))
+        dest-ns (:name (q/find-namespace-definition-by-filename db dest-filename))
         inner-usages (var-usages-within zloc uri db)
         ;; if source-ns things are used within the form
         ;; we can't move it

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -157,7 +157,7 @@
                                                                             local-analysis))
                                                 namespace-suggestions (f.add-missing-libspec/find-namespace-suggestions
                                                                         (str dest-ns)
-                                                                        (f.add-missing-libspec/find-alias-ns-pairs analysis uri))
+                                                                        (f.add-missing-libspec/find-alias-ns-pairs db uri))
                                                 suggestion (if dest-require
                                                              {:alias (str (:alias dest-require))}
                                                              (first namespace-suggestions))

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -20,9 +20,8 @@
 
 (defn var-usages-within [zloc uri db]
   (let [{:keys [col row end-row end-col]} (meta (z/node zloc))
-        analysis (:analysis db)
         defs (q/find-var-usages-under-form
-               analysis
+               db
                (shared/uri->filename uri)
                row
                col
@@ -122,7 +121,7 @@
                        single-def?)]
     (when can-move?
       (let [def-to-move (first defs)
-            refs (q/find-references analysis def-to-move false)
+            refs (q/find-references db def-to-move false)
             dest-refs (filter (comp #(= % dest-filename) :filename) refs)
             per-file-usages (group-by (comp #(shared/filename->uri % db) :filename) refs)
             dest-uri (shared/filename->uri dest-filename db)

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -32,11 +32,7 @@
       defs)))
 
 (defn var-definitions-within [zloc uri db]
-  (let [analysis (:analysis db)
-        defs (q/find-var-definitions
-               analysis
-               (shared/uri->filename uri)
-               false)]
+  (let [defs (q/find-var-definitions db (shared/uri->filename uri) false)]
     (filterv
       #(edit/loc-encapsulates-usage? zloc %)
       defs)))

--- a/lib/src/clojure_lsp/feature/rename.clj
+++ b/lib/src/clojure_lsp/feature/rename.clj
@@ -192,11 +192,11 @@
 (defn prepare-rename
   [uri row col db]
   (let [filename (shared/uri->filename uri)
-        element (q/find-element-under-cursor (:analysis db) filename row col)]
+        element (q/find-element-under-cursor db filename row col)]
     (if-not element
       error-no-element
-      (let [references (q/find-references (:analysis db) element true)
-            definition (q/find-definition (:analysis db) element)
+      (let [references (q/find-references db element true)
+            definition (q/find-definition db element)
             source-paths (settings/get db [:source-paths])
             client-capabilities (:client-capabilities db)
             {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
@@ -206,8 +206,8 @@
 
 (defn rename-element [uri new-name db* filename element source]
   (let [db @db*
-        references (q/find-references (:analysis db) element true)
-        definition (q/find-definition (:analysis db) element)
+        references (q/find-references db element true)
+        definition (q/find-definition db element)
         source-paths (settings/get db [:source-paths])
         client-capabilities (:client-capabilities db)
         {:keys [error] :as result} (rename-status element definition references source-paths client-capabilities)]
@@ -239,7 +239,7 @@
   [uri new-name row col db*]
   (let [db @db*
         filename (shared/uri->filename uri)
-        element (q/find-element-under-cursor (:analysis db) filename row col)]
+        element (q/find-element-under-cursor db filename row col)]
     (if-not element
       error-no-element
       (rename-element uri new-name db* filename element :rename))))

--- a/lib/src/clojure_lsp/feature/rename.clj
+++ b/lib/src/clojure_lsp/feature/rename.clj
@@ -44,7 +44,7 @@
         ;; we find the locals analysis since when destructuring we have both
         ;; keyword and a locals analysis for the same position
         local-element (when keys-destructuring
-                        (q/find-local-by-destructured-keyword (:analysis db) filename reference))
+                        (q/find-local-by-destructured-keyword db filename reference))
         text (cond
                (and local-element
                     (string/includes? (:str local-element) "/")

--- a/lib/src/clojure_lsp/feature/resolve_macro.clj
+++ b/lib/src/clojure_lsp/feature/resolve_macro.clj
@@ -33,8 +33,7 @@
 (defn find-full-macro-symbol-to-resolve [zloc uri db]
   (when-let [{macro-name-row :row macro-name-col :col} (find-function-name-position zloc)]
     (let [filename (shared/uri->filename uri)
-          analysis (:analysis db)
-          element (q/find-element-under-cursor analysis filename macro-name-row macro-name-col)]
+          element (q/find-element-under-cursor db filename macro-name-row macro-name-col)]
       (when (:macro element)
         (let [excluded-vars (get excluded-macros (:to element))]
           (when (and (not= excluded-vars '*)

--- a/lib/src/clojure_lsp/feature/signature_help.clj
+++ b/lib/src/clojure_lsp/feature/signature_help.clj
@@ -85,7 +85,7 @@
       (let [db @db*
             arglist-nodes (function-loc->arglist-nodes function-loc)
             function-meta (meta (z/node function-loc))
-            definition (q/find-definition-from-cursor (:analysis db) filename (:row function-meta) (:col function-meta))
+            definition (q/find-definition-from-cursor db filename (:row function-meta) (:col function-meta))
             signatures (definition->signature-informations definition)
             active-signature (get-active-signature-index definition arglist-nodes)]
         (when (seq signatures)

--- a/lib/src/clojure_lsp/feature/test_tree.clj
+++ b/lib/src/clojure_lsp/feature/test_tree.clj
@@ -35,7 +35,7 @@
 
 (defn tree [uri db]
   (let [filename (shared/uri->filename uri)
-        ns-element (q/find-namespace-definition-by-filename (:analysis db) filename)
+        ns-element (q/find-namespace-definition-by-filename db filename)
         local-analysis (get-in db [:analysis filename])
         deftests (into []
                        (filter #(and (identical? :var-definitions (:bucket %))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -238,7 +238,7 @@
         :selection-range (if namespace-definition
                            (shared/->scope-range namespace-definition)
                            shared/full-file-range)
-        :children (->> (q/find-var-definitions analysis filename true)
+        :children (->> (q/find-var-definitions db filename true)
                        (mapv (fn [e]
                                (shared/assoc-some
                                  {:name (-> e :name name)

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -228,9 +228,7 @@
     :document-symbol
     (let [db @db/db*
           filename (shared/uri->filename textDocument)
-          analysis (:analysis db)
-          namespace-definition (->> (get analysis filename)
-                                    (q/find-first (comp #{:namespace-definitions} :bucket)))]
+          namespace-definition (q/find-namespace-definition-by-filename db filename)]
       [{:name (or (some-> namespace-definition :name name)
                   filename)
         :kind (f.document-symbol/element->symbol-kind namespace-definition)

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -405,11 +405,8 @@
         from-name (when-not ns-only? (symbol (name from)))
         from-ns (if ns-only?
                   from
-                  (symbol (namespace from)))
-        project-db (q/db-with-project-analysis db)]
-    (if-let [from-element (if ns-only?
-                            (q/find-namespace-definition-by-namespace project-db from-ns)
-                            (q/find-element-by-full-name project-db from-name from-ns))]
+                  (symbol (namespace from)))]
+    (if-let [from-element (q/find-element-for-rename db from-ns from-name)]
       (let [uri (shared/filename->uri (:filename from-element) db)]
         (open-file! {:uri uri :namespace from-ns} components)
         (let [{:keys [error document-changes]} (f.rename/rename-from-position uri (str to) (:name-row from-element) (:name-col from-element) db*)]

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -406,10 +406,10 @@
         from-ns (if ns-only?
                   from
                   (symbol (namespace from)))
-        project-analysis (into {} q/filter-project-analysis-xf (:analysis db))]
+        project-db (q/db-with-project-analysis db)]
     (if-let [from-element (if ns-only?
-                            (q/find-namespace-definition-by-namespace project-analysis from-ns)
-                            (q/find-element-by-full-name project-analysis from-name from-ns))]
+                            (q/find-namespace-definition-by-namespace project-db from-ns)
+                            (q/find-element-by-full-name project-db from-name from-ns))]
       (let [uri (shared/filename->uri (:filename from-element) db)]
         (open-file! {:uri uri :namespace from-ns} components)
         (let [{:keys [error document-changes]} (f.rename/rename-from-position uri (str to) (:name-row from-element) (:name-col from-element) db*)]

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -15,7 +15,7 @@
     (.equals ^clojure.lang.Symbol a b)
     (.equals ^String a b)))
 
-(defn find-first [pred coll]
+(defn ^:private find-first [pred coll]
   (reduce
     (fn [_ i]
       (when (pred i)
@@ -612,7 +612,7 @@
     (:analysis db)))
 
 (defn find-namespace-definition-by-filename [db filename]
-  (peek (find-namespace-definitions db filename)))
+  (first (find-namespace-definitions db filename)))
 
 (defn find-namespace-usage-by-alias [db filename alias]
   (->> (get-in db [:analysis filename])

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -460,7 +460,7 @@
     (catch Throwable e
       (logger/error e "can't find references"))))
 
-(defn xf-var-defs [include-private?]
+(defn ^:private xf-var-defs [include-private?]
   (comp
     (filter #(and (identical? :var-definitions (:bucket %))
                   (or include-private?
@@ -510,7 +510,7 @@
                      (= (:name-end-col %) (:name-end-col keyword-element))))
        first))
 
-(def find-all-ns-definitions-xf
+(def ^:private find-all-ns-definitions-xf
   (comp
     (mapcat val)
     (filter #(identical? :namespace-definitions (:bucket %)))))
@@ -600,32 +600,32 @@
           (map :duplicate-ns))
         (get-in db [:findings filename])))
 
-(defn find-namespace-definitions [analysis filename]
+(defn find-namespace-definitions [db filename]
   (into []
         (filter #(identical? :namespace-definitions (:bucket %)))
-        (get analysis filename)))
+        (get-in db [:analysis filename])))
 
-(defn find-namespace-definition-by-namespace [analysis namespace]
+(defn find-namespace-definition-by-namespace [db namespace]
   (find-last-order-by-project-analysis
     #(and (identical? :namespace-definitions (:bucket %))
           (= (:name %) namespace))
-    analysis))
+    (:analysis db)))
 
-(defn find-namespace-definition-by-filename [analysis filename]
-  (peek (find-namespace-definitions analysis filename)))
+(defn find-namespace-definition-by-filename [db filename]
+  (peek (find-namespace-definitions db filename)))
 
-(defn find-namespace-usage-by-alias [analysis filename alias]
-  (->> (get analysis filename)
+(defn find-namespace-usage-by-alias [db filename alias]
+  (->> (get-in db [:analysis filename])
        (filter #(and (identical? :namespace-usages (:bucket %))
                      (= alias (:alias %))))
        last))
 
-(defn find-element-by-full-name [analysis name ns]
+(defn find-element-by-full-name [db name ns]
   (find-last-order-by-project-analysis
     #(and (identical? :var-definitions (:bucket %))
           (= ns (:ns %))
           (= name (:name %)))
-    analysis))
+    (:analysis db)))
 
 (def default-public-vars-defined-by-to-exclude
   '#{clojure.test/deftest

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -243,11 +243,10 @@
 
 (defn ^:private widest-scoped-local [zloc uri db]
   (let [z-meta (meta (z/node zloc))
-        analysis (:analysis db)
-        local-defs (->> (q/find-local-usages-under-form analysis
+        local-defs (->> (q/find-local-usages-under-form db
                                                         (shared/uri->filename uri)
                                                         z-meta)
-                        (map #(q/find-definition analysis %)))]
+                        (map #(q/find-definition db %)))]
     (reduce
       (fn [accum d]
         (if (or (not accum)
@@ -449,8 +448,8 @@
               {defn-col :col} (meta (z/node form-loc))
 
               fn-sym (symbol fn-name)
-              clj-analysis (unify-to-one-language (:analysis db))
-              used-syms (->> (q/find-local-usages-under-form clj-analysis
+              scoped-db (update db :analysis unify-to-one-language)
+              used-syms (->> (q/find-local-usages-under-form scoped-db
                                                              (shared/uri->filename uri)
                                                              expr-meta)
                              (mapv :name))
@@ -635,7 +634,7 @@
                            (z/right)))
         ;; Prepend locals to param lists.
         ;; We prepend because it works whether replacing with `partial` or `#()`.
-        used-locals (->> (q/find-local-usages-under-form (:analysis db)
+        used-locals (->> (q/find-local-usages-under-form db
                                                          (shared/uri->filename uri)
                                                          fn-form-meta)
                          (map :name))
@@ -733,9 +732,9 @@
 
 (defn inline-symbol
   [uri line column db]
-  (let [definition (q/find-definition-from-cursor (:analysis db) (shared/uri->filename uri) line column)]
+  (let [definition (q/find-definition-from-cursor db (shared/uri->filename uri) line column)]
     (when-let [op (inline-symbol? definition db)]
-      (let [references (q/find-references-from-cursor (:analysis db) (shared/uri->filename uri) line column false)
+      (let [references (q/find-references-from-cursor db (shared/uri->filename uri) line column false)
             def-uri    (shared/filename->uri (:filename definition) db)
             ;; TODO: use safe-zloc-of-file and handle nils
             def-loc    (some-> (parser/zloc-of-file db def-uri)
@@ -777,7 +776,7 @@
           z-name (name z-sexpr)
           z-ns (namespace z-sexpr)]
       (if-let [ns-usage (q/find-namespace-usage-by-alias (:analysis db) (shared/uri->filename uri) (symbol z-ns))]
-        (if-let [ns-def (q/find-definition (:analysis db) ns-usage)]
+        (if-let [ns-def (q/find-definition db ns-usage)]
           (when-not (:external? ns-def)
             {:ns (:name ns-def)
              :name z-name})
@@ -801,7 +800,7 @@
   [local-zloc ns-or-alias fn-name defn-edit uri db]
   (let [ns-usage (q/find-namespace-usage-by-alias (:analysis db) (shared/uri->filename uri) (symbol ns-or-alias))
         ns-definition (when ns-usage
-                        (q/find-definition (:analysis db) ns-usage))
+                        (q/find-definition db ns-usage))
         source-paths (settings/get db [:source-paths])
         def-uri (cond
                   ns-definition

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -775,7 +775,7 @@
     (let [z-sexpr (z/sexpr zloc)
           z-name (name z-sexpr)
           z-ns (namespace z-sexpr)]
-      (if-let [ns-usage (q/find-namespace-usage-by-alias (:analysis db) (shared/uri->filename uri) (symbol z-ns))]
+      (if-let [ns-usage (q/find-namespace-usage-by-alias db (shared/uri->filename uri) (symbol z-ns))]
         (if-let [ns-def (q/find-definition db ns-usage)]
           (when-not (:external? ns-def)
             {:ns (:name ns-def)
@@ -798,7 +798,7 @@
 
 (defn ^:private create-function-for-alias
   [local-zloc ns-or-alias fn-name defn-edit uri db]
-  (let [ns-usage (q/find-namespace-usage-by-alias (:analysis db) (shared/uri->filename uri) (symbol ns-or-alias))
+  (let [ns-usage (q/find-namespace-usage-by-alias db (shared/uri->filename uri) (symbol ns-or-alias))
         ns-definition (when ns-usage
                         (q/find-definition db ns-usage))
         source-paths (settings/get db [:source-paths])

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -21,7 +21,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :info}}}})
     (h/assert-submaps
@@ -38,7 +38,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :warning}}}})
     (h/assert-submaps
@@ -55,7 +55,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :error}}}})
     (h/assert-submaps
@@ -72,7 +72,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :off}}}})
     (h/assert-submaps
@@ -89,7 +89,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
@@ -106,7 +106,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns}}}}})
     (h/assert-submaps
@@ -116,7 +116,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'foo}}}}})
     (h/assert-submaps
@@ -126,7 +126,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns/foo}}}}})
     (h/assert-submaps
@@ -136,7 +136,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/b.clj"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
@@ -146,7 +146,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/c.cljs"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
@@ -171,7 +171,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/d.cljs"
-      (:analysis @db/db*)
+      @db/db*
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps [] @findings)))

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -50,7 +50,7 @@
 
 (deftest outgoing-reference-filenames
   (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
-                                  :project-root-uri (h/file-uri "file:///")})
+                                   :project-root-uri (h/file-uri "file:///")})
   (h/load-code-and-locs (h/code "(ns a)"
                                 "(def a)"
                                 "(def b)") (h/file-uri "file:///src/a.clj"))
@@ -58,16 +58,13 @@
                                 "(def x)"
                                 "a/a"
                                 "a/a") (h/file-uri "file:///src/b.clj"))
-  (let [analysis-before (get-in @db/db* [:analysis "/src/b.clj"])]
+  (let [db-before @db/db*]
     (are [expected new-code]
          (do
            (h/load-code-and-locs new-code (h/file-uri "file:///src/b.clj"))
-           (let [analysis-after (get-in @db/db* [:analysis "/src/b.clj"])]
+           (let [db-after @db/db*]
              (is (= expected
-                    (f.file-management/reference-filenames "/src/b.clj"
-                                                           analysis-before
-                                                           analysis-after
-                                                           @db/db*)))))
+                    (f.file-management/reference-filenames "/src/b.clj" db-before db-after)))))
       ;; increasing
       #{"/src/a.clj"} (h/code "(ns b (:require [a]))"
                               "(def x)"
@@ -107,23 +104,20 @@
 
 (deftest incoming-reference-filenames
   (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
-                                  :project-root-uri (h/file-uri "file:///")})
+                                   :project-root-uri (h/file-uri "file:///")})
   (h/load-code-and-locs (h/code "(ns a)"
                                 "(def a)"
                                 "(def b)") (h/file-uri "file:///src/a.clj"))
   (h/load-code-and-locs (h/code "(ns b (:require [a]))"
                                 "a/a"
                                 "a/c") (h/file-uri "file:///src/b.clj"))
-  (let [analysis-before (get-in @db/db* [:analysis "/src/a.clj"])]
+  (let [db-before @db/db*]
     (are [expected new-code]
          (do
            (h/load-code-and-locs new-code (h/file-uri "file:///src/a.clj"))
-           (let [analysis-after (get-in @db/db* [:analysis "/src/a.clj"])]
+           (let [db-after @db/db*]
              (is (= expected
-                    (f.file-management/reference-filenames "/src/a.clj"
-                                                           analysis-before
-                                                           analysis-after
-                                                           @db/db*)))))
+                    (f.file-management/reference-filenames "/src/a.clj" db-before db-after)))))
       ;; remove existing
       #{"/src/b.clj"} (h/code "(ns a)"
                               "(def b)")

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -68,19 +68,19 @@
          [param-r param-c]
          [x-r x-c]
          [unknown-r unknown-c]] (h/load-code-and-locs code)
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submap
       '{:alias f-alias}
-      (q/find-element-under-cursor ana (h/file-path "/a.clj") alias-r alias-c))
+      (q/find-element-under-cursor db (h/file-path "/a.clj") alias-r alias-c))
     (h/assert-submap
       '{:name x}
-      (q/find-element-under-cursor ana (h/file-path "/a.clj") x-r x-c))
+      (q/find-element-under-cursor db (h/file-path "/a.clj") x-r x-c))
     (h/assert-submap
       '{:name filename}
-      (q/find-element-under-cursor ana (h/file-path "/a.clj") param-r param-c))
+      (q/find-element-under-cursor db (h/file-path "/a.clj") param-r param-c))
     (h/assert-submap
       '{:name unknown}
-      (q/find-element-under-cursor ana (h/file-path "/a.clj") unknown-r unknown-c))))
+      (q/find-element-under-cursor db (h/file-path "/a.clj") unknown-r unknown-c))))
 
 (deftest find-references-from-cursor
   (let [a-code (h/code "(ns a.b.c (:require [d.e.f :as |f-alias]))"
@@ -103,34 +103,34 @@
          [b-baz-kw-r b-baz-kw-c]] (h/load-code-and-locs (h/code "(ns baz)"
                                                                 "|::foo/foo-kw"
                                                                 "|::baz-kw") (h/file-uri "file:///baz.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") x-r x-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.clj") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") param-r param-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.clj") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.clj") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") alias-r alias-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.clj") alias-r alias-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-foo-kw-r :name-col a-foo-kw-c}
        {:name "foo-kw" :name-row b-foo-kw-r :name-col b-foo-kw-c}
        {:name "foo-kw" :name-row d-foo-kw-r :name-col d-foo-kw-c}
        {:name "foo-kw" :name-row c-foo-kw-r :name-col c-foo-kw-c}]
-      (q/find-references-from-cursor ana (h/file-path "/c.clj") b-foo-kw-r b-foo-kw-c true))
+      (q/find-references-from-cursor db (h/file-path "/c.clj") b-foo-kw-r b-foo-kw-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-baz-kw-r :name-col a-baz-kw-c :ns :clj-kondo/unknown-namespace}]
-      (q/find-references-from-cursor ana (h/file-path "/baz.clj") a-baz-kw-r a-baz-kw-c true))
+      (q/find-references-from-cursor db (h/file-path "/baz.clj") a-baz-kw-r a-baz-kw-c true))
     (h/assert-submaps
       [{:name "baz-kw" :name-row b-baz-kw-r :name-col b-baz-kw-c :ns 'baz}]
-      (q/find-references-from-cursor ana (h/file-path "/baz.clj") b-baz-kw-r b-baz-kw-c true))))
+      (q/find-references-from-cursor db (h/file-path "/baz.clj") b-baz-kw-r b-baz-kw-c true))))
 
 (deftest find-references-from-cursor-cljc
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -143,22 +143,22 @@
          [alias-use-r alias-use-c]
          [x-use-r x-use-c]
          [unknown-r unknown-c]] (h/load-code-and-locs code (h/file-uri "file:///a.cljc"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") x-r x-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.cljc") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") param-r param-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.cljc") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") unknown-r unknown-c true))
+      (q/find-references-from-cursor db (h/file-path "/a.cljc") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.cljc") alias-r alias-c true))))
+      (q/find-references-from-cursor db (h/file-path "/a.cljc") alias-r alias-c true))))
 
 (deftest find-references-from-namespace-definition
   (let [[[ns-def-r ns-def-c]] (h/load-code-and-locs (h/code "(ns |some.cool-ns) (def foo 1)"))
@@ -179,14 +179,14 @@
     (testing "from ns definition"
       (h/assert-submaps
         common-references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") ns-def-r ns-def-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") ns-def-r ns-def-c false)))
     (testing "Including definition"
       (h/assert-submaps
         (concat [{:filename (h/file-path "/a.clj")
                   :name 'some.cool-ns
                   :bucket :namespace-definitions}]
                 common-references)
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") ns-def-r ns-def-c true)))))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") ns-def-r ns-def-c true)))))
 
 (deftest find-references-from-namespace-usage
   (let [_ (h/load-code-and-locs (h/code "(ns some.cool-ns) (def foo 1)"))
@@ -206,7 +206,7 @@
           :from 'another.cool-ns
           :name "bar"
           :ns 'some.cool-ns}]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") usage-r usage-c false)))))
+        (q/find-references-from-cursor @db/db* (h/file-path "/b.clj") usage-r usage-c false)))))
 
 (deftest find-references-from-defrecord
   (let [code (str "(defrecord |MyRecord [])\n"
@@ -217,12 +217,12 @@
          [raw-r raw-c]
          [to-r to-c]
          [map-to-r map-to-c]] (h/load-code-and-locs code (h/file-uri "file:///a.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submaps
       [{:name 'MyRecord :bucket :var-usages :name-row raw-r :name-col raw-c}
        {:name '->MyRecord :bucket :var-usages :name-row to-r :name-col to-c}
        {:name 'map->MyRecord :bucket :var-usages :name-row map-to-r :name-col map-to-c}]
-      (q/find-references-from-cursor ana (h/file-path "/a.clj") def-r def-c false))))
+      (q/find-references-from-cursor db (h/file-path "/a.clj") def-r def-c false))))
 
 (deftest find-references-excluding-function-different-arity
   (let [a-code (h/code "(ns a)"
@@ -238,7 +238,7 @@
         [[bar-def-r bar-def-c]
          [bar-usa-r bar-usa-c]] (h/load-code-and-locs a-code (h/file-uri "file:///a.clj"))
         [[bar-usa-b-r bar-usa-b-c]] (h/load-code-and-locs b-code (h/file-uri "file:///b.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (testing "from definition"
       (h/assert-submaps
         '[{:name-row 6
@@ -252,7 +252,7 @@
            :from b
            :name-col 4
            :from-var bar}]
-        (q/find-references-from-cursor ana (h/file-path "/a.clj") bar-def-r bar-def-c false)))
+        (q/find-references-from-cursor db (h/file-path "/a.clj") bar-def-r bar-def-c false)))
     (testing "from usage"
       (h/assert-submaps
         '[{:name-row 6
@@ -266,7 +266,7 @@
            :from b
            :name-col 4
            :from-var bar}]
-        (q/find-references-from-cursor ana (h/file-path "/a.clj") bar-usa-r bar-usa-c false)))
+        (q/find-references-from-cursor db (h/file-path "/a.clj") bar-usa-r bar-usa-c false)))
     (testing "from other ns"
       (h/assert-submaps
         '[{:name-row 6
@@ -280,7 +280,7 @@
            :from b
            :name-col 4
            :from-var bar}]
-        (q/find-references-from-cursor ana (h/file-path "/b.clj") bar-usa-b-r bar-usa-b-c false)))))
+        (q/find-references-from-cursor db (h/file-path "/b.clj") bar-usa-b-r bar-usa-b-c false)))))
 
 (deftest find-references-from-protocol-impl
   (h/load-code-and-locs (h/code "(ns a)"
@@ -313,7 +313,7 @@
          :row 9 :col 1 :end-row 9 :end-col 27
          :bucket :var-usages
          :to a}]
-      (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 7 9 false))))
+      (q/find-references-from-cursor @db/db* (h/file-path "/b.clj") 7 9 false))))
 
 (deftest find-references-for-defmulti
   (let [[[defmulti-r defmulti-c]]
@@ -349,15 +349,15 @@
     (testing "from defmulti method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") defmulti-r defmulti-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") defmulti-r defmulti-c false)))
     (testing "from defmethod method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") defmethod-r defmethod-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/b.clj") defmethod-r defmethod-c false)))
     (testing "from usage name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") usage-r usage-c false)))))
+        (q/find-references-from-cursor @db/db* (h/file-path "/b.clj") usage-r usage-c false)))))
 
 (deftest find-references-for-defmulti-without-usages
   (let [[[defmulti-r defmulti-c]]
@@ -381,11 +381,11 @@
     (testing "from defmulti method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") defmulti-r defmulti-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") defmulti-r defmulti-c false)))
     (testing "from defmethod method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") defmethod-r defmethod-c false)))))
+        (q/find-references-from-cursor @db/db* (h/file-path "/b.clj") defmethod-r defmethod-c false)))))
 
 (deftest find-references-from-declare
   (let [[[declare-r declare-c]
@@ -405,15 +405,15 @@
     (testing "from declare"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") declare-r declare-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") declare-r declare-c false)))
     (testing "from def"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") def-r def-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") def-r def-c false)))
     (testing "from usage name"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") usage-r usage-c false)))))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") usage-r usage-c false)))))
 
 (deftest find-references-from-declare-without-usages
   (let [[[declare-r declare-c]
@@ -424,11 +424,11 @@
     (testing "from declare"
       (h/assert-submaps
         '[]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") declare-r declare-c false)))
+        (q/find-references-from-cursor @db/db* (h/file-path "/a.clj") declare-r declare-c false)))
     (testing "from def"
       (h/assert-submaps
         '[]
-        (q/find-references-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") def-r def-c false)))))
+        (q/find-references-from-cursor @db/db* (h/file-path "/b.clj") def-r def-c false)))))
 
 (deftest find-definition-from-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -442,75 +442,75 @@
          [x-use-r x-use-c]
          [unknown-r unknown-c]] (h/load-code-and-locs code)
         _ (h/load-code-and-locs "(ns d.e.f) (def foo 1)" (h/file-uri "file:///b.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submap
       {:name 'x :name-row x-r :name-col x-c}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") x-use-r x-use-c))
+      (q/find-definition-from-cursor db (h/file-path "/a.clj") x-use-r x-use-c))
     (h/assert-submap
       {:name 'filename :name-row param-r :name-col param-c}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") param-use-r param-use-c))
+      (q/find-definition-from-cursor db (h/file-path "/a.clj") param-use-r param-use-c))
     (is (= nil
-           (q/find-definition-from-cursor ana (h/file-path "/a.clj") unknown-r unknown-c)))
+           (q/find-definition-from-cursor db (h/file-path "/a.clj") unknown-r unknown-c)))
     (h/assert-submap
       {:name 'foo :filename (h/file-path "/b.clj") :ns 'd.e.f}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-use-r alias-use-c))
+      (q/find-definition-from-cursor db (h/file-path "/a.clj") alias-use-r alias-use-c))
     (h/assert-submap
       {:name 'd.e.f :bucket :namespace-definitions}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") alias-r alias-c))))
+      (q/find-definition-from-cursor db (h/file-path "/a.clj") alias-r alias-c))))
 
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
   (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
         _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "file:///a.clj"))
         [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                       "|f/bar") (h/file-uri "file:///b.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submap
       {:name 'bar :filename (h/file-path "/a.clj")}
-      (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
+      (q/find-definition-from-cursor db (h/file-path "/b.clj") bar-r bar-c))))
 
 (defn assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs []
   (testing "when on a clj file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.clj"))
-          ana (:analysis @db/db*)]
+          db @db/db*]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.clj") bar-r bar-c))))
+        (q/find-definition-from-cursor db (h/file-path "/b.clj") bar-r bar-c))))
   (testing "when on a cljs file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.cljs"))
-          ana (:analysis @db/db*)]
+          db @db/db*]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljs") bar-r bar-c))))
+        (q/find-definition-from-cursor db (h/file-path "/b.cljs") bar-r bar-c))))
   (testing "when on a cljc file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.cljc"))
-          ana (:analysis @db/db*)]
+          db @db/db*]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r bar-c))))
+        (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r bar-c))))
   (testing "when on a cljc file with multiple langs available"
     (let [[[bar-r-clj bar-c-clj]
            [bar-r-cljs bar-c-cljs]] (h/load-code-and-locs (h/code "(ns baz #?(:clj (:require [foo :as fc]) :cljs (:require [foo :as fs])))"
                                                                   "|fc/bar"
                                                                   "|fs/bar") (h/file-uri "file:///b.cljc"))
-          ana (:analysis @db/db*)]
+          db @db/db*]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r-clj bar-c-clj))
+        (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r-clj bar-c-clj))
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
-        (q/find-definition-from-cursor ana (h/file-path "/b.cljc") bar-r-cljs bar-c-cljs))))
+        (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r-cljs bar-c-cljs))))
   (testing "when a macro is require-macros on cljs, being the var-definition on a clj/cljc file."
     (h/clean-db!)
     (h/load-code-and-locs (h/code "(ns some.foo) (defmacro bar [& body] @body)") (h/file-uri "file:///some/foo.clj"))
     (h/load-code-and-locs (h/code "(ns some.foo (:require-macros [some.foo])) (def baz)") (h/file-uri "file:///some/foo.cljs"))
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns a (:require [some.foo :as f])) (f/|bar 1)") (h/file-uri "file:///a.cljs"))
-          ana (:analysis @db/db*)]
+          db @db/db*]
       (h/assert-submap
         {:name 'bar :filename (h/file-path "/some/foo.clj")}
-        (q/find-definition-from-cursor ana (h/file-path "/a.cljs") bar-r bar-c)))))
+        (q/find-definition-from-cursor db (h/file-path "/a.cljs") bar-r bar-c)))))
 
 (deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
   (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
@@ -528,18 +528,18 @@
                                   "(declare bar)"
                                   "(|bar)"
                                   "(defn bar [] 1)") (h/file-uri "file:///a.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submap
       {:name 'bar :filename (h/file-path "/a.clj") :defined-by 'clojure.core/defn :row 4}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c))))
+      (q/find-definition-from-cursor db (h/file-path "/a.clj") bar-r bar-c))))
 
 (deftest find-definition-from-namespace-alias
   (h/load-code-and-locs (h/code "(ns foo.bar) (def a 1)") (h/file-uri "file:///a.clj"))
   (let [[[foob-r foob-c]] (h/load-code-and-locs (h/code "(ns foo.baz (:require [foo.bar :as |foob]))") (h/file-uri "file:///b.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submap
       {:name-end-col 12 :name-end-row 1 :name-row 1 :name 'foo.bar :filename "/a.clj" :col 1 :name-col 5 :bucket :namespace-definitions :row 1}
-      (q/find-definition-from-cursor ana (h/file-path "/b.clj") foob-r foob-c))))
+      (q/find-definition-from-cursor db (h/file-path "/b.clj") foob-r foob-c))))
 
 (deftest find-definition-from-cursor-when-on-potemkin
   (h/load-code-and-locs (h/code "(ns foo.impl) (def bar)") (h/file-uri "file:///b.clj"))
@@ -548,10 +548,10 @@
                                   "  (:require [potemkin :refer [import-vars]]"
                                   "            [foo.impl]))"
                                   "(import-vars |impl/bar)") (h/file-uri "file:///a.clj"))
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (h/assert-submap
       {:name 'bar :filename (h/file-path "/b.clj") :defined-by 'clojure.core/def :row 1 :col 15}
-      (q/find-definition-from-cursor ana (h/file-path "/a.clj") bar-r bar-c))))
+      (q/find-definition-from-cursor db (h/file-path "/a.clj") bar-r bar-c))))
 
 ;; Uncoment after clj-kondo solves https://github.com/clj-kondo/clj-kondo/issues/1632
 #_(deftest find-definition-form-java-class-usage
@@ -563,7 +563,7 @@
                                                           "(|Foo.)") (h/file-uri "file:///a.clj"))]
         (h/assert-submap
           {} ;; TODO
-          (q/find-definition-from-cursor (:analysis @db/db) (h/file-path "/a.clj") foo-r foo-c @db/db)))))
+          (q/find-definition-from-cursor @db/db (h/file-path "/a.clj") foo-r foo-c @db/db)))))
 
 (deftest find-declaration-from-cursor
   (h/load-code-and-locs (h/code "(ns foo.baz) (def other 123)"))
@@ -579,7 +579,7 @@
                                       "|orange"
                                       "|other")
                               "file:///b.clj")
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (testing "from usage with alias"
       (h/assert-submap
         {:alias 'foob
@@ -587,7 +587,7 @@
          :bucket
          :namespace-alias
          :to 'foo.bar}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") something-r something-c)))
+        (q/find-declaration-from-cursor db (h/file-path "/b.clj") something-r something-c)))
     (testing "from usage with refer"
       (h/assert-submap
         '{:from sample
@@ -595,14 +595,14 @@
           :name orange
           :bucket :var-usages
           :refer true}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") orange-r orange-c)))
+        (q/find-declaration-from-cursor db (h/file-path "/b.clj") orange-r orange-c)))
     (testing "from usage with refer all"
       (h/assert-submap
         {:from 'sample
          :bucket
          :namespace-usages
          :name 'foo.baz}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.clj") other-r other-c)))))
+        (q/find-declaration-from-cursor db (h/file-path "/b.clj") other-r other-c)))))
 
 (deftest find-declaration-from-cursor-in-cljc
   (let [[[clj-ns-r clj-ns-c]
@@ -615,7 +615,7 @@
                                                 "#?(:clj foo/som|ething"
                                                 "   :cljs foo/som|ething)")
                                         "file:///b.cljc")
-        ana (:analysis @db/db*)]
+        db @db/db*]
     (testing "from clj usage"
       (h/assert-submap
         {:name 'foo
@@ -623,7 +623,7 @@
          :bucket :namespace-usages
          :row clj-ns-r
          :col clj-ns-c}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.cljc") clj-usage-r clj-usage-c)))
+        (q/find-declaration-from-cursor db (h/file-path "/b.cljc") clj-usage-r clj-usage-c)))
     (testing "from cljs usage"
       (h/assert-submap
         {:name 'foo
@@ -631,7 +631,7 @@
          :bucket :namespace-usages
          :row cljs-ns-r
          :col cljs-ns-c}
-        (q/find-declaration-from-cursor ana (h/file-path "/b.cljc") cljs-usage-r cljs-usage-c)))))
+        (q/find-declaration-from-cursor db (h/file-path "/b.cljc") cljs-usage-r cljs-usage-c)))))
 
 (deftest find-implementations-from-cursor-protocols
   (h/load-code-and-locs (h/code "(ns a)"
@@ -672,7 +672,7 @@
          :from-var make-foo
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 2 16)))
+      (q/find-implementations-from-cursor @db/db* (h/file-path "/a.clj") 2 16)))
   (testing "from protocol method definitions"
     (h/assert-submaps
       [{:impl-ns 'b
@@ -700,7 +700,7 @@
         :protocol-name 'Foo
         :filename "/b.clj"
         :bucket :protocol-impls}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 3 4)))
+      (q/find-implementations-from-cursor @db/db* (h/file-path "/a.clj") 3 4)))
   (testing "from implementation usage"
     (h/assert-submaps
       [{:impl-ns 'b
@@ -728,7 +728,7 @@
         :protocol-name 'Foo
         :filename "/b.clj"
         :bucket :protocol-impls}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 9 2))))
+      (q/find-implementations-from-cursor @db/db* (h/file-path "/b.clj") 9 2))))
 
 (deftest find-implementations-from-cursor-defmulti
   (h/load-code-and-locs (h/code "(ns a)"
@@ -760,7 +760,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/a.clj") 2 12)))
+      (q/find-implementations-from-cursor @db/db* (h/file-path "/a.clj") 2 12)))
   (testing "from defmethod declaration"
     (h/assert-submaps
       '[{:name foo
@@ -779,7 +779,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 2 13)))
+      (q/find-implementations-from-cursor @db/db* (h/file-path "/b.clj") 2 13)))
   (testing "from defmethod usage"
     (h/assert-submaps
       '[{:name foo
@@ -798,7 +798,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (:analysis @db/db*) (h/file-path "/b.clj") 8 2))))
+      (q/find-implementations-from-cursor @db/db* (h/file-path "/b.clj") 8 2))))
 
 (deftest find-unused-aliases
   (testing "clj"
@@ -951,7 +951,7 @@
           (h/load-code-and-locs "(ns a) (let [a 2 b 1] |(+ 2 b)| (- 2 a))")]
       (h/assert-submaps
         [{:name 'b}]
-        (q/find-local-usages-under-form (:analysis @db/db*) (h/file-path "/a.clj")
+        (q/find-local-usages-under-form @db/db* (h/file-path "/a.clj")
                                         {:row sum-pos-r, :col sum-pos-c
                                          :end-row sum-end-pos-r, :end-col sum-end-pos-c}))))
   (testing "inside defn"
@@ -960,6 +960,6 @@
           (h/load-code-and-locs "(ns a) (defn ab [b] |(let [a 1] (b a))|) (defn other [c] c)")]
       (h/assert-submaps
         [{:name 'b}]
-        (q/find-local-usages-under-form (:analysis @db/db*) (h/file-path "/a.clj")
+        (q/find-local-usages-under-form @db/db* (h/file-path "/a.clj")
                                         {:row let-pos-r, :col let-pos-c
                                          :end-row let-end-pos-r, :end-col let-end-pos-c})))))

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -805,144 +805,144 @@
     (testing "used require via alias"
       (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo")
       (is (= '#{}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.clj")))))
     (testing "used require via full-ns"
       (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo")
       (is (= '#{}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.clj")))))
     (testing "full-ns require"
       (h/load-code-and-locs "(ns a (:require [x] y)) foo")
       (is (= '#{}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.clj")))))
     (testing "single unused-alias"
       (h/load-code-and-locs "(ns a (:require [x :as f]))")
       (is (= '#{x}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.clj")))))
     (testing "used and unused aliases"
       (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o")
       (is (= '#{y bar}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj"))))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.clj"))))))
   (testing "cljc"
     (testing "used require via alias"
       (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.cljc")))))
     (testing "used require via full-ns"
       (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.cljc")))))
     (testing "full-ns require"
       (h/load-code-and-locs "(ns a (:require [x] y)) foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.cljc")))))
     (testing "single unused-alias"
       (h/load-code-and-locs "(ns a (:require [x :as f]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{x}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.cljc")))))
     (testing "used and unused aliases"
       (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o" (h/file-uri "file:///a.cljc"))
       (is (= '#{y bar}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.cljc")))))
     (testing "used alias in a reader conditional"
       (h/load-code-and-locs "(ns a (:require [y :as o] [x :as f])) #?(:clj f/foo)" (h/file-uri "file:///a.cljc"))
       (is (= '#{y}
-             (q/find-unused-aliases (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))))
+             (q/find-unused-aliases @db/db* (h/file-path "/a.cljc")))))))
 
 (deftest find-unused-refers
   (testing "clj"
     (testing "used require via refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo")
       (is (= '#{}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.clj")))))
     (testing "multiple used refers"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz")
       (is (= '#{}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.clj")))))
     (testing "single unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))")
       (is (= '#{x/foo}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.clj")))))
     (testing "multiple unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))")
       (is (= '#{x/foo x/bar}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.clj")))))
     (testing "multiple unused refer and used"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar")
       (is (= '#{x/foo x/baz}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj"))))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.clj"))))))
   (testing "cljc"
     (testing "used require via refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.cljc")))))
     (testing "multiple used refers"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.cljc")))))
     (testing "single unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{x/foo}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.cljc")))))
     (testing "multiple unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{x/foo x/bar}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.cljc")))))
     (testing "multiple unused refer and used"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar" (h/file-uri "file:///a.cljc"))
       (is (= '#{x/foo x/baz}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.cljc")))))
     (testing "used refer in a reader conditional"
       (h/load-code-and-locs "(ns a (:require [y :refer [o]] [x :refer [f]])) #?(:clj f)" (h/file-uri "file:///a.cljc"))
       (is (= '#{y/o}
-             (q/find-unused-refers (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))))
+             (q/find-unused-refers @db/db* (h/file-path "/a.cljc")))))))
 
 (deftest find-unused-imports
   (testing "clj"
     (testing "single used full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date)) Date.")
       (is (= '#{}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.clj")))))
     (testing "single unused full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date))")
       (is (= '#{java.util.Date}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.clj")))))
     (testing "multiple unused full imports"
       (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))")
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.clj")))))
     (testing "multiple unused package imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))")
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.clj")))))
     (testing "multiple unused and used imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime.")
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.clj"))))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.clj"))))))
   (testing "cljc"
     (testing "single used full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date)) Date." (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.cljc")))))
     (testing "single unused full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date))" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.cljc")))))
     (testing "multiple unused full imports"
       (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.cljc")))))
     (testing "multiple unused package imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.cljc")))))
     (testing "multiple unused and used imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime." (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.cljc")))))
     (testing "used import in a reader conditional"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) #?(:clj LocalTime.)" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (:analysis @db/db*) (:findings @db/db*) (h/file-path "/a.cljc")))))))
+             (q/find-unused-imports @db/db* (h/file-path "/a.cljc")))))))
 
 (deftest find-local-usages-under-cursor
   (testing "inside let"


### PR DESCRIPTION
This PR refactors the `queries` namespace so that its functions accept a `db` rather than `analysis`. In namespaces that do their own analysis filtering, it brings the db closer to the filters.

This change feels somewhat unmotivated, but it's the first step to storing more metadata in the db. With additional metadata, for example about the dependency graph [ref](https://github.com/clojure-lsp/clojure-lsp/issues/990), we'll be able to make the analysis filters more efficient, but only if we have access to the full db. These changes also hide a few small details, such as that queries that assist `clean-ns` actually rely more on diagnostics than analysis.

I discussed this PR with @ericdallo before submitting it. We agreed it would help minimize noise in the upcoming dep-graph-based queries PR.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
