### PR TITLE
Defmethods in symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   - Improve accuracy of progress reporting during uncached startup. #1134
   - Add refactoring `Destructure keys` to destructure keywords. #905
   - Add refactoring `Extract to def` to create a `def` from the thing under the cursor. #1136
-  - Include defmethods in document symbols. #1016
+  - Include defmethods in document and workspace symbols. #1016
 
 ## 2022.06.29-19.32.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - Improve accuracy of progress reporting during uncached startup. #1134
   - Add refactoring `Destructure keys` to destructure keywords. #905
   - Add refactoring `Extract to def` to create a `def` from the thing under the cursor. #1136
+  - Include defmethods in document symbols. #1016
 
 ## 2022.06.29-19.32.13
 

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -8,7 +8,7 @@
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
         medley/medley {:mvn/version "1.4.0"}
         anonimitoraf/clj-flx {:mvn/version "1.2.0"}
-        clj-kondo/clj-kondo {:mvn/version "2022.06.23-20220704.194013-4"
+        clj-kondo/clj-kondo {:mvn/version "2022.06.23-20220721.181000-8"
                              :exclude [com.cognitect/transit-clj
                                        babashka/fs]}
         com.fabiodomingues/clj-depend {:mvn/version "0.6.1"}

--- a/lib/src/clojure_lsp/feature/document_symbol.clj
+++ b/lib/src/clojure_lsp/feature/document_symbol.clj
@@ -13,9 +13,9 @@
     (#{:var-definitions :var-usages} (:bucket el)) :variable
     :else :null))
 
-(defn element->name [{elem-name :name :keys [dispatch-val]}]
+(defn element->name [{elem-name :name :keys [dispatch-val-str]}]
   (cond-> (name elem-name)
-    dispatch-val (str " " dispatch-val)))
+    dispatch-val-str (str " " dispatch-val-str)))
 
 (defn ^:private element->document-symbol [e]
   (shared/assoc-some

--- a/lib/src/clojure_lsp/feature/document_symbol.clj
+++ b/lib/src/clojure_lsp/feature/document_symbol.clj
@@ -1,4 +1,7 @@
-(ns clojure-lsp.feature.document-symbol)
+(ns clojure-lsp.feature.document-symbol
+  (:require
+   [clojure-lsp.queries :as q]
+   [clojure-lsp.shared :as shared]))
 
 (set! *warn-on-reflection* true)
 
@@ -11,3 +14,39 @@
         (:fixed-arities el)) :function
     (#{:var-definitions :var-usages} (:bucket el)) :variable
     :else :null))
+
+(defn ^:private element-symbol [e]
+  (shared/assoc-some
+    {:kind (element->symbol-kind e)
+     :range (shared/->scope-range e)
+     :selection-range (shared/->range e)
+     :tags (cond-> []
+             (:deprecated e) (conj 1))}
+    :detail (when (:private e)
+              "private")))
+
+(defn ^:private var-defs [db filename]
+  (->> (q/find-var-definitions db filename true)
+       (map (fn [e]
+              (assoc (element-symbol e)
+                     :name (-> e :name name))))))
+
+(defn ^:private defmethods [db filename]
+  (->> (q/find-defmethods db filename)
+       (map (fn [e]
+              (assoc (element-symbol e)
+                     :name (-> e :name name))))))
+
+(defn document-symbols [db filename]
+  (let [namespace-definition (q/find-namespace-definition-by-filename db filename)]
+    [{:name (or (some-> namespace-definition :name name)
+                filename)
+      :kind (element->symbol-kind namespace-definition)
+      :range shared/full-file-range
+      :selection-range (if namespace-definition
+                         (shared/->scope-range namespace-definition)
+                         shared/full-file-range)
+      :children (->> (concat (var-defs db filename)
+                             (defmethods db filename))
+                     (sort-by #(shared/position->line-column (:start (:selection-range %))))
+                     vec)}]))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -225,26 +225,8 @@
   (shared/logging-task
     :document-symbol
     (let [db @db/db*
-          filename (shared/uri->filename textDocument)
-          namespace-definition (q/find-namespace-definition-by-filename db filename)]
-      [{:name (or (some-> namespace-definition :name name)
-                  filename)
-        :kind (f.document-symbol/element->symbol-kind namespace-definition)
-        :range shared/full-file-range
-        :selection-range (if namespace-definition
-                           (shared/->scope-range namespace-definition)
-                           shared/full-file-range)
-        :children (->> (q/find-var-definitions db filename true)
-                       (mapv (fn [e]
-                               (shared/assoc-some
-                                 {:name (-> e :name name)
-                                  :kind (f.document-symbol/element->symbol-kind e)
-                                  :range (shared/->scope-range e)
-                                  :selection-range (shared/->range e)
-                                  :tags (cond-> []
-                                          (:deprecated e) (conj 1))}
-                                 :detail (when (:private e)
-                                           "private")))))}])))
+          filename (shared/uri->filename textDocument)]
+      (f.document-symbol/document-symbols db filename))))
 
 (defn document-highlight [{:keys [textDocument position]}]
   (process-after-changes

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -704,6 +704,12 @@
           (xf-var-defs false))
         (:analysis db)))
 
