### PR TITLE
Avoid blocking in go blocks

### DIFF
--- a/cli/build.clj
+++ b/cli/build.clj
@@ -66,7 +66,7 @@
   ((requiring-resolve 'deps-bin.impl.bin/build-bin)
    {:jar uber-file
     :name "clojure-lsp"
-    :jvm-opts (concat (:jvm-opts opts []) ["-Xmx2g" "-server"])
+    :jvm-opts (concat (:jvm-opts opts []) ["-Xmx2g" "-server" "-Dclojure.core.async.go-checking=true"])
     :skip-realign true}))
 
 (def prod-jar uber-aot)

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -142,9 +142,9 @@
         (concat (clj-depend-violations->diagnostics filename depend-level db))))))
 
 (defn sync-publish-diagnostics! [uri db]
-  (async/>!! db/diagnostics-chan
-             {:uri uri
-              :diagnostics (find-diagnostics uri db)}))
+  (async/put! db/diagnostics-chan
+              {:uri uri
+               :diagnostics (find-diagnostics uri db)}))
 
 (defn async-publish-diagnostics! [uri db]
   (if (#{:unit-test :api-test} (:env db)) ;; Avoid async on test which cause flakeness


### PR DESCRIPTION
Avoids using blocking operations (the !! ones) within go blocks, as this will block the limited number of threads dedicated to serving go blocks.

In some cases we switch to using the parking (!) versions, when we can make them visible from a `go`. 
These are the operations that look like they block, but actually free up the thread to do other work. (And are safe to use within a `go` block.)

In other cases, where we can't see the `go`, we switch from >!! and <!! to put! and take!. The earlier block while the later operate asynchronously. That is, >!! blocks the thread until the channel operation is done, and therefore is unsafe, whereas put! returns immediately, after enqueuing the operation to the background.

This PR also changes the debug build so that we get early warning of this problem.

- [x] We worked out that we were using the wrong core.async methods in discussions in #1058 
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
