### PR TITLE
Revert "Revert "Improve hover element selected (#1045)" (#1083)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Editor
+ - Restored #995 Improve element selected on `textDocument/hover` (previously reverted) with a fix that keeps it working for Calva even after a syntax error is introduced.
+
 ## 2022.06.29-19.32.13
 
 - Editor

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -368,9 +368,8 @@
 (defn hover [{:keys [textDocument position]} {:keys [db*]}]
   (shared/logging-task
     :hover
-    (let [[line column] (shared/position->line-column position)
-          filename (shared/uri->filename textDocument)]
-      (f.hover/hover filename line column db*))))
+    (let [[line column] (shared/position->line-column position)]
+      (f.hover/hover textDocument line column db*))))
 
 (defn signature-help [{:keys [textDocument position _context]}]
   (shared/logging-task

--- a/lib/src/clojure_lsp/parser.clj
+++ b/lib/src/clojure_lsp/parser.clj
@@ -103,7 +103,7 @@
   (try
     (zloc-of-string text)
     (catch Exception _e
-      (println "It was not possible to parse text. Probably not valid clojure code."))))
+      (logger/warn "It was not possible to parse text. Probably not valid clojure code."))))
 
 (defn zloc-of-file [db uri]
   (zloc-of-string (get-in db [:documents uri :text])))
@@ -111,7 +111,7 @@
 (defn safe-zloc-of-file [db uri]
   (try
     (zloc-of-file db uri)
-    (catch Exception _
+    (catch Exception _e
       (logger/warn "It was not possible to parse file. Probably not valid clojure code."))))
 
 (defn to-pos [zloc row col]

--- a/lib/test/clojure_lsp/features/hover_test.clj
+++ b/lib/test/clojure_lsp/features/hover_test.clj
@@ -35,7 +35,7 @@
                     {:language "clojure" :value sig}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
@@ -44,16 +44,16 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? true}
-                                            :client-capabilities nil})
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -63,16 +63,16 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
         (testing "hover arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:arity-on-same-line? true}}
-                                            :client-capabilities nil})
+                                                        :hover {:arity-on-same-line? true}}
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     doc
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -82,30 +82,30 @@
                                   doc
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))
 
         (testing "hide-filename? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:hide-file-location? true
-                                                               :arity-on-same-line? false
-                                                               :clojuredocs false}}
-                                            :client-capabilities nil})
+                                                        :hover {:hide-file-location? true
+                                                                :arity-on-same-line? false
+                                                                :clojuredocs false}}
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value sym}
                     {:language "clojure" :value sig}
                     doc]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:hide-file-location? true
-                                                               :arity-on-same-line? false
-                                                               :clojuredocs false}}
-                                            :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
+                                                        :hover {:hide-file-location? true
+                                                                :arity-on-same-line? false
+                                                                :clojuredocs false}}
+                                             :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
                                   ""
                                   doc])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") foo-row foo-col db/db*))))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") foo-row foo-col db/db*))))))))
 
     (testing "without docs"
       (let [sym "a/bar"
@@ -114,28 +114,28 @@
         (testing "show-docs-arity-on-same-line? disabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? false
-                                                       :hover {:hide-file-location? false
-                                                               :arity-on-same-line? false
-                                                               :clojuredocs false}}
-                                            :client-capabilities nil})
+                                                        :hover {:hide-file-location? false
+                                                                :arity-on-same-line? false
+                                                                :clojuredocs false}}
+                                             :client-capabilities nil})
             (is (= [{:language "clojure" :value sym}
                     {:language "clojure" :value sig}
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*)))))
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
             (is (= {:kind  "markdown"
                     :value (join [start-code sym sig end-code
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*))))))
 
         (testing "show-docs-arity-on-same-line? enabled"
           (testing "plain"
             (swap! db/db* shared/deep-merge {:settings {:show-docs-arity-on-same-line? true} :client-capabilities nil})
             (is (= [{:language "clojure" :value (str sym " " sig)}
                     filename]
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*)))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*)))))
 
           (testing "markdown"
             (swap! db/db* shared/deep-merge {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
@@ -143,4 +143,4 @@
                     :value (join [start-code (str sym " " sig) end-code
                                   line-break
                                   (str "*[" filename "](file:///a.clj)*")])}
-                   (:contents (f.hover/hover (h/file-path "/a.clj") bar-row bar-col db/db*))))))))))
+                   (:contents (f.hover/hover (h/file-uri "file:///a.clj") bar-row bar-col db/db*))))))))))


### PR DESCRIPTION
This reverts commit 012323126d0a9bf5aee4a8a2aa2c1663be001f85, restoring #1045 while avoiding problems in Calva, problems documented in #1080 and discussed at length on [Slack](https://clojurians.slack.com/archives/CPABC1H61/p1656093769590509).

The new hover code introduced in #1045 was the first real use of `parser/safe-zloc-of-string`. (It was used only in tests before, though we had plans to use it elsewhere.)

But there was a subtle bug in `safe-zloc-of-string`. When there was a parse error, it didn’t log to the logfile, it **printed to stdout**.

So the new hover code accidentally caused a print to stdout when there was a syntax error in the file. This corrupted the server’s output stream permanently. From this moment on, Calva was waiting for the stream to contain a valid message, but it never would. In the meantime, clojure-lsp kept writing to the stream, but it didn’t matter, because Calva couldn’t process it.

Changing the `println` to `logger/warn` fixes the problem.

We suspect that this wasn't a problem in Emacs because lsp-mode does a better job detecting and discarding messages that don't conform to the JSON-RPC spec.

The longer term fix is to avoid ever printing to the stream that lsp4j is using. If we're going to use `System/out`, lsp4j needs to have sole control over when that stream is written to. To this end, we're planning a longer-term fix to lsp4clj. We'll wrap every call into clojure-lsp with `with-out-str`, to avoid having output leak through to the clients. We'll log any output we receive to the log file.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
