### PR TITLE
Include declare as potential definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Fix hover showing previous function elements on some cases. #1098
   - Fix: find definition will find registration of unnamespaced keyword.
   - Fix to update unused-public-var lint on registered keywords as usages change in other files. #1018
+  - Fix to navigate to var defined by declare, when there aren't any later defs. #1107
 
 ## 2022.06.29-19.32.13
 

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -354,7 +354,6 @@
       :var-definitions
       #(and (= (:name element) (:name %))
             (= (:to element) (:ns %))
-            (not= 'clojure.core/declare (:defined-by %))
             (match-file-lang % element))
       (db-with-ns-analysis db (:to element)))
     (when (contains? (elem-langs element) :cljs)


### PR DESCRIPTION
So that when there aren't any later `def`s, going to definition will go to `declare`. 

- [x] Fixes #1107.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
