### PR TITLE
Use parser/safe-zloc-of-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Editor
  - Restored #995 Improve element selected on `textDocument/hover` (previously reverted) with a fix that keeps it working for Calva even after a syntax error is introduced.
+ - Improved call hierarchy performance by parsing less frequently. #1092
 
 ## 2022.06.29-19.32.13
 

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -199,8 +199,9 @@
   (let [[code [[row col] :as positions]] (positions-from-text code)]
     (let [position-count (count positions)]
       (assert (= 1 position-count) (format "Expected one cursor, got %s" position-count)))
-    (-> (parser/zloc-of-string code)
-        (parser/to-pos row col))))
+    (let [zloc (parser/safe-zloc-of-string code)]
+      (assert zloc "Unable to parse code")
+      (parser/to-pos zloc row col))))
 
 (defn- results->doc
   "Should mimic an LSP client processing results on a document"

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -115,15 +115,14 @@
 (defn hover [uri line column db*]
   (let [db @db*
         filename (shared/uri->filename uri)
-        zloc (some-> (f.file-management/force-get-document-text uri db*)
-                     (parser/safe-zloc-of-string)
-                     (parser/to-pos line column))
-        {function-loc-row :row
-         function-loc-col :col} (some-> (edit/find-function-usage-name-loc zloc)
-                                        z/node
-                                        meta)
-        element (if function-loc-row
-                  (q/find-element-under-cursor db filename function-loc-row function-loc-col)
+        func-position (some-> (f.file-management/force-get-document-text uri db*)
+                              (parser/safe-zloc-of-string)
+                              (parser/to-pos line column)
+                              edit/find-function-usage-name-loc
+                              z/node
+                              meta)
+        element (if func-position
+                  (q/find-element-under-cursor db filename (:row func-position) (:col func-position))
                   (loop [try-column column]
                     (if-let [usage (q/find-element-under-cursor db filename line try-column)]
                       usage

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -275,7 +275,7 @@
      :client-settings (:client-settings db-value)
      :final-settings (settings/all db-value)
      :cljfmt-raw (binding [*print-meta* true]
-                   (with-out-str (pr (f.format/resolve-user-cljfmt-config db-value))))
+                   (pr-str (f.format/resolve-user-cljfmt-config db-value)))
      :port (or (:port db-value)
                "NREPL only available on :debug profile (`make debug-cli`)")
      :server-version (shared/clojure-lsp-version)

--- a/lib/src/clojure_lsp/parser.clj
+++ b/lib/src/clojure_lsp/parser.clj
@@ -89,7 +89,7 @@
                     (z/find-token z/next #(= (str "::" temporary-value) (z/string %)))
                     (z-replace-preserving-meta (n/keyword-node (keyword (str ":" real-value))))))))))
 
-(defn zloc-of-string [text]
+(defn ^:private zloc-of-string [text]
   (try
     (z/of-string text)
     (catch clojure.lang.ExceptionInfo e
@@ -99,7 +99,6 @@
           (throw e)))))
 
 (defn safe-zloc-of-string [text]
-  ;; TODO: only used by tests.
   (try
     (zloc-of-string text)
     (catch Exception _e

--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -112,33 +112,11 @@
     :else
     (z/next loc)))
 
-(defn find-var-definition [loc filename db]
-  (when-let [root-loc (to-top loc)]
-    (when-let [fn-name-loc (some-> loc to-top z/next var-name-loc-from-op)]
-      (let [fn-name-loc-meta (meta (z/node fn-name-loc))
-            var-definition-ops (into []
-                                     (comp
-                                       (filter #(or (and (identical? :var-definitions (:bucket %))
-                                                         (= (:row fn-name-loc-meta) (:name-row %))
-                                                         (= (:col fn-name-loc-meta) (:name-col %)))
-                                                    (and (identical? :var-usages (:bucket %))
-                                                         (:defmethod %)
-                                                         (= (:row fn-name-loc-meta) (:name-row %))
-                                                         (= (:col fn-name-loc-meta) (:name-col %)))))
-                                       (keep #(find-at-pos root-loc (:name-row %) (:name-col %))))
-                                     (get-in db [:analysis filename]))]
-        (when (seq var-definition-ops)
-          {:fn-name-loc fn-name-loc
-           :var-definitions var-definition-ops})))))
-
-;; TODO Move the query part to queries.clj ?
-(defn find-var-definition-name-loc [loc filename db]
-  (:fn-name-loc (find-var-definition loc filename db)))
+(defn find-var-definition-name-loc [loc]
+  (some-> loc to-top z/next var-name-loc-from-op))
 
 (defn find-function-usage-name-loc [zloc]
-  (some-> zloc
-          (z/find-tag z/up :list)
-          z/down))
+  (some-> zloc (z/find-tag z/up :list) z/down))
 
 (defn single-child?
   [zloc]

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -919,7 +919,7 @@
                                      :range (-> test-zloc z/node meta)}]}}))))
 
 (defn can-create-test? [zloc uri db]
-  (when-let [function-name-loc (edit/find-var-definition-name-loc zloc (shared/uri->filename uri) db)]
+  (when-let [function-name-loc (edit/find-var-definition-name-loc zloc)]
     (let [source-paths (settings/get db [:source-paths])]
       (when-let [current-source-path (->> source-paths
                                           (filter #(and (string/starts-with? (shared/uri->filename uri) %)

--- a/lib/test/clojure_lsp/parser_test.clj
+++ b/lib/test/clojure_lsp/parser_test.clj
@@ -29,7 +29,7 @@
 
 (deftest to-pos-test
   (testing "complete code"
-    (let [zloc (parser/zloc-of-string "  foo  ")]
+    (let [zloc (parser/safe-zloc-of-string "  foo  ")]
       (is (= nil (z/string (parser/to-pos zloc 1 1))))
       (is (= 'foo (z/sexpr (parser/to-pos zloc 1 3))))
       (is (= 'foo (z/sexpr (parser/to-pos zloc 1 5))))

--- a/lib/test/clojure_lsp/refactor/edit_test.clj
+++ b/lib/test/clojure_lsp/refactor/edit_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.refactor.edit-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]
@@ -104,7 +103,7 @@
   (h/load-code-and-locs code)
   (let [zloc (-> code z/of-string (z/find-next-value z/next 'd))]
     (is (= "foo"
-           (z/string (edit/find-var-definition-name-loc zloc "/a.clj" @db/db*))))))
+           (z/string (edit/find-var-definition-name-loc zloc))))))
 
 (deftest find-function-definition-name
   (testing "defn"


### PR DESCRIPTION
Converts all usages of `parser/zloc-of-string` to `parser/safe-zloc-of-string`. Instead of letting exceptions short-circuit, we short-circuit on nils. This keeps stack traces out of the logs.

This patch also improves the performance of call hierarchies by parsing less. This was just an opportunistic refactoring—while looking at the parsing done in call-hierarchy I noticed were doing it a lot more frequently than necessary. There's more performance work that can be done here. See comments in call_hierarchy.clj.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
