### PR TITLE
Process document-symbol after changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Fix destructuring of things that have been destructured before. #1156
   - Some completions require that a new alias be added to the ns form. Fix this feature for Calva users, and improve performance for all users. #1068
   - Fix resolve-macro-as code action corner case. #1084
+  - Ensure line numbers provided by document-symbol correspond to the latest version of the file. #1178
 
 ## 2022.07.24-18.25.43
 

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -216,8 +216,8 @@
             (q/find-implementations-from-cursor db (shared/uri->filename (:uri text-document)) row col)))))
 
 (defn document-symbol [{:keys [db*]} {:keys [text-document]}]
-  (shared/logging-task
-    :document-symbol
+  (process-after-changes
+    :document-symbol (:uri text-document) db*
     (let [db @db*
           filename (shared/uri->filename (:uri text-document))]
       (f.document-symbol/document-symbols db filename))))


### PR DESCRIPTION
Wait for analysis of file before responding to document-symbol.

Fixes #1178

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
