### PR TITLE
fix: goto definition should find registration of simple keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Improve performance by adding second level of analysis indexing.
   - Improve performance of things that need keyword definitions, like completion and custom lint.
   - Fix hover showing previous function elements on some cases. #1098
+  - Fix: find definition will find registration of unnamespaced keyword.
 
 ## 2022.06.29-19.32.13
 

--- a/cli/integration-test/integration/definition_test.clj
+++ b/cli/integration-test/integration/definition_test.clj
@@ -41,7 +41,7 @@
       (h/assert-submap
         {:uri (h/source-path->uri "definition/b.clj")
          :range {:start {:line 5 :character 0}
-                 :end {:line 5 :character 7}}}
+                 :end {:line 5 :character 17}}}
         (lsp/request! (fixture/definition-request "definition/b.clj" 5 2))))
 
     (testing "definition of invalid local namespaced keyword is the keyword itself"

--- a/cli/integration-test/sample-test/src/sample_test/definition/b.clj
+++ b/cli/integration-test/sample-test/src/sample_test/definition/b.clj
@@ -3,7 +3,7 @@
 
 (a/some-public-func 2)
 
-:my-key
+:definition-b-key
 
 ::my-key
 

--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -1,7 +1,6 @@
 (ns clojure-lsp.refactor.edit
   (:require
    [clojure.set :as set]
-   [lsp4clj.protocols.logger :as logger]
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]))
 


### PR DESCRIPTION
This was noticed while working on #1097. 

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
