### PR TITLE
Waits for client to do rename before moving db data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Drag requests two smaller edits, instead of one large edit, potentially avoiding flicker. #1043
   - Drag is disabled between clauses, to avoid arbitrarily choosing one to move. #1030
   - Cursor doesn't move within dragged clause. #1029
+  - Avoid invalid cached analysis and document text after a rename. #1049
 
 ## 2022.05.31-17.35.50
 

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -260,13 +260,12 @@
 (defn did-save [uri db*]
   (swap! db* #(assoc-in % [:documents uri :saved-on-disk] true)))
 
-(defn will-rename-files [files db*]
-  (let [db @db*]
-    (->> files
-         (keep (fn [{:keys [oldUri newUri]}]
-                 (let [old-filename (shared/uri->filename oldUri)
-                       new-ns (shared/uri->namespace newUri db)
-                       ns-definition (q/find-namespace-definition-by-filename db old-filename)]
-                   (when ns-definition
-                     (f.rename/rename-element oldUri new-ns db* old-filename ns-definition :rename-file)))))
-         (reduce #(shared/deep-merge %1 %2) {:document-changes []}))))
+(defn will-rename-files [files db]
+  (->> files
+       (keep (fn [{:keys [oldUri newUri]}]
+               (let [old-filename (shared/uri->filename oldUri)
+                     new-ns (shared/uri->namespace newUri db)
+                     ns-definition (q/find-namespace-definition-by-filename db old-filename)]
+                 (when ns-definition
+                   (f.rename/rename-element oldUri new-ns db ns-definition :rename-file)))))
+       (reduce #(shared/deep-merge %1 %2) {:document-changes []})))

--- a/lib/src/clojure_lsp/feature/rename.clj
+++ b/lib/src/clojure_lsp/feature/rename.clj
@@ -3,7 +3,6 @@
    [clojure-lsp.queries :as q]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
-   [clojure.set :as set]
    [clojure.string :as string]))
 
 (set! *warn-on-reflection* true)
@@ -204,9 +203,8 @@
           result
           (shared/->range element))))))
 
-(defn rename-element [uri new-name db* filename element source]
-  (let [db @db*
-        references (q/find-references db element true)
+(defn rename-element [uri new-name db element source]
+  (let [references (q/find-references db element true)
         definition (q/find-definition db element)
         source-paths (settings/get db [:source-paths])
         client-capabilities (:client-capabilities db)
@@ -225,9 +223,6 @@
                  (not (identical? :namespace-alias (:bucket element)))
                  (not= :rename-file source))
           (let [new-uri (shared/namespace->uri replacement source-paths (:filename definition) db)]
-            (swap! db* (fn [db] (-> db
-                                    (update :documents #(set/rename-keys % {filename (shared/uri->filename new-uri)}))
-                                    (update :analysis #(set/rename-keys % {filename (shared/uri->filename new-uri)})))))
             (shared/client-changes (concat doc-changes
                                            [{:kind "rename"
                                              :old-uri uri
@@ -236,10 +231,9 @@
           (shared/client-changes doc-changes db))))))
 
 (defn rename-from-position
-  [uri new-name row col db*]
-  (let [db @db*
-        filename (shared/uri->filename uri)
+  [uri new-name row col db]
+  (let [filename (shared/uri->filename uri)
         element (q/find-element-under-cursor db filename row col)]
     (if-not element
       error-no-element
-      (rename-element uri new-name db* filename element :rename))))
+      (rename-element uri new-name db element :rename))))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -187,7 +187,7 @@
   (shared/logging-task
     :rename
     (let [[row col] (shared/position->line-column position)]
-      (f.rename/rename-from-position textDocument newName row col db/db*))))
+      (f.rename/rename-from-position textDocument newName row col @db/db*))))
 
 (defn definition [{:keys [textDocument position]} {:keys [db*]}]
   (shared/logging-task
@@ -482,7 +482,7 @@
 (defn will-rename-files [{:keys [files]} {:keys [db*]}]
   (shared/logging-task
     :will-rename-files
-    (f.file-management/will-rename-files files db*)))
+    (f.file-management/will-rename-files files @db*)))
 
 (defrecord ClojureLSPFeatureHandler [components*]
   feature-handler/ILSPFeatureHandler

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -409,23 +409,22 @@
     (if-let [from-element (q/find-element-for-rename db from-ns from-name)]
       (let [uri (shared/filename->uri (:filename from-element) db)]
         (open-file! {:uri uri :namespace from-ns} components)
-        (let [{:keys [error document-changes]} (f.rename/rename-from-position uri (str to) (:name-row from-element) (:name-col from-element) db*)]
+        (let [{:keys [error document-changes]} (f.rename/rename-from-position uri (str to) (:name-row from-element) (:name-col from-element) db)]
           (if document-changes
-            (let [db @db*]
-              (if-let [edits (->> document-changes
-                                  (pmap #(document-change->edit-summary % db))
-                                  (remove nil?)
-                                  seq)]
-                (if dry?
+            (if-let [edits (->> document-changes
+                                (pmap #(document-change->edit-summary % db))
+                                (remove nil?)
+                                seq)]
+              (if dry?
+                {:result-code 0
+                 :message (edits->diff-string edits options db)
+                 :edits edits}
+                (do
+                  (mapv #(apply-workspace-edit-summary! % db*) edits)
                   {:result-code 0
-                   :message (edits->diff-string edits options db)
-                   :edits edits}
-                  (do
-                    (mapv #(apply-workspace-edit-summary! % db*) edits)
-                    {:result-code 0
-                     :message (format "Renamed %s to %s" from to)
-                     :edits edits}))
-                {:result-code 1 :message "Nothing to rename"}))
+                   :message (format "Renamed %s to %s" from to)
+                   :edits edits}))
+              {:result-code 1 :message "Nothing to rename"})
             {:result-code 1 :message (format "Could not rename %s to %s. %s" from to (-> error :message))})))
       {:result-code 1 :message (format "Symbol %s not found in project" from)})))
 

--- a/lib/test/clojure_lsp/features/rename_test.clj
+++ b/lib/test/clojure_lsp/features/rename_test.clj
@@ -16,14 +16,14 @@
                                                    (h/file-uri "file:///a.cljc"))]
     (testing "should not rename plain keywords"
       (let [[row col] a-start
-            result (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col db/db*)]
+            result (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col @db/db*)]
         (is (= {:error {:code :invalid-params
                         :message "Can't rename, only namespaced keywords can be renamed."}}
                result))))
 
     (testing "should rename local in destructure but not keywords"
       (let [[row col] a-binding-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text "b" :range (h/->range a-binding-start a-binding-stop)}
                  {:new-text "b" :range (h/->range a-local-usage-start a-local-usage-stop)}]}
@@ -38,7 +38,7 @@
                            (h/file-uri "file:///b.cljc"))]
     (testing "renaming only the name"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":hello/bar" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":hello/bar" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":hello/bar" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -46,7 +46,7 @@
                changes))))
     (testing "renaming only the namespace"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/foo" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/foo" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":bye/foo" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -54,7 +54,7 @@
                changes))))
     (testing "renaming namespace and name"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/bar" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/bar" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":bye/bar" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -76,21 +76,21 @@
                                            (h/file-uri "file:///c.cljc"))]
     (testing "should rename local in destructure with ':' and keywords if namespaced"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/c" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/c" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":a/c" :range (h/->range a-start a-stop)}
                  {:new-text ":a/c" :range (h/->range a-binding-start a-binding-stop)}]}
                changes))))
     (testing "should rename local in destructure without ':' and keywords if namespaced"
       (let [[row col] b-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":c/e" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":c/e" row col @db/db*))]
         (is (= {(h/file-uri "file:///b.cljc")
                 [{:new-text ":c/e" :range (h/->range b-start b-stop)}
                  {:new-text "c/e" :range (h/->range b-binding-start b-binding-stop)}]}
                changes))))
     (testing "should rename local in destructure with namespace on :keys"
       (let [[row col] c-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///c.cljc") ":e/f" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///c.cljc") ":e/f" row col @db/db*))]
         (is (= {(h/file-uri "file:///c.cljc")
                 [{:new-text ":e/f" :range (h/->range c-start c-stop)}
                  {:new-text "f" :range (h/->range c-binding-start c-binding-stop)}]}
@@ -118,13 +118,13 @@
           (h/file-uri "file:///b.cljc"))]
     (testing "renaming keywords renames correctly namespaced maps as well"
       (let [[row col] a-b-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/g" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/g" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc") [{:new-text ":a/g" :range (h/->range a-b-start a-b-stop)}
                                                {:new-text ":g" :range (h/->range b-ns-start b-ns-stop)}]}
                changes))))
     (testing "renaming from aliased namespace to namespace"
       (let [[row col] h1-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":hello/world" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":hello/world" row col @db/db*))]
         (is (= {(h/file-uri "file:///b.cljc") [{:new-text ":hello/world" :range (h/->range h1-start h1-stop)}
                                                {:new-text ":hello/world" :range (h/->range h2-start h2-stop)}]}
                changes))))
