### PR TITLE
Separate analysis of keyword definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Improve system wide performance by keeping a graph of dependencies between namespaces. #990 #1053
     Enable setting `:experimental {:dep-graph-queries true}` to beta test this feature.
   - Improve performance by adding second level of analysis indexing.
+  - Improve performance of things that need keyword definitions, like completion and custom lint.
 
 ## 2022.06.29-19.32.13
 

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -21,7 +21,7 @@
 (defonce created-watched-files-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 4)
+(def version 5)
 
 (defn ^:private sqlite-db-file [project-root]
   (io/file (str project-root) ".lsp" ".cache" "sqlite.db"))

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -36,7 +36,7 @@
     kondo-config))
 
 (defn ^:private unused-public-var->finding [element kondo-config]
-  (let [keyword-def? (boolean (:reg element))
+  (let [keyword-def? (identical? :keyword-definitions (:bucket element))
         kondo-config (if (:ns element)
                        (kondo-config-for-ns kondo-config (:ns element))
                        kondo-config)]

--- a/lib/src/clojure_lsp/feature/semantic_tokens.clj
+++ b/lib/src/clojure_lsp/feature/semantic_tokens.clj
@@ -171,7 +171,7 @@
              (identical? :namespace-definitions bucket)
              [(element->absolute-token element :namespace)]
 
-             (and (identical? :keywords bucket)
+             (and (contains? #{:keyword-definitions :keyword-usages} bucket)
                   (not (:str element))
                   (not (:keys-destructuring element)))
              (keywords->absolute-tokens element)

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -74,6 +74,13 @@
       (update :findings merge findings)
       (assoc :kondo-config config)))
 
+(defn ^:private element-with-fallback-name-position [element]
+  (assoc element
+         :name-row (or (:name-row element) (:row element))
+         :name-col (or (:name-col element) (:col element))
+         :name-end-row (or (:name-end-row element) (:end-row element))
+         :name-end-col (or (:name-end-col element) (:end-col element))))
+
 ;;;; Normalization
 
 ;; The analysis we get back from clj-kondo is indexed by bucket
@@ -106,12 +113,13 @@
                                   :alias-end-row :name-end-row
                                   :alias-end-col :name-end-col}))))
 
-    (:locals :local-usages :keywords)
+    (:locals :local-usages)
+    [(element-with-fallback-name-position element)]
+
+    :keywords
     [(-> element
-         (assoc :name-row (or (:name-row element) (:row element))
-                :name-col (or (:name-col element) (:col element))
-                :name-end-row (or (:name-end-row element) (:end-row element))
-                :name-end-col (or (:name-end-col element) (:end-col element))))]
+         element-with-fallback-name-position
+         (assoc :bucket (if (:reg element) :keyword-definitions :keyword-usages)))]
 
     :java-class-definitions
     [(-> element
@@ -124,10 +132,7 @@
     :java-class-usages
     [(-> element
          (dissoc :uri)
-         (assoc :name-row (or (:name-row element) (:row element))
-                :name-col (or (:name-col element) (:col element))
-                :name-end-row (or (:name-end-row element) (:end-row element))
-                :name-end-col (or (:name-end-col element) (:end-col element))))]
+         (element-with-fallback-name-position))]
 
     [element]))
 

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -308,7 +308,7 @@
                             :name 'some.cool-ns
                             :from 'other.cool-ns}
                            {:filename (h/file-path "/c.clj")
-                            :bucket :keywords
+                            :bucket :keyword-usages
                             :from 'another.cool-ns
                             :name "bar"
                             :ns 'some.cool-ns}]]
@@ -338,7 +338,7 @@
           :name 'some.cool-ns
           :from 'other.cool-ns}
          {:filename (h/file-path "/c.clj")
-          :bucket :keywords
+          :bucket :keyword-usages
           :from 'another.cool-ns
           :name "bar"
           :ns 'some.cool-ns}]


### PR DESCRIPTION
Some performance sensitive things like completion and custom linting need to find all keyword definitions. But to get to them they had to search through every keyword usage. Since there are orders of magnitude more keyword usages than keyword definitions, this was unnecessarily slow.

This splits clj-kondo keywords into keyword-usages and keyword-definitions during analysis normalization. Now it's much faster to get to the definitions.

Before this patch completing a keyword in metabase took about 100ms. Now it takes 30ms.

This will assist in fixing #1018 and is the last of the three PRs that bump db/version.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #1018 
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
