### PR TITLE
Fix drag from a quoted symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Improve performance of find-declaration feature. #1021
   - Fix to avoid suggesting an alias from a clj file to a cljs file. #1024
   - Find references of namespace usages now find all namespace usages on project, not only the definition. #1022
+  - Fix drag from quoted symbols and other special nodes #969
 
 ## 2022.05.31-17.35.50
 

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -658,7 +658,33 @@
                                   " :c 3}")
                           (h/code "{:c 3"
                                   " |:a {:a/a 1"
-                                  "     :a/b 2}}"))))
+                                  "     :a/b 2}}")))
+  (testing "special nodes"
+    (assert-drag-backward (h/code "[|'b 1]")
+                          (h/code "[1 '|b]"))
+    (assert-drag-backward (h/code "[|@b 1]")
+                          (h/code "[1 @|b]"))
+    (assert-drag-backward (h/code "[|#=b 1]")
+                          (h/code "[1 #=|b]"))
+    (assert-drag-backward (h/code "[|^:foo 2 1]")
+                          (h/code "[1 ^|:foo 2]"))
+    (assert-drag-backward (h/code "[|#^:foo 2 1]")
+                          (h/code "[1 #^|:foo 2]"))
+    (assert-drag-backward (h/code "[|#my-macro 2 1]")
+                          (h/code "[1 #|my-macro 2]"))
+    (assert-drag-backward (h/code "[|`map 1]")
+                          (h/code "[1 `|map]"))
+    (assert-drag-backward (h/code "[|~two 1]")
+                          (h/code "[1 ~|two]"))
+    (assert-drag-backward (h/code "[|~@two 1]")
+                          (h/code "[1 ~@|two]"))
+    (assert-drag-backward (h/code "[|#'two 1]")
+                          (h/code "[1 #'|two]"))
+    (assert-drag-backward (h/code "[|#::foo {:b 2} 1]")
+                          (h/code "[1 #:|:foo {:b 2}]"))
+    ;; doesn't work, because uneval is treated as whitespace by rest of drag code
+    #_(assert-drag-backward (h/code "[|#_two 1]")
+                            (h/code "[1 #_|two]"))))
 
 (deftest drag-forward
   (testing "common cases"
@@ -1030,7 +1056,33 @@
                                  " |:c 3}")
                          (h/code "{|:c 3"
                                  " :a {:a/a 1"
-                                 "     :a/b 2}}"))))
+                                 "     :a/b 2}}")))
+  (testing "special nodes"
+    (assert-drag-forward (h/code "[2 |'b]")
+                         (h/code "['|b 2]"))
+    (assert-drag-forward (h/code "[2 |@b]")
+                         (h/code "[@|b 2]"))
+    (assert-drag-forward (h/code "[2 |#=b]")
+                         (h/code "[#=|b 2]"))
+    (assert-drag-forward (h/code "[2 |^:foo 1]")
+                         (h/code "[^|:foo 1 2]"))
+    (assert-drag-forward (h/code "[2 |#^:foo 1]")
+                         (h/code "[#^|:foo 1 2]"))
+    (assert-drag-forward (h/code "[2 |#my-macro 1]")
+                         (h/code "[#|my-macro 1 2]"))
+    (assert-drag-forward (h/code "[2 |`map]")
+                         (h/code "[`|map 2]"))
+    (assert-drag-forward (h/code "[2 |~one]")
+                         (h/code "[~|one 2]"))
+    (assert-drag-forward (h/code "[2 |~@one]")
+                         (h/code "[~@|one 2]"))
+    (assert-drag-forward (h/code "[2 |#'one]")
+                         (h/code "[#'|one 2]"))
+    (assert-drag-forward (h/code "[2 |#::foo {:a 1}]")
+                         (h/code "[#:|:foo {:a 1} 2]"))
+    ;; doesn't work, because uneval is treated as whitespace by rest of drag code
+    #_(assert-drag-forward (h/code "[2 |#_one]")
+                           (h/code "[#_|one 2]"))))
 
 ;; These are macros so test failures have the right line numbers
 (defmacro assert-no-erroneous-backwards [code]

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -682,7 +682,9 @@
                           (h/code "[1 #'|two]"))
     (assert-drag-backward (h/code "[|#::foo {:b 2} 1]")
                           (h/code "[1 #:|:foo {:b 2}]"))
-    ;; doesn't work, because uneval is treated as whitespace by rest of drag code
+    (assert-drag-backward (h/code "[|#\"re\" 1]")
+                          (h/code "[1 #|\"re\"]"))
+    ;; doesn't work, because uneval is treated as a comment by rest of drag code
     #_(assert-drag-backward (h/code "[|#_two 1]")
                             (h/code "[1 #_|two]"))))
 
@@ -1080,7 +1082,9 @@
                          (h/code "[#'|one 2]"))
     (assert-drag-forward (h/code "[2 |#::foo {:a 1}]")
                          (h/code "[#:|:foo {:a 1} 2]"))
-    ;; doesn't work, because uneval is treated as whitespace by rest of drag code
+    (assert-drag-forward (h/code "[2 |#\"re\"]")
+                         (h/code "[#|\"re\" 2]"))
+    ;; doesn't work, because uneval is treated as a comment by rest of drag code
     #_(assert-drag-forward (h/code "[2 |#_one]")
                            (h/code "[#_|one 2]"))))
 


### PR DESCRIPTION
Fixes drag from `[v '|q :kw]`. In this and similar cases, drag wouldn't do anything, making drag feel "stuck".

Fixes #969

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #969
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
