### PR TITLE
Extend prior map destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Improve completion sorting, showing locals before functions and other completion items. #1158
   - Fix hover to show current var definition docs instead of `def`/`defn`. #1157
   - Improve hover for requires to show ns docstring. #1171
+  - Fix destructuring of things that have been destructured before. #1156
 
 ## 2022.07.24-18.25.43
 

--- a/lib/src/clojure_lsp/feature/destructure_keys.clj
+++ b/lib/src/clojure_lsp/feature/destructure_keys.clj
@@ -7,70 +7,113 @@
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]))
 
-(defn local-def-elem-to-destructure [zloc uri db]
+(defn ^:private loc-destructuring-key
+  "When `loc` is a val inside a map and its key is a keyword, returns its key.
+  `{:as |x} ;; => :as`"
+  [loc]
+  (let [up-loc (z/up loc)
+        left-loc (z/left loc)]
+    (when (and up-loc left-loc
+               (z/map? up-loc)
+               (n/keyword-node? (z/node left-loc)))
+      (z/sexpr left-loc))))
+
+(defn local-to-destructure [zloc uri db]
   (when zloc
     (let [filename (shared/uri->filename uri)
           {:keys [row col]} (meta (z/node zloc))]
-      (when-let [local-elem (q/find-definition-from-cursor db filename row col)]
-        (when (= :locals (:bucket local-elem))
-          local-elem)))))
+      (when-let [def-elem (q/find-definition-from-cursor db filename row col)]
+        (when (= :locals (:bucket def-elem))
+          (let [top-zloc (edit/to-top zloc)
+                def-zloc (edit/find-at-pos top-zloc (:row def-elem) (:col def-elem))
+                up-loc (z/up def-zloc)
+                destructuring-key (when (and up-loc (= :vector (z/tag up-loc)))
+                                    (loc-destructuring-key up-loc))]
+            ;; rule out things that are already bound in a destructuring form
+            (when (or (not destructuring-key)
+                      (not (contains? #{"keys" "syms" "strs"}
+                                      (name destructuring-key))))
+              {:def-elem def-elem
+               :top-zloc top-zloc
+               :def-zloc def-zloc})))))))
 
 (defn can-destructure-keys? [zloc uri db]
-  (boolean (local-def-elem-to-destructure zloc uri db)))
+  (boolean (local-to-destructure zloc uri db)))
 
-(defn ^:private usage-data [usage-zlocs]
-  (map (fn [usage-loc]
-         (let [left-loc (z/left usage-loc)
-               up-loc (z/up usage-loc)]
-           (or (when (and left-loc
-                          (z/leftmost? left-loc)
-                          (= :list (z/tag up-loc)))
-                 (cond
-                   (n/keyword-node? (z/node left-loc))
-                   (let [kw (z/sexpr left-loc)
-                         local-usage (symbol (name kw))]
-                     {:node-type :keys
-                      :replacing-loc up-loc
-                      :local (if (qualified-ident? kw)
-                               (if (:auto-resolved? (z/node left-loc))
-                                 (z/node left-loc)
-                                 (symbol (namespace kw) (name kw)))
-                               local-usage)
-                      :local-usage local-usage})
-                   (= :quote (z/tag left-loc))
-                   (let [sym (z/sexpr (z/down left-loc))]
-                     {:node-type :syms
-                      :replacing-loc up-loc
-                      :local sym
-                      :local-usage (symbol (name sym))})
-                   :else nil))
-               {:node-type :keep})))
-       usage-zlocs))
+(defn ^:private usage-datum [usage-loc]
+  (let [left-loc (z/left usage-loc)
+        up-loc (z/up usage-loc)]
+    (or (when (and left-loc
+                   (z/leftmost? left-loc)
+                   (= :list (z/tag up-loc)))
+          (let [left-node (z/node left-loc)]
+            (cond
+              (n/keyword-node? left-node)
+              (let [kw (n/sexpr left-node)
+                    local-usage (symbol (name kw))]
+                {:destructure? true
+                 :destructure-key :keys
+                 :replacing-loc up-loc
+                 :local (if (qualified-ident? kw)
+                          (if (:auto-resolved? left-node)
+                            left-node
+                            (symbol (namespace kw) (name kw)))
+                          local-usage)
+                 :local-usage local-usage})
+              (= :quote (n/tag left-node))
+              (let [sym (z/sexpr (z/down left-loc))]
+                {:destructure? true
+                 :destructure-key :syms
+                 :replacing-loc up-loc
+                 :local sym
+                 :local-usage (symbol (name sym))})
+              :else nil)))
+        {:destructure? false})))
 
