### PR TITLE
Removes several blocking puts from file-management

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,4 +5,5 @@
                                       rewrite-clj.node]}}
  :lint-as {rewrite-clj.zip.subedit/edit->    clojure.core/->
            rewrite-clj.zip.subedit/subedit-> clojure.core/->
-           clojure-lsp.refactor.edit/my-defn clojure.core/defn}}
+           clojure-lsp.refactor.edit/my-defn clojure.core/defn
+           clojure-lsp.test-helper/let-mock-chans clojure.core/let}}

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -46,7 +46,7 @@
     (f.diagnostic/async-publish-diagnostics! uri @db*))
   (when allow-create-ns
     (when-let [create-ns-edits (create-ns-changes uri text @db*)]
-      (async/>!! db/edits-chan create-ns-edits))))
+      (async/put! db/edits-chan create-ns-edits))))
 
 (defn ^:private set-xor [a b]
   (into (set/difference a b)
@@ -213,9 +213,9 @@
                                   (assoc-in [:documents uri :v] version)
                                   (assoc-in [:documents uri :text] final-text)
                                   (update :processing-changes conj uri))))
-    (async/>!! db/current-changes-chan {:uri uri
-                                        :text final-text
-                                        :version version})))
+    (async/put! db/current-changes-chan {:uri uri
+                                         :text final-text
+                                         :version version})))
 
 (defn analyze-watched-created-files! [uris {:keys [db* producer]}]
   (let [filenames (map shared/uri->filename uris)
@@ -229,7 +229,7 @@
 (defn did-change-watched-files [changes db*]
   (doseq [{:keys [uri type]} changes]
     (case type
-      :created (async/>!! db/created-watched-files-chan uri)
+      :created (async/put! db/created-watched-files-chan uri)
       :changed (when (settings/get @db* [:compute-external-file-changes] true)
                  (shared/logging-task
                    :changed-watched-file

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -4,7 +4,6 @@
    [clojure-lsp.feature.file-management :as f.file-management]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
-   [clojure.core.async :as async]
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as medley]))
 
@@ -27,26 +26,89 @@
   (h/load-code-and-locs "(ns bar) d e f" (h/file-uri "file:///user/project/src/clj/bar.clj"))
   (h/load-code-and-locs "(ns some-jar)" (h/file-uri "file:///some/path/to/jar.jar:/some/file.clj"))
   (testing "when file exists on disk"
-    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-    (with-redefs [shared/file-exists? (constantly true)]
-      (f.file-management/did-close "file:///user/project/src/clj/foo.clj" db/db*))
-    (is (get-in @db/db* [:analysis "/user/project/src/clj/foo.clj"]))
-    (is (get-in @db/db* [:findings "/user/project/src/clj/foo.clj"]))
-    (is (get-in @db/db* [:documents "file:///user/project/src/clj/foo.clj"])))
+    (h/let-mock-chans
+      [mock-diagnostics-chan #'db/diagnostics-chan]
+      (with-redefs [shared/file-exists? (constantly true)]
+        (f.file-management/did-close "file:///user/project/src/clj/foo.clj" db/db*))
+      (is (get-in @db/db* [:analysis "/user/project/src/clj/foo.clj"]))
+      (is (get-in @db/db* [:findings "/user/project/src/clj/foo.clj"]))
+      (is (get-in @db/db* [:documents "file:///user/project/src/clj/foo.clj"]))
+      (h/assert-no-take mock-diagnostics-chan 500)))
   (testing "when local file not exists on disk"
-    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-    (with-redefs [shared/file-exists? (constantly false)]
-      (f.file-management/did-close "file:///user/project/src/clj/bar.clj" db/db*))
-    (is (nil? (get-in @db/db* [:analysis "/user/project/src/clj/bar.clj"])))
-    (is (nil? (get-in @db/db* [:findings "/user/project/src/clj/bar.clj"])))
-    (is (nil? (get-in @db/db* [:documents "file:///user/project/src/clj/bar.clj"]))))
+    (h/let-mock-chans
+      [mock-diagnostics-chan #'db/diagnostics-chan]
+      (with-redefs [shared/file-exists? (constantly false)]
+        (f.file-management/did-close "file:///user/project/src/clj/bar.clj" db/db*))
+      (is (nil? (get-in @db/db* [:analysis "/user/project/src/clj/bar.clj"])))
+      (is (nil? (get-in @db/db* [:findings "/user/project/src/clj/bar.clj"])))
+      (is (nil? (get-in @db/db* [:documents "file:///user/project/src/clj/bar.clj"])))
+      (is (= {:uri "file:///user/project/src/clj/bar.clj"
+              :diagnostics []}
+             (h/take-or-timeout mock-diagnostics-chan 500)))))
   (testing "when file is external we do not remove analysis"
-    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-    (with-redefs [shared/file-exists? (constantly false)]
-      (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" db/db*))
-    (is (get-in @db/db* [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
-    (is (get-in @db/db* [:findings "/some/path/to/jar.jar:/some/file.clj"]))
-    (is (get-in @db/db* [:documents "file:///some/path/to/jar.jar:/some/file.clj"]))))
+    (h/let-mock-chans
+      [mock-diagnostics-chan #'db/diagnostics-chan]
+      (with-redefs [shared/file-exists? (constantly false)]
+        (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" db/db*))
+      (is (get-in @db/db* [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (get-in @db/db* [:findings "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (get-in @db/db* [:documents "file:///some/path/to/jar.jar:/some/file.clj"]))
+      (h/assert-no-take mock-diagnostics-chan 500))))
+
+(deftest did-open
+  (testing "on an empty file"
+    (h/let-mock-chans
+      [mock-edits-chan #'db/edits-chan
+       mock-diagnostics-chan #'db/diagnostics-chan]
+      (let [filename "/user/project/src/aaa/bbb.clj"
+            uri (h/file-uri (str "file://" filename))]
+        (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+                                                    :source-paths #{(h/file-path "/user/project/src")}}
+                                         :project-root-uri (h/file-uri "file:///user/project")})
+        (h/load-code-and-locs "" uri)
+        (is (get-in @db/db* [:analysis filename]))
+        (is (get-in @db/db* [:findings filename]))
+        (is (get-in @db/db* [:documents uri]))
+        (testing "should publish empty diagnostics"
+          (is (= {:uri uri, :diagnostics []}
+                 (h/take-or-timeout mock-diagnostics-chan 500))))
+        (testing "should add ns"
+          (is (= {:changes
+                  {uri
+                   [{:range
+                     {:start {:line 0, :character 0},
+                      :end {:line 999998, :character 999998}},
+                     :new-text "(ns aaa.bbb)"}]}}
+                 (h/take-or-timeout mock-edits-chan 500))))))))
+
+(deftest did-change
+  (h/let-mock-chans
+    [mock-changes-chan #'db/current-changes-chan]
+    (let [original-text (h/code "(ns aaa)"
+                                "(def foo 1)")
+          edited-text (h/code "(ns aaa)"
+                              "(def bar 1)")]
+      (h/load-code-and-locs original-text)
+      (f.file-management/did-change h/default-uri
+                                    [{:text "bar"
+                                      :range {:start {:line 1 :character 5}
+                                              :end {:line 1 :character 8}}}]
+                                    2
+                                    db/db*)
+      (is (= 2 (get-in @db/db* [:documents h/default-uri :v])))
+      (is (= edited-text (get-in @db/db* [:documents h/default-uri :text])))
+      (is (= {:uri h/default-uri, :text edited-text, :version 2}
+             (h/take-or-timeout mock-changes-chan 500))))))
+
+(deftest did-change-watched-files
+  (testing "created file"
+    (h/let-mock-chans
+      [mock-created-chan #'db/created-watched-files-chan]
+      (f.file-management/did-change-watched-files
+        [{:type :created
+          :uri h/default-uri}]
+        db/db*)
+      (is (= h/default-uri (h/take-or-timeout mock-created-chan 500))))))
 
 (deftest outgoing-reference-filenames
   (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}


### PR DESCRIPTION
Uses put! (async) instead of >!! (blocking). We don't need these calls to block, so better to let them be async.

Also refactors tests to have better tools for testing what gets put on chans.

Still to do:

- [ ] Create integration test for `did-change`
- [ ] Consider replacing `(go (>! ...))` with `(put! ...)` for all diagnostics publishing.
- [ ] Alternatively, the opposite, replace all `(put! ...)` with `(go (>! ...))`

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
