### PR TITLE
Choose PowerShell exec program on Windows based on availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,13 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
-      - name: Install Clojure
+      - name: Install clojure build tools
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.1013'
-
-      - name: Install Babashka
-        run: curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install | sudo bash
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
 
       - name: Generate embedded binary
         run: make prod-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,51 @@ jobs:
       - name: Run babashka pod tests
         run: make pod-test
 
+  jvm-integration-test-windows:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [8]
+    steps:
+      - uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+
+      - name: Install clojure build tools
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.3.1013'
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
+
+      - name: Install launch4j
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install launch4j
+
+      - name: Generate embedded binary
+        env:
+          LAUNCH4J_HOME: "C:\\Program Files (x86)\\Launch4j"
+        run: |
+          cd cli
+          clojure -T:build prod-cli
+      - name: Run integration tests
+        run: |
+          cd cli
+          bb integration-test ../clojure-lsp.exe
+
+      # - name: Run babashka pod tests
+      #   run: |
+      #     cd cli
+      #     clojure -M:pod-test
+
   graalvm-build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,13 +156,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Clojure
+      - name: Install clojure build tools
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.1013'
-
-      - name: Install Babashka
-        run: curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install | sudo bash
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
 
       - uses: actions/download-artifact@v2
         name: clojure-lsp-native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,10 @@ jobs:
           cd cli
           bb integration-test ../clojure-lsp.exe
 
-      # - name: Run babashka pod tests
-      #   run: |
-      #     cd cli
-      #     clojure -M:pod-test
+      - name: Run babashka pod tests
+        run: |
+          cd cli
+          clojure -M:pod-test
 
   graalvm-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,40 +77,6 @@ jobs:
           path: clojure-lsp
           name: clojure-lsp
 
-  build-cli-jar-win:
-    if: startsWith(github.ref, 'refs/tags/2')
-    name: Build JVM cli win
-    runs-on: windows-2022
-    steps:
-      - uses: actions/checkout@v2.2.0
-        with:
-          fetch-depth: 0
-      - name: Prepare java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Install Clojure
-        uses: DeLaGuardo/setup-clojure@master
-        with:
-          cli: '1.10.3.1013'
-
-      - name: Get latest tag
-        id: latest-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-
-      - name: Generate jar for native
-        run: |
-          cd cli
-          clojure -T:build prod-jar-for-native
-          mv target/clojure-lsp-standalone.jar ../clojure-lsp-standalone-win.jar
-
-      - name: Upload jar
-        uses: actions/upload-artifact@v2
-        with:
-          path: clojure-lsp-standalone-win.jar
-          name: clojure-lsp-standalone-win.jar
-
   linux-amd64:
     name: Build native linux amd64 binary
     needs: [build-lib-jar, build-cli-jar]
@@ -356,13 +322,13 @@ jobs:
 
   windows:
     name: Build native Windows binary
-    needs: [build-lib-jar, build-cli-jar-win]
+    needs: [build-lib-jar, build-cli-jar]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: clojure-lsp-standalone-win.jar
+          name: clojure-lsp-standalone.jar
 
       - name: configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.2
@@ -403,7 +369,7 @@ jobs:
 
       - name: Build Windows native image
         env:
-          CLOJURE_LSP_JAR: ..\clojure-lsp-standalone-win.jar
+          CLOJURE_LSP_JAR: ..\clojure-lsp-standalone.jar
           CLOJURE_LSP_XMX: "-J-Xmx7g"
         run: |
           cd cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,40 @@ jobs:
           path: clojure-lsp
           name: clojure-lsp
 
+  build-cli-jar-win:
+    if: startsWith(github.ref, 'refs/tags/2')
+    name: Build JVM cli win
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+      - name: Prepare java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.3.1013'
+
+      - name: Get latest tag
+        id: latest-tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+
+      - name: Generate jar for native
+        run: |
+          cd cli
+          clojure -T:build prod-jar-for-native
+          mv target/clojure-lsp-standalone.jar ../clojure-lsp-standalone-win.jar
+
+      - name: Upload jar
+        uses: actions/upload-artifact@v2
+        with:
+          path: clojure-lsp-standalone-win.jar
+          name: clojure-lsp-standalone-win.jar
+
   linux-amd64:
     name: Build native linux amd64 binary
     needs: [build-lib-jar, build-cli-jar]
