### PR TITLE
Update to latest clj-nix

### DIFF
--- a/.github/workflows/update_deps-lock.yml
+++ b/.github/workflows/update_deps-lock.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: cachix/install-nix-action@v17
 
       - name: Update deps-lock
-        run: "nix run github:jlesquembre/clj-nix#deps-lock"
+        run: "nix run github:jlesquembre/clj-nix?ref=0.2.0#deps-lock"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.0.3

--- a/deps-lock.json
+++ b/deps-lock.json
@@ -1,5 +1,5 @@
 {
-  "lock-version": 2,
+  "lock-version": 3,
   "git-deps": [
     {
       "lib": "babashka/babashka.pods",
@@ -19,6 +19,7 @@
       "lib": "io.github.clojure/tools.build",
       "url": "https://github.com/clojure/tools.build.git",
       "rev": "ba1a2bf421838802e7bdefc541b41f57582e53b6",
+      "tag": "v0.8.2",
       "git-dir": "https/github.com/clojure/tools.build",
       "hash": "sha256-p8kdg9UmpUq+JeyxL+g5R0GwdcP7cOI6wZuJnXK9Y8I="
     }

--- a/flake.lock
+++ b/flake.lock
@@ -9,15 +9,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1654025848,
-        "narHash": "sha256-sBSbeFIH9zOWPgN8C24iKwICSdp2cp9YEmhINi7hL1E=",
+        "lastModified": 1655125606,
+        "narHash": "sha256-mnqND6/PZMug5Jr92adJcNmwS+XYtVvtKjuowK9A9ec=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "983813df50ad1ff075e393cfef02d1b2835c28a9",
+        "rev": "77302aa77afa25e24292aa54eec31e70caa4faf0",
         "type": "github"
       },
       "original": {
         "owner": "jlesquembre",
+        "ref": "0.2.0",
         "repo": "clj-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     clj-nix = {
-      url = "github:jlesquembre/clj-nix";
+      url = "github:jlesquembre/clj-nix?ref=0.2.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
In latest clj-nix, to add better support for maven snapshot version, I had to update the lock file format. Unfortunately, next time you run the update deps-lock workflow, the lock file and the clj-nix version will get out of sync. This PR solves that.
 
Also pins clj-nix to a specific version to avoid that problem in the future

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
