### PR TITLE
Fix namespace rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
   - Fix to update unused-public-var lint on registered keywords as usages change in other files. #1018
   - Fix to navigate to var defined by declare, when there aren't any later defs. #1107
   - Fix to always go to the definition of the correct var imported by potemkin. #1020
-  - Fix namespace renaming causing wrong renames introduced on previous release.
 
 ## 2022.06.29-19.32.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Fix to update unused-public-var lint on registered keywords as usages change in other files. #1018
   - Fix to navigate to var defined by declare, when there aren't any later defs. #1107
   - Fix to always go to the definition of the correct var imported by potemkin. #1020
+  - Fix to correctly rename namespaces. #1121
 
 ## 2022.06.29-19.32.13
 

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -176,10 +176,13 @@
 
 (def default-uri (file-uri "file:///a.clj"))
 
+(defn load-code [code & [uri]]
+  (let [uri (or uri default-uri)]
+    (handlers/did-open {:textDocument {:uri uri :text code}} components)))
+
 (defn load-code-and-locs [code & [uri]]
-  (let [[code positions] (positions-from-text code)
-        uri (or uri default-uri)]
-    (handlers/did-open {:textDocument {:uri uri :text code}} components)
+  (let [[code positions] (positions-from-text code)]
+    (load-code code uri)
     positions))
 
 (defn ->position [[row col]]

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -263,6 +263,10 @@
       (shared/dissoc-in [:analysis filename])
       (shared/dissoc-in [:findings filename])))
 
+(defn ^:private file-deleted [db* uri filename]
+  (swap! db* db-without-file uri filename)
+  (f.diagnostic/publish-empty-diagnostics! uri @db*))
+
 (defn did-change-watched-files [changes db*]
   (doseq [{:keys [uri type]} changes]
     (case type
@@ -276,16 +280,14 @@
                                db*)))
       :deleted (shared/logging-task
                  :delete-watched-file
-                 (let [filename (shared/uri->filename uri)]
-                   (swap! db* db-without-file uri filename))))))
+                 (file-deleted db* uri (shared/uri->filename uri))))))
 
 (defn did-close [uri db*]
   (let [filename (shared/uri->filename uri)
         source-paths (settings/get @db* [:source-paths])]
     (when (and (not (shared/external-filename? filename source-paths))
                (not (shared/file-exists? (io/file filename))))
-      (swap! db* db-without-file uri filename)
-      (f.diagnostic/publish-empty-diagnostics! uri @db*))))
+      (file-deleted db* uri filename))))
 
 (defn force-get-document-text
   "Get document text from db, if document not found, tries to open the document"
@@ -303,7 +305,9 @@
        (keep (fn [{:keys [oldUri newUri]}]
                (let [old-filename (shared/uri->filename oldUri)
                      new-ns (shared/uri->namespace newUri db)
-                     ns-definition (q/find-namespace-definition-by-filename db old-filename)]
-                 (when ns-definition
-                   (f.rename/rename-element oldUri new-ns db ns-definition :rename-file)))))
+                     old-ns-definition (q/find-namespace-definition-by-filename db old-filename)]
+                 (when (and new-ns
+                            old-ns-definition
+                            (not= new-ns (name (:name old-ns-definition))))
+                   (f.rename/rename-element oldUri new-ns db old-ns-definition :rename-file)))))
        (reduce #(shared/deep-merge %1 %2) {:document-changes []})))

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -298,13 +298,12 @@
 (defn did-save [uri db*]
   (swap! db* #(assoc-in % [:documents uri :saved-on-disk] true)))
 
-(defn will-rename-files [files db*]
-  (let [db @db*]
-    (->> files
-         (keep (fn [{:keys [oldUri newUri]}]
-                 (let [old-filename (shared/uri->filename oldUri)
-                       new-ns (shared/uri->namespace newUri db)
-                       ns-definition (q/find-namespace-definition-by-filename db old-filename)]
-                   (when ns-definition
-                     (f.rename/rename-element oldUri new-ns db* old-filename ns-definition :rename-file)))))
-         (reduce #(shared/deep-merge %1 %2) {:document-changes []}))))
+(defn will-rename-files [files db]
+  (->> files
+       (keep (fn [{:keys [oldUri newUri]}]
+               (let [old-filename (shared/uri->filename oldUri)
+                     new-ns (shared/uri->namespace newUri db)
+                     ns-definition (q/find-namespace-definition-by-filename db old-filename)]
+                 (when ns-definition
+                   (f.rename/rename-element oldUri new-ns db ns-definition :rename-file)))))
+       (reduce #(shared/deep-merge %1 %2) {:document-changes []})))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -180,7 +180,7 @@
   (shared/logging-task
     :rename
     (let [[row col] (shared/position->line-column position)]
-      (f.rename/rename-from-position textDocument newName row col db/db*))))
+      (f.rename/rename-from-position textDocument newName row col @db/db*))))
 
 (defn definition [{:keys [textDocument position]} {:keys [db*]}]
   (shared/logging-task
@@ -475,7 +475,7 @@
 (defn will-rename-files [{:keys [files]} {:keys [db*]}]
   (shared/logging-task
     :will-rename-files
-    (f.file-management/will-rename-files files db*)))
+    (f.file-management/will-rename-files files @db*)))
 
 (defrecord ClojureLSPFeatureHandler [components*]
   feature-handler/ILSPFeatureHandler

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -387,7 +387,7 @@
     (if-let [from-element (q/find-element-for-rename db from-ns from-name)]
       (let [uri (shared/filename->uri (:filename from-element) db)]
         (open-file! {:uri uri :namespace from-ns} components)
-        (let [{:keys [error document-changes]} (f.rename/rename-from-position uri (str to) (:name-row from-element) (:name-col from-element) db*)]
+        (let [{:keys [error document-changes]} (f.rename/rename-from-position uri (str to) (:name-row from-element) (:name-col from-element) db)]
           (if document-changes
             (if-let [edits (->> document-changes
                                 (pmap #(document-change->edit-summary % db))

--- a/lib/test/clojure_lsp/features/rename_test.clj
+++ b/lib/test/clojure_lsp/features/rename_test.clj
@@ -16,14 +16,14 @@
                                                    (h/file-uri "file:///a.cljc"))]
     (testing "should not rename plain keywords"
       (let [[row col] a-start
-            result (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col db/db*)]
+            result (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col @db/db*)]
         (is (= {:error {:code :invalid-params
                         :message "Can't rename, only namespaced keywords can be renamed."}}
                result))))
 
     (testing "should rename local in destructure but not keywords"
       (let [[row col] a-binding-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text "b" :range (h/->range a-binding-start a-binding-stop)}
                  {:new-text "b" :range (h/->range a-local-usage-start a-local-usage-stop)}]}
@@ -38,7 +38,7 @@
                            (h/file-uri "file:///b.cljc"))]
     (testing "renaming only the name"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":hello/bar" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":hello/bar" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":hello/bar" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -46,7 +46,7 @@
                changes))))
     (testing "renaming only the namespace"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/foo" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/foo" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":bye/foo" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -54,7 +54,7 @@
                changes))))
     (testing "renaming namespace and name"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/bar" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/bar" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":bye/bar" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -76,21 +76,21 @@
                                            (h/file-uri "file:///c.cljc"))]
     (testing "should rename local in destructure with ':' and keywords if namespaced"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/c" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/c" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":a/c" :range (h/->range a-start a-stop)}
                  {:new-text ":a/c" :range (h/->range a-binding-start a-binding-stop)}]}
                changes))))
     (testing "should rename local in destructure without ':' and keywords if namespaced"
       (let [[row col] b-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":c/e" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":c/e" row col @db/db*))]
         (is (= {(h/file-uri "file:///b.cljc")
                 [{:new-text ":c/e" :range (h/->range b-start b-stop)}
                  {:new-text "c/e" :range (h/->range b-binding-start b-binding-stop)}]}
                changes))))
     (testing "should rename local in destructure with namespace on :keys"
       (let [[row col] c-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///c.cljc") ":e/f" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///c.cljc") ":e/f" row col @db/db*))]
         (is (= {(h/file-uri "file:///c.cljc")
                 [{:new-text ":e/f" :range (h/->range c-start c-stop)}
                  {:new-text "f" :range (h/->range c-binding-start c-binding-stop)}]}
@@ -118,13 +118,13 @@
           (h/file-uri "file:///b.cljc"))]
     (testing "renaming keywords renames correctly namespaced maps as well"
       (let [[row col] a-b-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/g" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/g" row col @db/db*))]
         (is (= {(h/file-uri "file:///a.cljc") [{:new-text ":a/g" :range (h/->range a-b-start a-b-stop)}
                                                {:new-text ":g" :range (h/->range b-ns-start b-ns-stop)}]}
                changes))))
     (testing "renaming from aliased namespace to namespace"
       (let [[row col] h1-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":hello/world" row col db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":hello/world" row col @db/db*))]
         (is (= {(h/file-uri "file:///b.cljc") [{:new-text ":hello/world" :range (h/->range h1-start h1-stop)}
                                                {:new-text ":hello/world" :range (h/->range h2-start h2-stop)}]}
                changes))))
