### PR TITLE
Query xf

### DIFF
--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -206,7 +206,7 @@
 (defn ^:private with-ns-definition-elements [matches-fn non-local-db]
   (into []
         (comp
-          (mapcat (comp :namespace-definitions val))
+          q/xf-analysis->namespace-definitions
           (filter #(matches-fn (:name %)))
           (map #(element->completion-item % nil :ns-definition)))
         (:analysis non-local-db)))
@@ -215,7 +215,7 @@
   (let [refer-ns (z/sexpr (edit/find-refer-ns cursor-loc))]
     (into []
           (comp
-            (mapcat (comp :var-definitions val))
+            q/xf-analysis->var-definitions
             (filter #(and (= refer-ns (:ns %))
                           (matches-fn (:name %))))
             (map #(element->completion-item % nil :refer)))
@@ -272,7 +272,7 @@
                                   set)]
         (into []
               (comp
-                (mapcat (comp :var-definitions val))
+                q/xf-analysis->var-definitions
                 (keep
                   #(when (and (not (:private %))
                               (contains? alias-namespaces (:ns %))
@@ -291,7 +291,7 @@
 (defn ^:private with-elements-from-full-ns [db full-ns]
   (into []
         (comp
-          (mapcat (comp :var-definitions val))
+          q/xf-analysis->var-definitions
           (filter #(and (= (:ns %) (symbol full-ns))
                         (not (:private %))))
           (map #(element->completion-item % full-ns :ns-definition)))
@@ -309,7 +309,7 @@
         name (-> cursor-loc z/sexpr name)]
     (into []
           (comp
-            (mapcat (comp :keyword-definitions val))
+            q/xf-analysis->keyword-definitions
             (filter #(and (= ns (:ns %))
                           (or (not cursor-loc)
                               (string/starts-with? (:name %) name))))

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -185,14 +185,20 @@
     (h/clean-db!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
-    (let [element (#'q/find-last-order-by-project-analysis :namespace-definitions #(= 'foo.bar (:name %)) @db/db*)]
+    (let [element (#'q/find-last-order-by-project-analysis
+                   (comp q/xf-analysis->namespace-definitions
+                         (filter #(= 'foo.bar (:name %))))
+                   @db/db*)]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (h/clean-db!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
-    (let [element (#'q/find-last-order-by-project-analysis :namespace-definitions #(= 'foo.bar (:name %)) @db/db*)]
+    (let [element (#'q/find-last-order-by-project-analysis
+                   (comp q/xf-analysis->namespace-definitions
+                         (filter #(= 'foo.bar (:name %))))
+                   @db/db*)]
       (is (= (h/file-path "/b.clj") (:filename element))))))
 
 (deftest find-element-under-cursor

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -187,7 +187,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (let [element (#'q/find-last-order-by-project-analysis
                    (comp q/xf-analysis->namespace-definitions
-                         (filter #(= 'foo.bar (:name %))))
+                         (q/xf-same-name 'foo.bar))
                    @db/db*)]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
@@ -197,7 +197,7 @@
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (let [element (#'q/find-last-order-by-project-analysis
                    (comp q/xf-analysis->namespace-definitions
-                         (filter #(= 'foo.bar (:name %))))
+                         (q/xf-same-name 'foo.bar))
                    @db/db*)]
       (is (= (h/file-path "/b.clj") (:filename element))))))
 


### PR DESCRIPTION
@ericdallo what do you think of this refactoring? The idea was to extract the common things queries do into transducers. I think it's interesting how it makes the queries more declarative. It's also a nice way to encourage the correct use of `identical?` and `safe-equal?` But I can also see how it could make them less approachable for someone who was just scanning the code for the first time. Up to you whether to go this direction.
