### PR TITLE
Remove `find-namespace-name`

### DIFF
--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -211,14 +211,6 @@
       (z/find-value z/next 'ns) ; go to ns
       (z/up))) ; ns form
 
-(defn find-namespace-name [zloc]
-  (some-> zloc
-          find-namespace
-          z/down
-          z/next
-          z/sexpr
-          str))
-
 (defn node-marked? [node marker]
   (contains? (get node ::markers) marker))
 

--- a/lib/test/clojure_lsp/refactor/edit_test.clj
+++ b/lib/test/clojure_lsp/refactor/edit_test.clj
@@ -86,18 +86,6 @@
                (edit/find-ops-up "->")
                z/sexpr)))))
 
-(deftest find-namespace-name
-  (testing "without ns on file"
-    (is (nil? (-> "(foo ((x) [a] (b {c |d})))"
-                  h/zloc-from-code
-                  edit/find-namespace-name))))
-  (testing "with ns on file"
-    (is (= "some.foo.bar"
-           (-> (h/code "(ns some.foo.bar (require [some.foo :as s]))"
-                       "(foo ((x) [a] (b {c |d})))")
-               h/zloc-from-code
-               edit/find-namespace-name)))))
-
 (defn ^:private assert-function-name [code]
   (h/clean-db!)
   (h/load-code-and-locs code)


### PR DESCRIPTION
After 54b4251f, `edit/find-namespace-name` is unused.