### PR TITLE
Remove safe-zloc-of-string

### DIFF
--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -116,7 +116,7 @@
   (let [db @db*
         filename (shared/uri->filename uri)
         zloc (some-> (f.file-management/force-get-document-text uri db*)
-                     (parser/safe-zloc-of-string)
+                     (parser/zloc-of-string)
                      (parser/to-pos line column))
         {function-loc-row :row
          function-loc-col :col} (some-> (edit/find-function-usage-name-loc zloc)

--- a/lib/src/clojure_lsp/feature/signature_help.clj
+++ b/lib/src/clojure_lsp/feature/signature_help.clj
@@ -77,7 +77,6 @@
 (defn signature-help [uri row col db*]
   (let [filename (shared/uri->filename uri)
         zloc (some-> (f.file-management/force-get-document-text uri db*)
-                     ;; TODO: use safe-zloc-of-string and handle nils
                      (parser/zloc-of-string)
                      (parser/to-pos row col))
         function-loc (edit/find-function-usage-name-loc zloc)]

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -275,7 +275,7 @@
      :client-settings (:client-settings db-value)
      :final-settings (settings/all db-value)
      :cljfmt-raw (binding [*print-meta* true]
-                   (with-out-str (pr (f.format/resolve-user-cljfmt-config db-value))))
+                   (pr-str (f.format/resolve-user-cljfmt-config db-value)))
      :port (or (:port db-value)
                "NREPL only available on :debug profile (`make debug-cli`)")
      :server-version (shared/clojure-lsp-version)

--- a/lib/src/clojure_lsp/parser.clj
+++ b/lib/src/clojure_lsp/parser.clj
@@ -98,13 +98,6 @@
           (handle-single-colon-code text e)
           (throw e)))))
 
-(defn safe-zloc-of-string [text]
-  ;; TODO: only used by tests.
-  (try
-    (zloc-of-string text)
-    (catch Exception _e
-      (logger/warn "It was not possible to parse text. Probably not valid clojure code."))))
-
 (defn zloc-of-file [db uri]
   (zloc-of-string (get-in db [:documents uri :text])))
 

--- a/lib/test/clojure_lsp/parser_test.clj
+++ b/lib/test/clojure_lsp/parser_test.clj
@@ -7,8 +7,8 @@
 
 (h/reset-db-after-test)
 
-(deftest safe-zloc-of-string
-  (are [s] (= s (z/root-string (parser/safe-zloc-of-string s)))
+(deftest zloc-of-string
+  (are [s] (= s (z/root-string (parser/zloc-of-string s)))
     "(ns foo) foo/bar"
     "(ns foo) foo/ (+ 1 2)"
     "(ns foo) foo/\n(+ 1 2)"
@@ -25,7 +25,7 @@
     "(ns foo)\n::foo/\n"))
 
 (defn to-pos [s row col]
-  (-> s parser/safe-zloc-of-string (parser/to-pos row col) z/string))
+  (-> s parser/zloc-of-string (parser/to-pos row col) z/string))
 
 (deftest to-pos-test
   (testing "complete code"


### PR DESCRIPTION
This removes `safe-zloc-of-string`. If code needs a zloc, but the file has a syntax error, it's acceptable to short-circuit by throwing an exception. None of the current code needs to continue anyway. This formalizes that notion by removing the 'safe' version of parsing, allowing exceptions to be raised. The 'safe' version wasn't used anyway except by tests and one new codepath, all of which are actually fine with using the 'unsafe' version.

Getting rid of this nearly-dead code is a post-mortem TODO item from #1087. As usual with dead code, it's best to remove so that nobody accidentally starts using something that hasn't been reviewed recently and which may not be fully up to date. That was the case with #1087—a long time ago a bug was introduced in `safe-zloc-of-string`, where it printed to stdout instead of logging. Nobody noticed that until some new code started using `safe-zloc-of-string`. The long passage of time between changing `safe-zloc-of-string` and finally starting to use it made it very hard to track down as the root cause of #1087.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