@@ -145,7 +145,7 @@
     (h/assert-submap
       {:error {:code :invalid-params
                :message "Can't rename namespace, client does not support file renames."}}
-      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))
+      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))
   (testing "when client has document-changes capability but no valid source-paths"
     (h/clean-db!)
     (swap! db/db* shared/deep-merge
@@ -156,7 +156,7 @@
     (h/assert-submap
       {:error {:code :invalid-params
                :message "Can't rename namespace, invalid source-paths. Are project :source-paths configured correctly?"}}
-      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))
+      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))
   (testing "when source-paths are valid and client capabilities has document-changes"
     (h/clean-db!)
     (swap! db/db* shared/deep-merge
@@ -174,7 +174,7 @@
              {:kind "rename"
               :old-uri (h/file-uri "file:///my-project/src/foo/bar_baz.clj")
               :new-uri (h/file-uri "file:///my-project/src/foo/baz_qux.clj")}]}
-           (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 db/db*)))))
+           (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))))
 
 (deftest prepare-rename
   (testing "rename local var"


### PR DESCRIPTION
This fixes #1121. It also restores #1049, which was temporarily reverted as a quick fox for #1121.

When a user asks to rename a namespace, we instruct the client to edit the namespace and to rename the file. The client makes the edit (in the old file), then tell us via didChange. We start an asynchronous analysis. Then, the client sends us willRenameFiles. We respond by (incorrectly) asking the client to make the same edit to the old file we asked for before. The reason we do this is we haven't waited for the analysis to finish, so we think the file still has its old namespace.

This changes will-rename-files to wait for the analysis to finish. It also changes it to return no edits if the namespace has already been edited (which it has in this scenario, though it wouldn't if the file had been renamed because of something besides a rename refactoring).

Finally, it fixes another bug where we weren't clearing the diagnostics of deleted files. In my Emacs, rename refactorings still cause erroneous lint (we ask clj-kondo to analyze #.foo.clj, which doesn't exist, and it complains about that) but that might just be because of my Emacs config.



- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
