### PR TITLE
Revert "Improve hover element selected (#1045)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Editor
+  - Reverted #995 Improve element selected on `textDocument/hover`, as it caused clojure-lsp to stop working for Calva users after a syntax error was introduced. #1080
+
 ## 2022.06.22-14.09.50
 
 - General

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -368,8 +368,9 @@
 (defn hover [{:keys [textDocument position]} {:keys [db*]}]
   (shared/logging-task
     :hover
-    (let [[line column] (shared/position->line-column position)]
-      (f.hover/hover textDocument line column db*))))
+    (let [[line column] (shared/position->line-column position)
+          filename (shared/uri->filename textDocument)]
+      (f.hover/hover filename line column db*))))
 
 (defn signature-help [{:keys [textDocument position _context]}]
   (shared/logging-task

--- a/lib/test/clojure_lsp/features/hover_test.clj
+++ b/lib/test/clojure_lsp/features/hover_test.clj
@@ -35,7 +35,7 @@
                     {:language "clojure" :value sig}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
@@ -44,16 +44,16 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? true}
-                                             :client-capabilities nil})
+                                            :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -63,16 +63,16 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
         (testing "hover arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                        :hover {:arity-on-same-line? true}}
-                                             :client-capabilities nil})
+                                                       :hover {:arity-on-same-line? true}}
+                                            :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -82,30 +82,30 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
 
         (testing "hide-filename? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                        :hover {:hide-file-location? true
-                                                                :arity-on-same-line? false
-                                                                :clojuredocs false}}
-                                             :client-capabilities nil})
+                                                       :hover {:hide-file-location? true
+                                                               :arity-on-same-line? false
+                                                               :clojuredocs false}}
+                                            :client-capabilities nil})
             (is (= [{:language "clojure" :value sym}
                     {:language "clojure" :value sig}
                     doc]
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                        :hover {:hide-file-location? true
-                                                                :arity-on-same-line? false
-                                                                :clojuredocs false}}
-                                             :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
+                                                       :hover {:hide-file-location? true
+                                                               :arity-on-same-line? false
+                                                               :clojuredocs false}}
+                                            :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
                                   ""
                                   doc])}
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))))
 
     (testing "without docs"
       (let [sym "a/bar"
@@ -114,28 +114,28 @@
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                        :hover {:hide-file-location? false
-                                                                :arity-on-same-line? false
-                                                                :clojuredocs false}}
-                                             :client-capabilities nil})
+                                                       :hover {:hide-file-location? false
+                                                               :arity-on-same-line? false
+                                                               :clojuredocs false}}
+                                            :client-capabilities nil})
             (is (= [{:language "clojure" :value sym}
                     {:language "clojure" :value sig}
                     filename]
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? true} :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     filename]
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -143,4 +143,4 @@
                     :value (join [start-code (str sym " " sig) end-code
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*))))))))))
+                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*))))))))))


### PR DESCRIPTION
This reverts commit 54f895793bea90370bfc6da9674154ef07566033 and fixes #1080. 

This commit was causing clojure-lsp to stop working in Calva after introducing a syntax error. See #1080 and https://clojurians.slack.com/archives/CPABC1H61/p1656093769590509.

I plan to do more research on _why_ this commit broke Calva—it's not instantly obvious to me—but in the meantime, this PR can be used for testing, and could be merged if we want to release a quick fix.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #1080
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