-(defn ^:private keep-usage? [{:keys [node-type]}]
-  (= :keep node-type))
+(defn ^:private merge-destructuring
+  "Similar to shared/deep-merge, but preserves key order."
+  [prior-destructuring new-destructuring]
+  (->> (concat (keys prior-destructuring)
+               (keys new-destructuring))
+       distinct
+       (reduce (fn [m k]
+                 (assoc m k
+                        (let [v (get prior-destructuring k)
+                              v' (get new-destructuring k)]
+                          (if (keyword? k)
+                            ;; {:keys [a]}, {:keys [b]}
+                            (vec (concat v v'))
+                            ;; {a :a}
+                            v))))
+               (array-map))))
 
 (defn destructure-keys [zloc uri db]
-  (when-let [def-elem (local-def-elem-to-destructure zloc uri db)]
-    (let [top-zloc (edit/to-top zloc)
-          def-zloc (edit/find-at-pos top-zloc (:row def-elem) (:col def-elem))
-          usage-zlocs (map (fn [{:keys [row col]}]
-                             (edit/find-at-pos top-zloc row col))
-                           (q/find-references db def-elem false))
-          usage-data (usage-data usage-zlocs)
-          keep-def? (some keep-usage? usage-data)
-          usage-data (remove keep-usage? usage-data)
-          destructuring (->> usage-data
-                             (group-by :node-type)
-                             (medley/map-vals #(into []
-                                                     (comp (map :local)
-                                                           (distinct))
-                                                     %)))
-          destructuring (cond-> destructuring
-                          keep-def? (assoc :as (symbol (:name def-elem))))]
-      (into [{:range (meta (z/node def-zloc))
-              :loc (z/of-node (n/coerce destructuring))}]
-            (map (fn [{:keys [local-usage replacing-loc]}]
-                   {:range (meta (z/node replacing-loc))
-                    :loc   (z/of-node local-usage)})
-                 usage-data)))))
+  (when-let [{:keys [def-elem top-zloc def-zloc]} (local-to-destructure zloc uri db)]
+    (let [usage-data (->> (q/find-references db def-elem false)
+                          (map (fn [{:keys [row col]}]
+                                 (edit/find-at-pos top-zloc row col)))
+                          (map usage-datum))]
+      (when (some :destructure? usage-data)
+        (let [prior-destructuring (when (= :as (loc-destructuring-key def-zloc))
+                                    ;; NOTE: z/sexpr loses comments. Fix?
+                                    (dissoc (z/sexpr (z/up def-zloc)) :as))
+              new-destructuring (->> usage-data
+                                     (filter :destructure?)
+                                     (group-by :destructure-key)
+                                     (medley/map-vals #(into []
+                                                             (comp (map :local)
+                                                                   (distinct))
+                                                             %)))
+              destructuring (merge-destructuring prior-destructuring new-destructuring)
+              destructuring (cond-> destructuring
+                              (not-every? :destructure? usage-data)
+                              (assoc :as (symbol (:name def-elem))))]
+          (into [{:range (meta (z/node (if (seq prior-destructuring)
+                                         (z/up def-zloc)
+                                         def-zloc)))
+                  :loc (z/of-node (n/coerce destructuring))}]
+                (keep (fn [{:keys [local-usage replacing-loc]}]
+                        (when replacing-loc
+                          {:range (meta (z/node replacing-loc))
+                           :loc   (z/of-node local-usage)}))
+                      usage-data)))))))


### PR DESCRIPTION
When a local is the `:as` part of a prior map destructuring, this patch extends the destructuring.

```clojure
(let [{:keys [a b] :as x} loc]
  (+ a b (:c |x)))
;; =>
(let [{:keys [a b c]} loc]
  (+ a b c))
```

This patch also refuses to destructure when a prior map destructuring means we would introduce invalid syntax:

```clojure
(let [{:keys [a]} loc]
  (:x |a))
;; we DON'T refactor to this, because it's invalid
(let [{:keys [{:keys [x]}]} loc]
  x)
```

At also does not refactor the above form into a nested destructuring, even though that would be valid syntax:

```clojure
;; we DON'T refactor to this either, even though it's valid
(let [{{:keys [x]} :a} loc]
  x)
```

We avoid this both because it would add complexity to the refactoring implementation and because nested destructuring is sometimes considered poor style.

Finally, this patch refuses to destructure when no changes are necessary:

```clojure
(let [loc' loc] (tangent |loc'))
```

Fixes #1156.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
