### PR TITLE
Improve hover element selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Fix to avoid suggesting an alias from a clj file to a cljs file. #1024
   - Find references of namespace usages now find all namespace usages on project, not only the definition. #1022
   - Fix drag from quoted symbols and other special nodes #969
+  - Improve element selected on `textDocument/hover`, showing the function being called instead of the closest element found backwards. #995
 
 ## 2022.05.31-17.35.50
 

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -1,10 +1,14 @@
 (ns clojure-lsp.feature.hover
   (:require
    [clojure-lsp.feature.clojuredocs :as f.clojuredocs]
+   [clojure-lsp.feature.file-management :as f.file-management]
+   [clojure-lsp.parser :as parser]
    [clojure-lsp.queries :as q]
+   [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
-   [clojure.string :as string]))
+   [clojure.string :as string]
+   [rewrite-clj.zip :as z]))
 
 (set! *warn-on-reflection* true)
 
@@ -108,14 +112,24 @@
         sym (cons {:language "clojure"
                    :value (str (if arity-on-same-line? sym-line sym))})))))
 
-(defn hover [filename line column db*]
+(defn hover [uri line column db*]
   (let [db @db*
         analysis (:analysis db)
-        element (loop [try-column column]
-                  (if-let [usage (q/find-element-under-cursor analysis filename line try-column)]
-                    usage
-                    (when (pos? try-column)
-                      (recur (dec try-column)))))
+        filename (shared/uri->filename uri)
+        zloc (some-> (f.file-management/force-get-document-text uri db*)
+                     (parser/safe-zloc-of-string)
+                     (parser/to-pos line column))
+        {function-loc-row :row
+         function-loc-col :col} (some-> (edit/find-function-usage-name-loc zloc)
+                                        z/node
+                                        meta)
+        element (if function-loc-row
+                  (q/find-element-under-cursor analysis filename function-loc-row function-loc-col)
+                  (loop [try-column column]
+                    (if-let [usage (q/find-element-under-cursor analysis filename line try-column)]
+                      usage
+                      (when (pos? try-column)
+                        (recur (dec try-column))))))
         definition (when element (q/find-definition analysis element))]
     (cond
       definition

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -371,9 +371,8 @@
 (defn hover [{:keys [textDocument position]} {:keys [db*]}]
   (shared/logging-task
     :hover
-    (let [[line column] (shared/position->line-column position)
-          filename (shared/uri->filename textDocument)]
-      (f.hover/hover filename line column db*))))
+    (let [[line column] (shared/position->line-column position)]
+      (f.hover/hover textDocument line column db*))))
 
 (defn signature-help [{:keys [textDocument position _context]}]
   (shared/logging-task

--- a/lib/test/clojure_lsp/features/hover_test.clj
+++ b/lib/test/clojure_lsp/features/hover_test.clj
@@ -35,7 +35,7 @@
                     {:language "clojure" :value sig}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
@@ -44,16 +44,16 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? true}
-                                            :client-capabilities nil})
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -63,16 +63,16 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
         (testing "hover arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:arity-on-same-line? true}}
-                                            :client-capabilities nil})
+                                                        :hover {:arity-on-same-line? true}}
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -82,30 +82,30 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
 
         (testing "hide-filename? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:hide-file-location? true
-                                                               :arity-on-same-line? false
-                                                               :clojuredocs false}}
-                                            :client-capabilities nil})
+                                                        :hover {:hide-file-location? true
+                                                                :arity-on-same-line? false
+                                                                :clojuredocs false}}
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value sym}
                     {:language "clojure" :value sig}
                     doc]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:hide-file-location? true
-                                                               :arity-on-same-line? false
-                                                               :clojuredocs false}}
-                                            :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
+                                                        :hover {:hide-file-location? true
+                                                                :arity-on-same-line? false
+                                                                :clojuredocs false}}
+                                             :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
                                   ""
                                   doc])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))))
 
     (testing "without docs"
       (let [sym "a/bar"
@@ -114,28 +114,28 @@
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:hide-file-location? false
-                                                               :arity-on-same-line? false
-                                                               :clojuredocs false}}
-                                            :client-capabilities nil})
+                                                        :hover {:hide-file-location? false
+                                                                :arity-on-same-line? false
+                                                                :clojuredocs false}}
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value sym}
                     {:language "clojure" :value sig}
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? true} :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -143,4 +143,4 @@
                     :value (join [start-code (str sym " " sig) end-code
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*))))))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*))))))))))


### PR DESCRIPTION
Fixes #995

This is an attempt to improve the element selected during hover, the current behavior select any valid analysis element found on the current row/col, if no one is found, it tries to find a valid element until the start of the row decreasing the col.
This works for  "most" cases, but it fails for some lisp cases where we want to have the hover information about the current function being called (Check the issue for more details).

### Impl

The approach done on this PR is to:
- Parse the code with rewrite-clj
- find the function being called (op) (same algh used on signature-function feature)
- use its location meta to find the element
- if something is not found/is nil, fallback to current algh.

### Concerns

1. The hover feature usually is quite fast as it only query analysis, now we are introducing the parse of a file with rewrite-clj (should we think about caching the text/version of rewrite-clj nodes?)

2. do we always want to show the current function being called on hover and not the current cursor element? I think so, but not sure I am missing some corner case

--- 

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
~- [ ] I updated documentation if applicable (`docs` folder)~