@@ -145,7 +145,7 @@
     (h/assert-submap
       {:error {:code :invalid-params
                :message "Can't rename namespace, client does not support file renames."}}
-      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))
+      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))
   (testing "when client has document-changes capability but no valid source-paths"
     (h/clean-db!)
     (swap! db/db* shared/deep-merge
@@ -156,7 +156,7 @@
     (h/assert-submap
       {:error {:code :invalid-params
                :message "Can't rename namespace, invalid source-paths. Are project :source-paths configured correctly?"}}
-      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))
+      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))
   (testing "when source-paths are valid and client capabilities has document-changes"
     (h/clean-db!)
     (swap! db/db* shared/deep-merge
@@ -174,7 +174,7 @@
              {:kind "rename"
               :old-uri (h/file-uri "file:///my-project/src/foo/bar_baz.clj")
               :new-uri (h/file-uri "file:///my-project/src/foo/baz_qux.clj")}]}
-           (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))))
+           (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))))
 
 (deftest prepare-rename
   (testing "rename local var"


### PR DESCRIPTION
Instead of preemptively moving analysis and document within db, wait for the client to actually do the rename. When it does, it [should](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didRename) call `did-close` on the old file and `did-open` on the new file, which will remove the old file and add the document text and analysis for the new file.

Fixes #1049

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #1049
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