@@ -87,13 +121,13 @@ jobs:
         with:
           name: clojure-lsp-standalone.jar
 
-      - name: Install Clojure
+      - name: Install clojure build tools
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.1013'
-
-      - name: Install Babashka
-        run: curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install | sudo bash
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
 
       - name: Install GraalVM
         uses: DeLaGuardo/setup-graalvm@master
@@ -145,13 +179,13 @@ jobs:
         with:
           name: clojure-lsp-standalone.jar
 
-      - name: Install Clojure
+      - name: Install clojure build tools
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.1013'
-
-      - name: Install Babashka
-        run: curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install | sudo bash
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
 
       - uses: graalvm/setup-graalvm@v1
         with:
@@ -277,13 +311,13 @@ jobs:
         with:
           name: clojure-lsp-standalone.jar
 
-      - name: Install Clojure
+      - name: Install clojure build tools
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.1013'
-
-      - name: Install Babashka
-        run: curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install | sudo bash
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
 
       - name: Install GraalVM
         uses: DeLaGuardo/setup-graalvm@master
@@ -322,13 +356,13 @@ jobs:
 
   windows:
     name: Build native Windows binary
-    needs: [build-lib-jar, build-cli-jar]
+    needs: [build-lib-jar, build-cli-jar-win]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: clojure-lsp-standalone.jar
+          name: clojure-lsp-standalone-win.jar
 
       - name: configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.2
@@ -341,14 +375,13 @@ jobs:
         with:
           java-version: 11
 
-      - name: Install Clojure
-        run: |
-          iwr -useb download.clojure.org/install/win-install-1.10.3.1013.ps1 | iex
-
-      - name: Install Babashka
-        uses: turtlequeue/setup-babashka@v1.3.0
+      - name: Install clojure build tools
+        uses: DeLaGuardo/setup-clojure@master
         with:
-          babashka-version: 0.7.8
+          cli: '1.10.3.1013'
+          lein: '2.9.1'
+          boot: '2.8.3'
+          bb: '0.9.161'
 
       - name: Install MSVC
         uses: ilammy/msvc-dev-cmd@v1
@@ -370,7 +403,7 @@ jobs:
 
       - name: Build Windows native image
         env:
-          CLOJURE_LSP_JAR: ..\clojure-lsp-standalone.jar
+          CLOJURE_LSP_JAR: ..\clojure-lsp-standalone-win.jar
           CLOJURE_LSP_XMX: "-J-Xmx7g"
         run: |
           cd cli
@@ -383,10 +416,10 @@ jobs:
         with:
           file: clojure-lsp.exe
 
-      # Windows return the json in the same line but for some reason clients seems to accept that.
-      # - name: Run integration tests
-      #   run: |
-      #     bb integration-test/run-all.clj .\clojure-lsp.exe
+      - name: Run integration tests
+        run: |
+          cd cli
+          bb integration-test ../clojure-lsp.exe
 
       - name: Zip binary
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cli/integration-test/sample-test/clojure-lsp.integration-test.out
 output.calva-repl
 
 result
+
+# emacs
+*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
   - Generate nightly builds for macos aarch64 (M1/M2) every push on master.
   - Bump lsp4clj to `1.2.1`.
   - Bump cljfmt to `0.9.0`.
-  
+  - Fix issue with classpath clojure build tools invocation on MS-Windows. #1132
+  - Bump babashka/fs to `0.1.11`.
+
 - Editor
   - Improve completion sorting, showing locals before functions and other completion items. #1158
   - Fix hover to show current var definition docs instead of `def`/`defn`. #1157

