### PR TITLE
Extend tests of file-management

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,4 +5,5 @@
                                       rewrite-clj.node]}}
  :lint-as {rewrite-clj.zip.subedit/edit->    clojure.core/->
            rewrite-clj.zip.subedit/subedit-> clojure.core/->
-           clojure-lsp.refactor.edit/my-defn clojure.core/defn}}
+           clojure-lsp.refactor.edit/my-defn clojure.core/defn
+           clojure-lsp.test-helper/let-mock-chans clojure.core/let}}

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -10,6 +10,7 @@
     integration.definition-test
     integration.declaration-test
     integration.implementation-test
+    integration.text-change-test
     integration.code-action-test
     integration.completion-test
     integration.diagnostics-test
@@ -36,8 +37,8 @@
       (future-cancel fut))
     ret))
 
-(defn log-tail []
-  (:out (sh/sh "tail" "-n" "300" "clojure-lsp.integration-test.out" :dir "integration-test/sample-test/")))
+(defn log-tail [file lines]
+  (:out (sh/sh "tail" "-n" (str lines) file :dir "integration-test/sample-test/")))
 
 (def first-print-log-tail?* (atom true))
 
@@ -45,15 +46,18 @@
   (when (medley/deref-reset! first-print-log-tail?* false)
     (binding [*out* *err*]
       (println "--- RECENT LOG OUTPUT ---")
-      (print (log-tail))
-      (println "--- END RECENT LOG OUTPUT ---"))))
+      (print (log-tail "clojure-lsp.integration-test.out" 300))
+      (println "--- END RECENT LOG OUTPUT ---")
+      #_(println "--- LSP TRACE ---")
+      #_(print (log-tail "clojure-lsp.lsp-trace.out" 500))
+      #_(println "--- END LSP TRACE ---"))))
 
 (declare ^:dynamic original-report)
 
 (defn log-tail-report [data]
+  (original-report data)
   (when (contains? #{:fail :error} (:type data))
-    (print-log-tail!))
-  (original-report data))
+    (print-log-tail!)))
 
 (defmacro with-log-tail-report
   "Execute body with modified test reporting functions that prints log tail on failure."

--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -83,6 +83,11 @@
     :context      {:diagnostics []}
     :range        {:start {:line row :character col}}}])
 
+(defn hover-request [path row col]
+  [:textDocument/hover
+   {:textDocument {:uri (h/source-path->uri path)}
+    :position     {:line row :character col}}])
+
 (defn execute-command-request [command & args]
   [:workspace/executeCommand
    {:command   command
@@ -110,3 +115,13 @@
        :languageId "clojure"
        :version 0
        :text text}}]))
+
+(defn did-change-notification [path version changes]
+  [:textDocument/didChange
+   {:textDocument {:uri (h/source-path->uri path)
+                   :version version}
+    :contentChanges (map (fn [[text start-row start-col end-row end-col]]
+                           {:text text
+                            :range {:start {:line start-row :character start-col}
+                                    :end {:line end-row :character end-col}}})
+                         changes)}])

--- a/cli/integration-test/integration/text_change_test.clj
+++ b/cli/integration-test/integration/text_change_test.clj
@@ -1,0 +1,29 @@
+(ns integration.text-change-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [integration.fixture :as fixture]
+   [integration.lsp :as lsp]))
+
+(def sample-file-path "text_change/a.clj")
+
+(lsp/clean-after-test)
+
+(deftest apply-changes
+  (lsp/start-process!)
+  (lsp/request! (fixture/initialize-request))
+  (lsp/notify! (fixture/initialized-notification))
+  (lsp/notify! (fixture/did-open-notification sample-file-path))
+
+  (testing "Change is applied"
+    (is (= "original"
+           (-> (lsp/request! (fixture/hover-request sample-file-path 4 2))
+               :contents
+               (get 2))))
+
+    (lsp/notify! (fixture/did-change-notification sample-file-path 1 [["changed" 2 11 2 19]]))
+    (lsp/client-awaits-server-diagnostics sample-file-path)
+
+    (is (= "changed"
+           (-> (lsp/request! (fixture/hover-request sample-file-path 4 2))
+               :contents
+               (get 2))))))

