### PR TITLE
Timeout integration tests after waiting 30s for server response

### DIFF
--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -195,3 +195,13 @@
                                      #(= method-str (:method %))
                                      :received-requests)]
     (:params msg)))
+
+(defn request-and-await-server-response! [client method body]
+  (let [resp (deref (send-request client method body)
+                    30000
+                    ::timeout)]
+    (if (= ::timeout resp)
+      (do
+        (log client :red "timeout waiting for server response to client request:" method)
+        (throw (ex-info "timeout waiting for server response to client request" {:method method :body body})))
+      resp)))

--- a/cli/integration-test/integration/lsp.clj
+++ b/cli/integration-test/integration/lsp.clj
@@ -43,7 +43,7 @@
   (client/send-notification *mock-client* method body))
 
 (defn request! [[method body]]
-  @(client/send-request *mock-client* method body))
+  (client/request-and-await-server-response! *mock-client* method body))
 
 (defn client-awaits-server-diagnostics [path]
   (client/await-server-diagnostics *mock-client* path))


### PR DESCRIPTION
Instead of letting the integration tests wait forever for a response from the server, this times them out after 30 seconds. This will provide some additional information in the logs about what the client was waiting for, helping to debug flaky tests. If 30 seconds isn't long enough for certain requests, we can either make the timeout longer, or make the timeout configurable per request.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