+(defn find-defmethods [db filename]
+  (into []
+        (comp (filter :defmethod)
+              (medley/distinct-by (juxt :to :name :name-row :name-col)))
+        (get-in db [:analysis filename :var-usages])))
+
 (defn find-keyword-definitions [db filename]
   (into []
         (medley/distinct-by (juxt :ns :name :row :col))

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -704,11 +704,26 @@
           (xf-var-defs false))
         (:analysis db)))
 
+(def ^:private xf-defmethods
+  (comp (filter :defmethod)
+        (medley/distinct-by (juxt :to :name :name-row :name-col))))
+
 (defn find-defmethods [db filename]
   (into []
-        (comp (filter :defmethod)
-              (medley/distinct-by (juxt :to :name :name-row :name-col)))
+        xf-defmethods
         (get-in db [:analysis filename :var-usages])))
+
+(defn find-internal-definitions
+  "All ns definitions, var definitions and defmethods."
+  [db]
+  (let [analysis (internal-analysis db)]
+    (concat (into []
+                  (xf-analysis->buckets-elems :namespace-definitions :var-definitions)
+                  analysis)
+            (into []
+                  (comp xf-analysis->var-usages
+                        xf-defmethods)
+                  analysis))))
 
 (defn find-keyword-definitions [db filename]
   (into []

--- a/lib/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/lib/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -11,12 +11,15 @@
   (h/load-code-and-locs (h/code "(ns foo.alpaca.ns (:require [clojure.string :as string]))"
                                 "(defonce my-alpapapaca (atom {}))"
                                 "(def alpac 1)"
-                                "(defn alpacas [a b] alpac)"))
+                                "(defn alpacas [a b] alpac)"
+                                "(defmulti llama identity)"))
   (h/load-code-and-locs (h/code "(ns foo.goat.ns (:require [foo.alpaca.ns :as a]))"
-                                "(defn goats-from-alpacas [alpacas] (map inc alpacas))")
+                                "(defn goats-from-alpacas [alpacas] (map inc alpacas))"
+                                "(defmethod a/llama \"wooly\")")
                         (h/file-uri "file:///b.clj"))
   (testing "querying all symbols"
-    (is (= [{:name "foo.alpaca.ns"
+    (is (= [;; a.clj
+            {:name "foo.alpaca.ns"
              :kind :namespace
              :location
              {:uri (h/file-uri "file:///a.clj")
@@ -36,21 +39,33 @@
              :location
              {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 3 :character 0} :end {:line 3 :character 26}}}}
+            {:name "llama",
+             :kind :variable,
+             :location
+             {:uri (h/file-uri "file:///a.clj"),
+              :range {:start {:line 4, :character 0}, :end {:line 4, :character 25}}}}
+            ;; b.clj
             {:kind :namespace,
-             :location {:range {:end {:character 49, :line 0}, :start {:character 0, :line 0}},
+             :location {:range {:start {:line 0, :character 0}, :end {:line 0, :character 49}},
                         :uri (h/file-uri "file:///b.clj")},
              :name "foo.goat.ns"}
             {:kind :function,
-             :location {:range {:end {:character 53, :line 1}, :start {:character 0, :line 1}},
+             :location {:range {:start {:line 1, :character 0}, :end {:line 1, :character 53}},
                         :uri (h/file-uri "file:///b.clj")},
-             :name "goats-from-alpacas"}]
+             :name "goats-from-alpacas"}
+            {:name "llama",
+             :kind :variable,
+             :location {:range {:start {:line 2, :character 11}, :end {:line 2, :character 18}},
+                        :uri (h/file-uri "file:///b.clj")}}]
            (f.workspace-symbols/workspace-symbols "" @db/db*))))
   (testing "querying a specific function using fuzzy search"
-    (is (= [{:name "foo.alpaca.ns"
+    (is (= [;; a.clj
+            {:name "foo.alpaca.ns"
              :kind :namespace
              :location
              {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 0 :character 0} :end {:line 0 :character 57}}}}
+            ;; later in file, but better search score
             {:name "alpacas"
              :kind :function
              :location
@@ -61,8 +76,9 @@
              :location
              {:uri (h/file-uri "file:///a.clj")
               :range {:start {:line 1 :character 0} :end {:line 1 :character 33}}}}
+            ;; b.clj
             {:kind :function,
-             :location {:range {:end {:character 53, :line 1}, :start {:character 0, :line 1}},
+             :location {:range {:start {:line 1, :character 0}, :end {:line 1, :character 53}},
                         :uri (h/file-uri "file:///b.clj")},
              :name "goats-from-alpacas"}]
            (f.workspace-symbols/workspace-symbols "alpaca" @db/db*)))))

--- a/lib/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/lib/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -53,7 +53,7 @@
              :location {:range {:start {:line 1, :character 0}, :end {:line 1, :character 53}},
                         :uri (h/file-uri "file:///b.clj")},
              :name "goats-from-alpacas"}
-            {:name "llama",
+            {:name "llama \"wooly\"",
              :kind :variable,
              :location {:range {:start {:line 2, :character 11}, :end {:line 2, :character 18}},
                         :uri (h/file-uri "file:///b.clj")}}]

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -65,7 +65,7 @@
       (is (some? (get-in @db/db* [:analysis (h/file-path "/project/src/foo/baz.edn")]))))))
 
 (deftest document-symbol
-  (let [code "(ns a) (def bar ::bar) (def ^:m baz 1)"
+  (let [code "(ns a) (def bar ::bar) (def ^:m baz 1) (defmulti mult identity) (defmethod mult \"foo\")"
         result [{:name "a"
                  :kind :namespace
                  :range {:start {:line 0 :character 0} :end {:line 999999 :character 999999}}
@@ -79,6 +79,23 @@
                              :kind :variable
                              :range {:start {:line 0 :character 23} :end {:line 0 :character 38}}
                              :selection-range {:start {:line 0 :character 32} :end {:line 0 :character 35}}
+                             :tags []}
+                            ;; defmulti
+                            {:name "mult",
+                             :kind :variable,
+                             :range {:start {:line 0, :character 39}, :end {:line 0, :character 63}},
+                             :selection-range {:start {:line 0, :character 49}, :end {:line 0, :character 53}},
+                             :tags []}
+                            ;; defmethod
+                            ;; TODO: after
+                            ;; https://github.com/clj-kondo/clj-kondo/issues/1716
+                            ;; switch this to `mult "foo"`, and mark
+                            ;; https://github.com/clojure-lsp/clojure-lsp/issues/1016
+                            ;; as fixed.
+                            {:name "mult",
+                             :kind :variable,
+                             :range {:start {:line 0, :character 75}, :end {:line 0, :character 79}},
+                             :selection-range {:start {:line 0, :character 75}, :end {:line 0, :character 79}},
                              :tags []}]}]]
     (testing "clj files"
       (h/load-code-and-locs code)

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -87,12 +87,7 @@
                              :selection-range {:start {:line 0, :character 49}, :end {:line 0, :character 53}},
                              :tags []}
                             ;; defmethod
-                            ;; TODO: after
-                            ;; https://github.com/clj-kondo/clj-kondo/issues/1716
-                            ;; switch this to `mult "foo"`, and mark
-                            ;; https://github.com/clojure-lsp/clojure-lsp/issues/1016
-                            ;; as fixed.
-                            {:name "mult",
+                            {:name "mult \"foo\"",
                              :kind :variable,
                              :range {:start {:line 0, :character 75}, :end {:line 0, :character 79}},
                              :selection-range {:start {:line 0, :character 75}, :end {:line 0, :character 79}},


### PR DESCRIPTION
This PR lists defmethods in document-symbols and workspace-symbols. Before, if your code was
```clojure
(defmulti area :shape/type)
(defmethod area :circle [shape])
(defmethod area :square [shape])
```
Then document-symbols would be
```
area
```
Now it will be

```
area
area :circle
area :square
```

Fixes #1016

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
