### PR TITLE
Index analysis by file and bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Improve call hierarchy performance by parsing less frequently. #1092
   - Improve system wide performance by keeping a graph of dependencies between namespaces. #990 #1053
     Enable setting `:experimental {:dep-graph-queries true}` to beta test this feature.
+  - Improve performance by adding second level of analysis indexing.
 
 ## 2022.06.29-19.32.13
 

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -21,7 +21,7 @@
 (defonce created-watched-files-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 3)
+(def version 4)
 
 (defn ^:private sqlite-db-file [project-root]
   (io/file (str project-root) ".lsp" ".cache" "sqlite.db"))

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -210,10 +210,9 @@
                          (z/find-next-value ':as)
                          z/right
                          z/sexpr)]
-    (let [local-elements (get-in db [:analysis filename])
-          used-alias? (some #(and (= :var-usages (:bucket %))
-                                  (= alias (:alias %)))
-                            local-elements)]
+    (let [local-var-usages (get-in db [:analysis filename :var-usages])
+          used-alias? (some #(= alias (:alias %))
+                            local-var-usages)]
       (if used-alias?
         node
         (z/remove node)))

--- a/lib/src/clojure_lsp/feature/document_symbol.clj
+++ b/lib/src/clojure_lsp/feature/document_symbol.clj
@@ -2,8 +2,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defn declaration? [e]
-  (#{:namespace-definitions :var-definitions} (:bucket e)))
+(def declaration-buckets #{:namespace-definitions :var-definitions})
 
 (defn element->symbol-kind [el]
   (cond

--- a/lib/src/clojure_lsp/feature/drag.clj
+++ b/lib/src/clojure_lsp/feature/drag.clj
@@ -361,8 +361,9 @@
                                               :name-end-row end-row
                                               :name-end-col end-col}]
                                    #(shared/inside? % scope)))
-                  elements (filter (enclosed-by? (z/node vector-zloc))
-                                   (get-in db [:analysis (shared/uri->filename uri)]))]
+                  elements (->> (get-in db [:analysis (shared/uri->filename uri)])
+                                (mapcat val)
+                                (filter (enclosed-by? (z/node vector-zloc))))]
               (->> child-nodes
                    (partition 2)
                    (every? (fn [[lvar rvar]]

--- a/lib/src/clojure_lsp/feature/semantic_tokens.clj
+++ b/lib/src/clojure_lsp/feature/semantic_tokens.clj
@@ -216,15 +216,17 @@
        doall))
 
 (defn full-tokens [uri db]
-  (let [elements (get-in db [:analysis (shared/uri->filename uri)])]
-    (->> elements
+  (let [buckets (get-in db [:analysis (shared/uri->filename uri)])]
+    (->> buckets
+         (mapcat val)
          elements->absolute-tokens
          absolute-tokens->relative-tokens)))
 
 (defn range-tokens
   [uri range db]
-  (let [elements (get-in db [:analysis (shared/uri->filename uri)])]
-    (->> elements
+  (let [buckets (get-in db [:analysis (shared/uri->filename uri)])]
+    (->> buckets
+         (mapcat val)
          (filter #(element-inside-range? % range))
          elements->absolute-tokens
          absolute-tokens->relative-tokens)))

--- a/lib/src/clojure_lsp/feature/test_tree.clj
+++ b/lib/src/clojure_lsp/feature/test_tree.clj
@@ -36,17 +36,15 @@
 (defn tree [uri db]
   (let [filename (shared/uri->filename uri)
         ns-element (q/find-namespace-definition-by-filename db filename)
-        local-elements (get-in db [:analysis filename])
+        local-buckets (get-in db [:analysis filename])
         deftests (into []
-                       (filter #(and (identical? :var-definitions (:bucket %))
-                                     (contains? '#{clojure.test/deftest cljs.test/deftest}
-                                                (:defined-by %))))
-                       local-elements)
+                       (filter #(contains? '#{clojure.test/deftest cljs.test/deftest}
+                                           (:defined-by %)))
+                       (:var-definitions local-buckets))
         testings (into []
-                       (filter #(and (identical? :var-usages (:bucket %))
-                                     (= 'testing (:name %))
+                       (filter #(and (= 'testing (:name %))
                                      (contains? '#{clojure.test cljs.test} (:to %))))
-                       local-elements)
+                       (:var-usages local-buckets))
         tests-tree (mapv #(deftest->tree % testings) deftests)]
     (when (seq tests-tree)
       {:uri uri

--- a/lib/src/clojure_lsp/feature/workspace_symbols.clj
+++ b/lib/src/clojure_lsp/feature/workspace_symbols.clj
@@ -47,8 +47,9 @@
 (defn workspace-symbols [query db]
   ;; TODO refactor to be a complete transducer
   (->> (q/internal-analysis db)
-       (mapcat val)
-       (filter f.document-symbol/declaration?)
+       (map val)
+       (mapcat (fn [buckets]
+                 (mapcat buckets f.document-symbol/declaration-buckets)))
        (fuzzy-filter query)
        (mapv (fn [element]
                {:name (-> element :name name)

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -491,16 +491,15 @@
                                    (safe-equal? (:to element) (:to %))
                                    (safe-equal? (:name element) (:name %)))))
                ;; protocol method usage or defmethod usage
-               (comp
-                 (mapcat (fn [[_ {:keys [protocol-impls var-usages]}]]
-                           (concat protocol-impls var-usages)))
-                 (filter #(or (and (identical? :protocol-impls (:bucket %))
-                                   (safe-equal? (:to element) (:protocol-ns %))
-                                   (safe-equal? (:name element) (:method-name %)))
-                              (and (identical? :var-usages (:bucket %))
-                                   (:defmethod %)
-                                   (safe-equal? (:to element) (:to %))
-                                   (safe-equal? (:name element) (:name %)))))))]
+               (comp (map val)
+                     (mapcat (fn [{:keys [protocol-impls var-usages]}]
+                               (concat (filter #(and (safe-equal? (:to element) (:protocol-ns %))
+                                                     (safe-equal? (:name element) (:method-name %)))
+                                               protocol-impls)
+                                       (filter #(and (:defmethod %)
+                                                     (safe-equal? (:to element) (:to %))
+                                                     (safe-equal? (:name element) (:name %)))
+                                               var-usages))))))]
       (into []
             (comp
               xf

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -573,8 +573,9 @@
     (into []
           (comp
             (mapcat (fn [[_filename {:keys [var-definitions var-usages]}]]
-                      (cond->> var-usages
-                        include-declaration? (into var-definitions))))
+                      (concat (when include-declaration?
+                                var-definitions)
+                              var-usages)))
             (filter #(contains? names (:name %)))
             (filter #(safe-equal? (:ns element) (or (:ns %) (:to %))))
             (filter #(or include-declaration?

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -154,7 +154,7 @@
   (h/load-code-and-locs "(ns aaa) (ns ccc)" (h/file-uri "file:///aaa.clj"))
   (h/load-code-and-locs "(ns bbb)" (h/file-uri "file:///bbb.clj"))
   (h/load-code-and-locs "(ns jjj)" (h/file-uri "file:///jjj.cljs"))
-  (is (= '#{aaa bbb ccc jjj clojure.core}
+  (is (= '#{aaa bbb ccc jjj}
          (q/ns-names @db/db*))))
 
 (deftest internal-ns-names

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -154,7 +154,9 @@
   (h/load-code-and-locs "(ns aaa) (ns ccc)" (h/file-uri "file:///aaa.clj"))
   (h/load-code-and-locs "(ns bbb)" (h/file-uri "file:///bbb.clj"))
   (h/load-code-and-locs "(ns jjj)" (h/file-uri "file:///jjj.cljs"))
-  (is (= '#{aaa bbb ccc jjj}
+  (is (= (if (dg?)
+           '#{aaa bbb ccc jjj clojure.core cljs.core}
+           '#{aaa bbb ccc jjj})
          (q/ns-names @db/db*))))
 
 (deftest internal-ns-names

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -154,7 +154,7 @@
   (h/load-code-and-locs "(ns aaa) (ns ccc)" (h/file-uri "file:///aaa.clj"))
   (h/load-code-and-locs "(ns bbb)" (h/file-uri "file:///bbb.clj"))
   (h/load-code-and-locs "(ns jjj)" (h/file-uri "file:///jjj.cljs"))
-  (is (= '#{aaa bbb ccc jjj}
+  (is (= '#{aaa bbb ccc jjj clojure.core}
          (q/ns-names @db/db*))))
 
 (deftest internal-ns-names

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -183,14 +183,14 @@
     (h/clean-db!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
-    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) @db/db*)]
+    (let [element (#'q/find-last-order-by-project-analysis :namespace-definitions #(= 'foo.bar (:name %)) @db/db*)]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (h/clean-db!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
-    (let [element (#'q/find-last-order-by-project-analysis #(= 'foo.bar (:name %)) @db/db*)]
+    (let [element (#'q/find-last-order-by-project-analysis :namespace-definitions #(= 'foo.bar (:name %)) @db/db*)]
       (is (= (h/file-path "/b.clj") (:filename element))))))
 
 (deftest find-element-under-cursor


### PR DESCRIPTION
Index analysis by file _and_ bucket, instead of just file as we did before. This is helpful because the majority of queries need to look in only select buckets.

@ericdallo as we discussed, this is the second of three PRs that bump the db/version. I'd like to get them all in this release, if possible. The third one will be much smaller.

This PR improves performance a little, but as with the third PR, it's mostly preparation for fixing #1018. To fix #1018 we'll need very fast access to keyword definitions, which could be in any file. This PR will help with that by letting us skip many analysis elements (especially var usages and locals). The third PR will split keywords into usages and definitions which will be the last step to being able to access keyword definitions quickly.

- [x] This is prep for #1018
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