--- a/cli/integration-test/sample-test/src/sample_test/linked_editing_range/a.cljc
+++ b/cli/integration-test/sample-test/src/sample_test/linked_editing_range/a.cljc
@@ -1,4 +1,4 @@
-(ns sample-test.src.sample-test.linked-editing-range.a)
+(ns sample-test.linked-editing-range.a)
 
 (defn foo [some other]
   (let [c (+ some other)]

--- a/cli/integration-test/sample-test/src/sample_test/linked_editing_range/b.cljc
+++ b/cli/integration-test/sample-test/src/sample_test/linked_editing_range/b.cljc
@@ -1,4 +1,4 @@
-(ns sample-test.src.sample-test.linked-editing-range.b
-  (:require [sample-test.src.sample-test.linked-editing-range.a :as a]))
+(ns sample-test.linked-editing-range.b
+  (:require [sample-test.linked-editing-range.a :as a]))
 
 a/foo

--- a/cli/integration-test/sample-test/src/sample_test/text_change/a.clj
+++ b/cli/integration-test/sample-test/src/sample_test/text_change/a.clj
@@ -1,0 +1,5 @@
+(ns sample-test.text-change.a)
+
+(defn foo "original" [] 1)
+
+(foo)

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -254,10 +254,11 @@
                                               client-settings
                                               known-files-pattern)
                                   clojure-feature-handler)
+        in System/in
+        out System/out
         ;; For debugging, it's possible to trace all I/O through lsp4j.
-        ;; tracer (java.io.PrintWriter. (io/writer (io/file "path/to/some/log/file")))
-        ;; launcher (Launcher/createLauncher server ClojureLanguageClient System/in System/out false tracer)
-        launcher (Launcher/createLauncher server ClojureLanguageClient System/in System/out)
+        ;; launcher (Launcher/createLauncher server ClojureLanguageClient in out false (java.io.PrintWriter. (io/writer (io/file "../../integration-test/sample-test/clojure-lsp.lsp-trace.out"))))
+        launcher (Launcher/createLauncher server ClojureLanguageClient in out)
         language-client ^ClojureLanguageClient (.getRemoteProxy launcher)
         producer (->ClojureLspProducer language-client
                                        (lsp/->LSPProducer language-client db*)

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -4,7 +4,6 @@
    [clojure-lsp.feature.file-management :as f.file-management]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
-   [clojure.core.async :as async]
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as medley]))
 
