### PR TITLE
Simplify find-definition for namespace-aliases

### DIFF
--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -333,11 +333,9 @@
 
 (defmethod find-definition :namespace-alias
   [db {:keys [to] :as element}]
-  (find-last-order-by-project-analysis
-    :namespace-definitions
-    #(and (= (:name %) to)
-          (match-file-lang % element))
-    (db-with-ns-analysis db to)))
+  (find-definition db (assoc element
+                             :bucket :namespace-usages
+                             :name to)))
 
 (defmethod find-definition :namespace-usages
   [db element]


### PR DESCRIPTION
Normalization creates namespace-aliases from namespace-usages. That means that to find the definition of an alias, we can convert it back into a usage.