### PR TITLE
Fix: navigate to definition of potemkin var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Fix: find definition will find registration of unnamespaced keyword.
   - Fix to update unused-public-var lint on registered keywords as usages change in other files. #1018
   - Fix to navigate to var defined by declare, when there aren't any later defs. #1107
+  - Fix to always go to the definition of the correct var imported by potemkin. #1020
 
 ## 2022.06.29-19.32.13
 

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -8,7 +8,7 @@
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
         medley/medley {:mvn/version "1.4.0"}
         anonimitoraf/clj-flx {:mvn/version "1.2.0"}
-        clj-kondo/clj-kondo {:mvn/version "2022.06.22"
+        clj-kondo/clj-kondo {:mvn/version "2022.06.23-20220704.194013-4"
                              :exclude [com.cognitect/transit-clj
                                        babashka/fs]}
         com.fabiodomingues/clj-depend {:mvn/version "0.6.1"}

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -375,20 +375,11 @@
       element))
 
 (defmethod find-definition :var-definitions
-  [db element]
-  (if (= 'potemkin/import-vars (:defined-by element))
-    ;; FIXME: this is buggy... it goes to **any** definition with the same name,
-    ;; not specifically the one from the imported ns. See
-    ;; https://github.com/clojure-lsp/clojure-lsp/issues/1020
-    ;; To fix, use :imported-ns and :imported-var, and treat this like a
-    ;; var-usage Don't forget to switch from db to (db-with-ns-analysis db
-    ;; (:imported-ns element))
-    (find-last-order-by-project-analysis
-      :var-definitions
-      #(and (= (:name %) (:name element))
-            (not= 'potemkin/import-vars (:defined-by %))
-            (match-file-lang % element))
-      db)
+  [db {:keys [defined-by imported-ns] :as element}]
+  (if (safe-equal? 'potemkin/import-vars defined-by)
+    (find-definition db (assoc element
+                               :bucket :var-usages
+                               :to imported-ns))
     element))
 
 (defmethod find-definition :protocol-impls

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -694,7 +694,7 @@
   (let [[[bar-r bar-c]] (h/load-code-and-locs
                           (h/code "(ns foo.api"
                                   "  (:require [potemkin :refer [import-vars]]"
-                                  "            [foo.impl]))"
+                                  "            [foo.impl :as impl]))"
                                   "(import-vars |impl/bar)") (h/file-uri "file:///a.clj"))
         db @db/db*]
     (h/assert-submap


### PR DESCRIPTION
Always navigate to the correct definition of a var imported by potemkin, instead of any var with the same name.

- [x] Fixes #1020
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