--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -18,7 +18,7 @@
                                                    :sha "6df443fabf0d7313c8956cb6f55e47318402991f"}}
             :main-opts ["-m" "cognitect.test-runner" "-d" "pod-test"]}
            :build {:extra-paths ["../lib/resources"]
-                   :extra-deps {babashka/fs {:mvn/version "0.1.6"}
+                   :extra-deps {babashka/fs {:mvn/version "0.1.11"}
                                 babashka/process {:mvn/version "0.1.7"}}
                    :replace-deps {io.github.clojure/tools.build {:tag "v0.8.3" :sha "0d20256"}
                                   com.github.ericdallo/deps-bin {:mvn/version "0.1.2"}

--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -18,6 +18,8 @@
                                                    :sha "6df443fabf0d7313c8956cb6f55e47318402991f"}}
             :main-opts ["-m" "cognitect.test-runner" "-d" "pod-test"]}
            :build {:extra-paths ["../lib/resources"]
+                   :extra-deps {babashka/fs {:mvn/version "0.1.6"}
+                                babashka/process {:mvn/version "0.1.7"}}
                    :replace-deps {io.github.clojure/tools.build {:tag "v0.8.3" :sha "0d20256"}
                                   com.github.ericdallo/deps-bin {:mvn/version "0.1.2"}
                                   slipset/deps-deploy {:mvn/version "0.2.0"}}

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -1,34 +1,38 @@
 (ns entrypoint
   (:require
+   [babashka.fs :as fs]
    [clojure.test :as t]
    [medley.core :as medley]
    [clojure.java.shell :as sh]))
 
+
 (def namespaces
-  '[
-    integration.initialize-test
-    integration.definition-test
-    integration.declaration-test
-    integration.implementation-test
-    integration.text-change-test
-    integration.code-action-test
-    integration.completion-test
-    integration.diagnostics-test
-    integration.settings-change-test
-    integration.formatting-test
-    integration.rename-test
-    integration.document-highlight-test
-    integration.document-symbol-test
-    integration.linked-editing-range-test
-    integration.cursor-info-test
-    integration.java-interop-test
-    integration.stubs-test
-    integration.api.version-test
-    integration.api.clean-ns-test
-    integration.api.diagnostics-test
-    integration.api.format-test
-    integration.api.rename-test
-    ])
+  (if (fs/windows?)
+    '[integration.classpath-test]
+
+    '[integration.initialize-test
+      integration.definition-test
+      integration.declaration-test
+      integration.implementation-test
+      integration.text-change-test
+      integration.code-action-test
+      integration.completion-test
+      integration.diagnostics-test
+      integration.settings-change-test
+      integration.formatting-test
+      integration.rename-test
+      integration.document-highlight-test
+      integration.document-symbol-test
+      integration.linked-editing-range-test
+      integration.cursor-info-test
+      integration.java-interop-test
+      integration.stubs-test
+      integration.classpath-test
+      integration.api.version-test
+      integration.api.clean-ns-test
+      integration.api.diagnostics-test
+      integration.api.format-test
+      integration.api.rename-test]))
 
 (defn timeout [timeout-ms callback]
   (let [fut (future (callback))

--- a/cli/integration-test/integration/classpath_test.clj
+++ b/cli/integration-test/integration/classpath_test.clj
@@ -1,0 +1,47 @@
+(ns integration.classpath-test
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is]]
+   [integration.fixture :as fixture]
+   [integration.lsp :as lsp]))
+
+(lsp/clean-after-test)
+
+(defn getRootPath [sample-test-dir]
+  (-> (fs/canonicalize ".")
+      (fs/path "integration-test" sample-test-dir)))
+
+(defn getRootUri
+  "Return the URI to the given SAMPLE-TEST-DIR."
+  [sample-test-dir]
+  (-> (getRootPath sample-test-dir)
+      .toUri .toString))
+
+(defn delete-lsp-cache [sample-test-dir]
+  (-> (getRootPath sample-test-dir)
+      (fs/path ".lsp" ".cache")
+      fs/delete-tree))
+
+(defn classpath-test-project [sample-test-dir]
+  (delete-lsp-cache sample-test-dir)
+  (lsp/start-process!)
+  (lsp/request! [:initialize {:rootUri (getRootUri sample-test-dir)
+                              :initializationOptions fixture/default-init-options}])
+  (let [{:keys [classpath] :as _res} (lsp/request! ["clojure/serverInfo/raw" {}])]
+    (is (some #(str/includes? % "datomic-free") classpath))))
+
+(deftest claspath-babashka
+  (classpath-test-project "sample-test-bb"))
+
+(deftest claspath-boot
+  (classpath-test-project "sample-test-boot"))
+
+(deftest claspath-cli
+  (classpath-test-project "sample-test"))
+
+(deftest claspath-lein
+  (classpath-test-project "sample-test-lein"))
+
+(deftest claspath-shadow
+  (classpath-test-project "sample-test-shadow"))

--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -198,7 +198,7 @@
 
 (defn request-and-await-server-response! [client method body]
   (let [resp (deref (protocols.endpoint/send-request client method body)
-                    60000
+                    90000
                     ::timeout)]
     (if (= ::timeout resp)
       (do

--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -198,7 +198,7 @@
 
 (defn request-and-await-server-response! [client method body]
   (let [resp (deref (protocols.endpoint/send-request client method body)
-                    30000
+                    60000
                     ::timeout)]
     (if (= ::timeout resp)
       (do

--- a/cli/integration-test/sample-test-bb/.lsp/config.edn
+++ b/cli/integration-test/sample-test-bb/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:linters {:clj-kondo {:ns-exclude-regex ""}}
+ :log-path "clojure-lsp.integration-test.out"}

--- a/cli/integration-test/sample-test-bb/bb.edn
+++ b/cli/integration-test/sample-test-bb/bb.edn
@@ -1,0 +1,1 @@
+{:deps {com.datomic/datomic-free {:mvn/version "0.9.5697"}}}

--- a/cli/integration-test/sample-test-boot/.lsp/config.edn
+++ b/cli/integration-test/sample-test-boot/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:linters {:clj-kondo {:ns-exclude-regex ""}}
+ :log-path "clojure-lsp.integration-test.out"}

--- a/cli/integration-test/sample-test-boot/build.boot
+++ b/cli/integration-test/sample-test-boot/build.boot
@@ -1,0 +1,2 @@
+(set-env!
+  :dependencies '[[com.datomic/datomic-free  "0.9.5697"]])

--- a/cli/integration-test/sample-test-lein/.lsp/config.edn
+++ b/cli/integration-test/sample-test-lein/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:linters {:clj-kondo {:ns-exclude-regex ""}}
+ :log-path "clojure-lsp.integration-test.out"}

--- a/cli/integration-test/sample-test-lein/project.clj
+++ b/cli/integration-test/sample-test-lein/project.clj
@@ -1,0 +1,2 @@
+(defproject clojure-lsp.integration/sample "test"
+  :dependencies [[com.datomic/datomic-free  "0.9.5697"]])

--- a/cli/integration-test/sample-test-shadow/.lsp/config.edn
+++ b/cli/integration-test/sample-test-shadow/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:linters {:clj-kondo {:ns-exclude-regex ""}}
+ :log-path "clojure-lsp.integration-test.out"}

--- a/cli/integration-test/sample-test-shadow/shadow-cljs.edn
+++ b/cli/integration-test/sample-test-shadow/shadow-cljs.edn
@@ -1,0 +1,1 @@
+{:dependencies [[com.datomic/datomic-free  "0.9.5697"]]}

--- a/cli/pod-test/clojure_lsp/pod_test.clj
+++ b/cli/pod-test/clojure_lsp/pod_test.clj
@@ -2,11 +2,14 @@
   (:require
    [babashka.pods :as pods]
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]))
 
 (def pod-spec (if (= "native" (System/getenv "CLOJURE_LSP_TEST_ENV"))
                 ["../clojure-lsp"]
-                ["clojure" "-M:run"]))
+                (if (str/starts-with? (System/getProperty "os.name") "Windows")
+                  ["powershell" "-Command" "clojure" "-M:run"]
+                  ["clojure" "-M:run"])))
 
 (pods/load-pod pod-spec)
 (require '[clojure-lsp.api :as clojure-lsp])

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -15,7 +15,8 @@
         com.cognitect/transit-clj {:mvn/version "1.0.329"}
         com.github.clj-easy/stub {:mvn/version "0.2.3"}
         org.benf/cfr {:mvn/version "0.152"}
-        babashka/fs {:mvn/version "0.1.6"}
+
+        babashka/fs {:mvn/version "0.1.11"}
         com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
         ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         }

--- a/lib/src/clojure_lsp/classpath.clj
+++ b/lib/src/clojure_lsp/classpath.clj
@@ -151,8 +151,6 @@
          (mapv #(lookup-classpath-handling-error! % root-path producer))
          (reduce set/union))))
 
-
-
 (defn ^:private lein-source-aliases [source-aliases]
   (some->> source-aliases
            (map #(str "+" (name %)))

--- a/lib/test/clojure_lsp/classpath_test.clj
+++ b/lib/test/clojure_lsp/classpath_test.clj
@@ -1,5 +1,7 @@
 (ns clojure-lsp.classpath-test
   (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
    [clojure-lsp.classpath :as classpath]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
@@ -8,7 +10,8 @@
 (h/reset-components-before-test)
 
 (deftest default-project-specs-test
-  (with-redefs [shared/windows-os? false]
+  (with-redefs [classpath/locate-executable identity]
+
     (testing "empty source-aliases"
       (is (h/assert-contains-submaps
             [{:project-path "project.clj"
@@ -48,3 +51,243 @@
              {:project-path "bb.edn"
               :classpath-cmd ["bb" "print-deps" "--format" "classpath"]}]
             (classpath/default-project-specs #{:something :otherthing}))))))
+
+(defn make-components
+  "Create a PROJECT-FILENAME file at DIR and return a clojure-lsp
+components reference to it."
+  [dir project-filename]
+  (let [project (.toString (fs/path dir project-filename))
+        db {:project-root-uri (-> dir .toUri .toString)
+            :settings {:project-specs
+                       (classpath/default-project-specs #{})}}]
+    (spit project "")
+    {:db* (atom db)}))
+
+(defn locate-executable-mock
+  "Return a fn that mocks `clojure-lsp.classpath/locate-executable` by
+  returning EXECUTABLE paths as found in the static RESPONSES map."
+  [responses]
+  (fn [executable]
+    (some (fn [[exec response]]
+            (when (= executable exec)
+              response))
+          responses)))
+
+(defn shell-mock
+  "Return a fn that mocks `clojure-lsp.classpath/shell` by returning a
+  succesfull exit code with a corresponding value from RESPONSES when
+  the CMD-AND-ARGS match a RESPONSES key or returns a failed exit code
+  if not."
+  [responses]
+  (fn [& cmd-and-args]
+    (if-let [out (some (fn [[response-key response]]
+                         (when (= response-key cmd-and-args)
+                           response))
+                       responses)]
+      {:exit 0 :out out}
+
+      {:exit 1})))
+
+(deftest classpath
+
+  (testing "babashka"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [classpath/locate-executable (locate-executable-mock {"bb" "pathto/bb.xyz"})
+
+                    classpath/shell
+                    (shell-mock {["pathto/bb.xyz" "print-deps" "--format" "classpath" :dir (.toString temp-dir)]
+                                 (str/join fs/path-separator ["a" "b"])})]
+
+        (let [components (make-components temp-dir "bb.edn")]
+          (is (= #{"a" "b"} (classpath/scan-classpath! components)))))))
+
+  (testing "boot"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [classpath/locate-executable (locate-executable-mock {"boot" "pathto/boot.xyz"})
+
+                    classpath/shell
+                    (shell-mock {["pathto/boot.xyz" "show" "--fake-classpath" :dir (.toString temp-dir)]
+                                 (str/join fs/path-separator ["a" "b"])})]
+        (let [components (make-components temp-dir "build.boot")]
+          (is (= #{"a" "b"} (classpath/scan-classpath! components)))))))
+
+  (testing "clojure"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? false
+
+                    classpath/locate-executable (locate-executable-mock {"clojure" "pathto/clojure.xyz"})
+
+                    classpath/shell
+                    (shell-mock {["pathto/clojure.xyz" "-Spath" :dir (.toString temp-dir)]
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+  ;; exhaustive testing of powershell invocation on windows
+
+  (testing "clojure win [powershell clojure]"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+
+                    classpath/locate-executable (locate-executable-mock {"powershell" "pathto/powershell.exe"})
+
+                    classpath/shell
+                    (shell-mock {(#'classpath/psh-cmd "pathto/powershell.exe" "Get-Command" "clojure")
+                                 "clojure command exists"
+
+                                 (#'classpath/psh-cmd "pathto/powershell.exe" "clojure" "-Spath" :dir (.toString temp-dir))
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+  (testing "clojure win [pwsh clojure]"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+
+                    classpath/locate-executable (locate-executable-mock {"pwsh" "pathto/pwsh.exe"})
+
+                    classpath/shell
+                    (shell-mock {(#'classpath/psh-cmd "pathto/pwsh.exe" "Get-Command" "clojure")
+                                 "clojure command exists"
+
+                                 (#'classpath/psh-cmd "pathto/pwsh.exe" "clojure" "-Spath" :dir (.toString temp-dir))
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+  (testing "clojure win [powershell clojure] & [pwsh clojure]"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+
+                    classpath/locate-executable (locate-executable-mock {"powershell" "pathto/powershell.exe"
+                                                                         "pwsh" "pathto/pwsh.exe"})
+
+                    classpath/shell
+                    (shell-mock {(#'classpath/psh-cmd "pathto/powershell.exe" "Get-Command" "clojure")
+                                 "clojure command exists"
+                                 (#'classpath/psh-cmd "pathto/pwsh.exe" "Get-Command" "clojure")
+                                 "clojure command exists"
+
+                                 (#'classpath/psh-cmd "pathto/powershell.exe" "clojure" "-Spath" :dir (.toString temp-dir))
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+  (testing "clojure win [powershell clojure] & [pwsh]"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+
+                    classpath/locate-executable (locate-executable-mock {"powershell" "pathto/powershell.exe"
+                                                                         "pwsh" "pathto/pwsh.exe"})
+
+                    classpath/shell
+                    (shell-mock {(#'classpath/psh-cmd "pathto/powershell.exe" "Get-Command" "clojure")
+                                 "clojure command exists"
+
+                                 (#'classpath/psh-cmd "pathto/powershell.exe" "clojure" "-Spath" :dir (.toString temp-dir))
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+  (testing "clojure win [powershell] & [pwsh clojure]"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+
+                    classpath/locate-executable (locate-executable-mock {"powershell" "pathto/powershell.exe"
+                                                                         "pwsh" "pathto/pwsh.exe"})
+
+                    classpath/shell
+                    (shell-mock {(#'classpath/psh-cmd "pathto/pwsh.exe" "Get-Command" "clojure")
+                                 "clojure command exists"
+
+                                 (#'classpath/psh-cmd "pathto/pwsh.exe" "clojure" "-Spath" :dir (.toString temp-dir))
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+
+  ;; test with multiple project files present
+  (testing "clojure & bb"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? false
+
+                    classpath/locate-executable (locate-executable-mock {"bb" "pathto/bb.xyz"
+                                                                         "clojure" "pathto/clojure.xyz"})
+
+                    classpath/shell
+                    (shell-mock {["pathto/bb.xyz" "print-deps" "--format" "classpath" :dir (.toString temp-dir)]
+                                 (str/join fs/path-separator ["a" "b"])
+
+                                 ["pathto/clojure.xyz" "-Spath" :dir (.toString temp-dir)]
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "deps.edn")
+              bb (.toString (fs/path temp-dir "bb.edn"))]
+          (spit bb "")
+          (is (= #{"a" "b" "c"} (classpath/scan-classpath! components)))))))
+
+  (testing "lein"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? false
+                    classpath/locate-executable (locate-executable-mock {"lein" "pathto/lein.xyz"})
+                    classpath/shell (shell-mock {["pathto/lein.xyz" "classpath" :dir (.toString temp-dir)]
+                                                 (str/join fs/path-separator ["a" "b"])})]
+        (let [components (make-components temp-dir "project.clj")]
+          (is (= #{"a" "b"} (classpath/scan-classpath! components)))))))
+
+  ;; lein can be either a standalone script or invoked via powershell.
+  (testing "lein win"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+                    classpath/locate-executable (locate-executable-mock {"lein" "pathto/lein.xyz"})
+                    classpath/shell (shell-mock {["pathto/lein.xyz" "classpath" :dir (.toString temp-dir)]
+                                                 (str/join fs/path-separator ["a" "b"])})]
+        (let [components (make-components temp-dir "project.clj")]
+          (is (= #{"a" "b"} (classpath/scan-classpath! components)))))))
+
+  ;; just run a sample of powershell invocation tests, exhaustive testing is done via clojure
+  (testing "lein win [pwsh clojure]"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [shared/windows-os? true
+
+                    classpath/locate-executable (locate-executable-mock {"pwsh" "pathto/pwsh.exe"})
+
+                    classpath/shell
+                    (shell-mock {(#'classpath/psh-cmd "pathto/pwsh.exe" "Get-Command" "lein")
+                                 "lein command exists"
+
+                                 (#'classpath/psh-cmd "pathto/pwsh.exe" "lein" "classpath" :dir (.toString temp-dir))
+                                 (str/join fs/path-separator ["a" "c"])})]
+
+        (let [components (make-components temp-dir "project.clj")]
+          (is (= #{"a" "c"} (classpath/scan-classpath! components)))))))
+
+  (testing "shadow-cljs"
+    (fs/with-temp-dir
+      [temp-dir]
+      (with-redefs [classpath/locate-executable (locate-executable-mock {"npx" "pathto/npx.xyz"})
+
+                    classpath/shell
+                    (shell-mock {["pathto/npx.xyz" "shadow-cljs" "classpath" :dir (.toString temp-dir)]
+                                 (str/join fs/path-separator ["a" "b"])})]
+
+        (let [components (make-components temp-dir "shadow-cljs.edn")]
+          (is (= #{"a" "b"} (classpath/scan-classpath! components))))))))


### PR DESCRIPTION
Hi,

can you please consider patch to fix an issue on MS-Windows that always tries to invoke `pwsh.exe` to scan the classpath, even if it is not installed. It fixes #1132.

`clojure-lsp` invokes one of `Clojure`, `lein`, `boot` or `bb` executables on *nix to retrieve a project's class path.  Invoking these programs on MS-Windows by this name is not always successful, if their extension is not `.exe` or `.bat`. In that case they have either to be invoked with their name+extension (e.g. `npx.cmd`) or if they are PowerShell `.ps1` scripts (as with Clojure cli tools or some installation of `lein`) they have to be invoked with a PowerShell executable (either `powershell.exe` that is preinstalled on Windows or `pws.exe` if newer versions of PowerShell is installed by the user).

Currently `clojure-lsp` tries to invoke all project executables using `pwsh` which is not preinstalled with MS-Windows, and thus fails.

This patch either adds the extension to the project executable so that can be invoked, or, in the case of a powershell script, tries to locate the PowerShell executable installed on the system and uses that to invoke it.

For demo purposes, I've created tests that confirm the good usage across all different type of projects and architectures, though I understand that this is quite a lot. The tests will be skipped if the project executable is not installed (e.g. `boot`), but will always run on GitHub. I've named the action  `cross platform tests`, although it runs only these new tests under `classpath`. Currently the clojure-lsp test suite does not pass under MS-Windows, and I plan at some point to make everything work on Win, and perhaps add them in this action. Feel free to ask it to be removed.

Thanks





- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)

