### PR TITLE
Ensure that :keep no-ops the initial form indent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Fix to navigate to var defined by declare, when there aren't any later defs. #1107
   - Fix to always go to the definition of the correct var imported by potemkin. #1020
   - Fix to correctly rename namespaces. #1121
+  - Fix to correctly :keep require and import indent spacing. #1141
 
 ## 2022.06.29-19.32.13
 
@@ -78,7 +79,7 @@
   - Fix find definition of macros required by :require-macros on cljs files. #980
   - Add support to completion keywords found on function definition `:keys` destructuring, improving completion on api calls.
   - Avoid duplicate parens when inserting snippets during completion. #982
-  
+
 - CLI/API
   - Make all cli features open files faster, improving speed of all CLI/API features. Fixes #985
 
@@ -101,7 +102,7 @@
 
 - CLI/API
   - Bump lsp4clj to `0.3.0`.
-  
+
 This release was supported by [Clojurists Together](https://www.clojuriststogether.org/)
 
 ## 2022.04.18-00.59.32
@@ -138,17 +139,17 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
 
 - CLI
   - Reduce CPU and wall-clock time in cli commands clean-ns and diagnostics
-  
+
 This release was supported by [Clojurists Together](https://www.clojuriststogether.org/)
 
 ## 2022.03.31-20.00.20
 
 - Fix URI resolver on java JDK logic.
-- Fix zipfile scheme when finding external deps. 
+- Fix zipfile scheme when finding external deps.
 
 ## 2022.03.31-14.21.14
 
-- Add java class find-definition support, decompiling .class files when available. #762 
+- Add java class find-definition support, decompiling .class files when available. #762
 - Add JDK source discoverability feature, searching for installed JDK for later analyze with clj-kondo and support java classes interop.
 - Add `:java :download-jdk-source?` setting to download JDK source after startup if not cached before globally or found locally. Disabled by default.
 - Avoid high CPU usage and freezes by more efficiently finding referenced files to notify on file change. #844 @mainej

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -391,7 +391,7 @@
     parent-node))
 
 (defn ^:private clean-imports
-  [ns-loc {:keys [ns-inner-blocks-indentation unused-imports] :as clean-ctx} settings]
+  [ns-loc {:keys [unused-imports] :as clean-ctx} settings]
   (if-let [import-loc (z/find-value (zsub/subzip ns-loc) z/next :import)]
     (let [col (ns-inner-blocks-indentation-parent-col import-loc clean-ctx)
           keep-first-line-spacing (calc-keep-first-line-spacing import-loc)

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -47,7 +47,7 @@
       new-node)))
 
 (defn ^:private process-clean-ns
-  [ns-loc removed-nodes col form-type clean-ctx]
+  [ns-loc removed-nodes col keep-first-line-spacing form-type clean-ctx]
   (let [removed-nodes (edit/map-children removed-nodes remove-empty-reader-conditional)
         sep (n/whitespace-node (apply str (repeat col " ")))
         single-space (n/whitespace-node " ")
@@ -113,6 +113,12 @@
                          (and (= :same-line (:ns-inner-blocks-indentation clean-ctx))
                               (= idx 0))
                          [single-space node]
+
+                         (and (= :keep (:ns-inner-blocks-indentation clean-ctx))
+                              keep-first-line-spacing
+                              (= idx 0))
+                         [(n/whitespace-node (apply str (repeat keep-first-line-spacing " ")))
+                          node]
 
                          (some-> (nth forms-w-comments (dec idx) nil)
                                  n/comment?)
@@ -274,14 +280,24 @@
         :else nil)
       2))
 
+(defn ^:private calc-keep-first-line-spacing
+  "Difference between end of :require/:import and start of next node,
+   nil if they are not on the same line."
+  [form-type-loc]
+  (let [require-meta (-> form-type-loc z/node meta)
+        right-meta (-> form-type-loc z/right z/node meta)]
+    (when (= (:row require-meta) (:row right-meta))
+      (- (:col right-meta) (:end-col require-meta)))))
+
 (defn ^:private clean-requires
   [ns-loc clean-ctx]
   (if-let [require-loc (z/find-value (zsub/subzip ns-loc) z/next :require)]
     (let [col (ns-inner-blocks-indentation-parent-col require-loc clean-ctx)
+          keep-first-line-spacing (calc-keep-first-line-spacing require-loc)
           removed-nodes (-> require-loc
                             z/remove
                             (remove-unused-requires clean-ctx col))]
-      (process-clean-ns ns-loc removed-nodes col :require clean-ctx))
+      (process-clean-ns ns-loc removed-nodes col keep-first-line-spacing :require clean-ctx))
     ns-loc))
 
 (defn ^:private package-import?
@@ -377,15 +393,12 @@
 (defn ^:private clean-imports
   [ns-loc {:keys [ns-inner-blocks-indentation unused-imports] :as clean-ctx} settings]
   (if-let [import-loc (z/find-value (zsub/subzip ns-loc) z/next :import)]
-    (let [col (if import-loc
-                (if (= :same-line ns-inner-blocks-indentation)
-                  (-> import-loc z/node meta :end-col)
-                  (-> import-loc z/node meta :col dec))
-                2)
+    (let [col (ns-inner-blocks-indentation-parent-col import-loc clean-ctx)
+          keep-first-line-spacing (calc-keep-first-line-spacing import-loc)
           removed-nodes (-> import-loc
                             z/remove
                             (edit/map-children #(remove-unused-import % import-loc unused-imports clean-ctx settings)))]
-      (process-clean-ns ns-loc removed-nodes col :import clean-ctx))
+      (process-clean-ns ns-loc removed-nodes col keep-first-line-spacing :import clean-ctx))
     ns-loc))
 
 (defn ^:private sort-ns-children

--- a/lib/test/clojure_lsp/feature/clean_ns_test.clj
+++ b/lib/test/clojure_lsp/feature/clean_ns_test.clj
@@ -94,7 +94,27 @@
                            "     [foo  :as f]"
                            "     [z]))"
                            "(s/defn func []"
-                           "  (f/some))")))
+                           "  (f/some))"))
+    (testing "should no op if clean"
+      (let [test-no-op #(test-clean-ns {:settings {:clean {:ns-inner-blocks-indentation :keep}}}
+                                       %1
+                                       %1)]
+        (test-no-op (h/code "(ns foo.bar"
+                            " (:require  b"
+                            "            f))"))
+        (test-no-op (h/code "(ns foo.bar"
+                            " (:require"
+                            "    b"
+                            "    f))"))
+        (test-no-op (h/code "(ns foo.bar"
+                            " (:import  java.io.File"
+                            "           java.util.Date))"
+                            "File Date"))
+        (test-no-op (h/code "(ns foo.bar"
+                            " (:import"
+                            "     java.io.File"
+                            "     java.util.Date))"
+                            "File Date")))))
   (testing "with first require as unused"
     (test-clean-ns {}
                    (h/code "(ns foo.bar"


### PR DESCRIPTION
Fixes #1141 

I made `:import` also use `ns-inner-blocks-indentation-parent-col` for followup cols, as I see no reason why that should be different than `:require`.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