@@ -27,26 +26,89 @@
   (h/load-code-and-locs "(ns bar) d e f" (h/file-uri "file:///user/project/src/clj/bar.clj"))
   (h/load-code-and-locs "(ns some-jar)" (h/file-uri "file:///some/path/to/jar.jar:/some/file.clj"))
   (testing "when file exists on disk"
-    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-    (with-redefs [shared/file-exists? (constantly true)]
-      (f.file-management/did-close "file:///user/project/src/clj/foo.clj" db/db*))
-    (is (get-in @db/db* [:analysis "/user/project/src/clj/foo.clj"]))
-    (is (get-in @db/db* [:findings "/user/project/src/clj/foo.clj"]))
-    (is (get-in @db/db* [:documents "file:///user/project/src/clj/foo.clj"])))
+    (h/let-mock-chans
+      [mock-diagnostics-chan #'db/diagnostics-chan]
+      (with-redefs [shared/file-exists? (constantly true)]
+        (f.file-management/did-close "file:///user/project/src/clj/foo.clj" db/db*))
+      (is (get-in @db/db* [:analysis "/user/project/src/clj/foo.clj"]))
+      (is (get-in @db/db* [:findings "/user/project/src/clj/foo.clj"]))
+      (is (get-in @db/db* [:documents "file:///user/project/src/clj/foo.clj"]))
+      (h/assert-no-take mock-diagnostics-chan 500)))
   (testing "when local file not exists on disk"
-    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-    (with-redefs [shared/file-exists? (constantly false)]
-      (f.file-management/did-close "file:///user/project/src/clj/bar.clj" db/db*))
-    (is (nil? (get-in @db/db* [:analysis "/user/project/src/clj/bar.clj"])))
-    (is (nil? (get-in @db/db* [:findings "/user/project/src/clj/bar.clj"])))
-    (is (nil? (get-in @db/db* [:documents "file:///user/project/src/clj/bar.clj"]))))
+    (h/let-mock-chans
+      [mock-diagnostics-chan #'db/diagnostics-chan]
+      (with-redefs [shared/file-exists? (constantly false)]
+        (f.file-management/did-close "file:///user/project/src/clj/bar.clj" db/db*))
+      (is (nil? (get-in @db/db* [:analysis "/user/project/src/clj/bar.clj"])))
+      (is (nil? (get-in @db/db* [:findings "/user/project/src/clj/bar.clj"])))
+      (is (nil? (get-in @db/db* [:documents "file:///user/project/src/clj/bar.clj"])))
+      (is (= {:uri "file:///user/project/src/clj/bar.clj"
+              :diagnostics []}
+             (h/take-or-timeout mock-diagnostics-chan 500)))))
   (testing "when file is external we do not remove analysis"
-    (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-    (with-redefs [shared/file-exists? (constantly false)]
-      (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" db/db*))
-    (is (get-in @db/db* [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
-    (is (get-in @db/db* [:findings "/some/path/to/jar.jar:/some/file.clj"]))
-    (is (get-in @db/db* [:documents "file:///some/path/to/jar.jar:/some/file.clj"]))))
+    (h/let-mock-chans
+      [mock-diagnostics-chan #'db/diagnostics-chan]
+      (with-redefs [shared/file-exists? (constantly false)]
+        (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" db/db*))
+      (is (get-in @db/db* [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (get-in @db/db* [:findings "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (get-in @db/db* [:documents "file:///some/path/to/jar.jar:/some/file.clj"]))
+      (h/assert-no-take mock-diagnostics-chan 500))))
+
+(deftest did-open
+  (testing "on an empty file"
+    (h/let-mock-chans
+      [mock-edits-chan #'db/edits-chan
+       mock-diagnostics-chan #'db/diagnostics-chan]
+      (let [filename "/user/project/src/aaa/bbb.clj"
+            uri (h/file-uri (str "file://" filename))]
+        (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+                                                    :source-paths #{(h/file-path "/user/project/src")}}
+                                         :project-root-uri (h/file-uri "file:///user/project")})
+        (h/load-code-and-locs "" uri)
+        (is (get-in @db/db* [:analysis filename]))
+        (is (get-in @db/db* [:findings filename]))
+        (is (get-in @db/db* [:documents uri]))
+        (testing "should publish empty diagnostics"
+          (is (= {:uri uri, :diagnostics []}
+                 (h/take-or-timeout mock-diagnostics-chan 500))))
+        (testing "should add ns"
+          (is (= {:changes
+                  {uri
+                   [{:range
+                     {:start {:line 0, :character 0},
+                      :end {:line 999998, :character 999998}},
+                     :new-text "(ns aaa.bbb)"}]}}
+                 (h/take-or-timeout mock-edits-chan 500))))))))
+
+(deftest did-change
+  (h/let-mock-chans
+    [mock-changes-chan #'db/current-changes-chan]
+    (let [original-text (h/code "(ns aaa)"
+                                "(def foo 1)")
+          edited-text (h/code "(ns aaa)"
+                              "(def bar 1)")]
+      (h/load-code-and-locs original-text)
+      (f.file-management/did-change h/default-uri
+                                    [{:text "bar"
+                                      :range {:start {:line 1 :character 5}
+                                              :end {:line 1 :character 8}}}]
+                                    2
+                                    db/db*)
+      (is (= 2 (get-in @db/db* [:documents h/default-uri :v])))
+      (is (= edited-text (get-in @db/db* [:documents h/default-uri :text])))
+      (is (= {:uri h/default-uri, :text edited-text, :version 2}
+             (h/take-or-timeout mock-changes-chan 500))))))
+
+(deftest did-change-watched-files
+  (testing "created file"
+    (h/let-mock-chans
+      [mock-created-chan #'db/created-watched-files-chan]
+      (f.file-management/did-change-watched-files
+        [{:type :created
+          :uri h/default-uri}]
+        db/db*)
+      (is (= h/default-uri (h/take-or-timeout mock-created-chan 500))))))
 
 (deftest outgoing-reference-filenames
   (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}


### PR DESCRIPTION
Adds tests for the async messages created by did-open, did-change and did-change-watched-files. Improves the tools for testing async messages. Adds integration test for did-change.


- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
