### PR TITLE
Document how to reset the project root.

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -146,6 +146,7 @@ then those can be added at the project level.
 - clojure-lsp persist the external jars analysis in a `.lsp/.cache/` folder, if you have issues with some specific feature,
 try to remove that dir and restart the server.
 - If you have issues with macros, [double check your clj-kondo config](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#unrecognized-macros).
+- Check that the project root is set correctly with `lsp-clojure-server-info`. If it is incorrect, run `lsp-workspace-folders-remove`, then `lsp`.
 
 ### Missing `Add require...` on code actions when using CoC and (neo)vim
 


### PR DESCRIPTION
If the project root is not set correctly, lsp will ignore config files such as
`clj-kondo/config.edn`. Document how to check if this is the case and reset the
project root if necessary.

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
