### PR TITLE
More carefully slurp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Some completions require that a new alias be added to the ns form. Fix this feature for Calva users, and improve performance for all users. #1068
   - Fix resolve-macro-as code action corner case. #1084
   - Ensure line numbers provided by document-symbol correspond to the latest version of the file. #1178
+  - Avoid exceptions when clients use URIs that don't exist on disk.
 
 ## 2022.07.24-18.25.43
 

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -41,13 +41,14 @@
   (memoize/ttl resolve-cljfmt-config :ttl/threshold memoize-ttl-threshold-milis))
 
 (defn formatting [uri db*]
-  (let [text (f.file-management/force-get-document-text uri db*)
-        cljfmt-settings (cljfmt-config @db*)
-        new-text (cljfmt/reformat-string text cljfmt-settings)]
-    (if (= new-text text)
-      []
-      [{:range shared/full-file-range
-        :new-text new-text}])))
+  (if-let [text (f.file-management/force-get-document-text uri db*)]
+    (let [cljfmt-settings (cljfmt-config @db*)
+          new-text (cljfmt/reformat-string text cljfmt-settings)]
+      (if (= new-text text)
+        []
+        [{:range shared/full-file-range
+          :new-text new-text}]))
+    []))
 
 (defn range-formatting [doc-id format-pos db]
   (let [cljfmt-settings (cljfmt-config db)

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -145,8 +145,8 @@
                                             (fn [file-uri usages]
                                               (let [usage (first usages)
                                                     filename (:filename usage)
-                                                    file-loc (-> (f.file-management/force-get-document-text file-uri db*)
-                                                                 z/of-string)
+                                                    file-loc (some-> (f.file-management/force-get-document-text file-uri db*)
+                                                                     z/of-string)
                                                     db @db*
                                                     local-buckets (get-in db [:analysis filename])
                                                     source-refer (first (filter #(and (:refer %)

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -91,22 +91,22 @@
   ([db uri edit]
    (edit->summary db uri edit nil))
   ([db uri {:keys [range new-text]} old-text]
-   (let [old-text (or old-text
-                      (get-in db [:documents uri :text])
-                      (slurp uri))
-         new-full-text (f.file-management/replace-text
-                         old-text
-                         new-text
-                         (-> range :start :line)
-                         (-> range :start :character)
-                         (-> range :end :line)
-                         (-> range :end :character))]
-     (when (not= new-full-text old-text)
-       {:kind :change
-        :uri uri
-        :version (get-in db [:documents uri :version] 0)
-        :old-text old-text
-        :new-text new-full-text}))))
+   (when-let [old-text (or old-text
+                           (get-in db [:documents uri :text])
+                           (shared/slurp-uri uri))]
+     (let [new-full-text (f.file-management/replace-text
+                           old-text
+                           new-text
+                           (-> range :start :line)
+                           (-> range :start :character)
+                           (-> range :end :line)
+                           (-> range :end :character))]
+       (when (not= new-full-text old-text)
+         {:kind :change
+          :uri uri
+          :version (get-in db [:documents uri :version] 0)
+          :old-text old-text
+          :new-text new-full-text})))))
 
 (defn ^:private document-change->edit-summary [{:keys [text-document edits kind old-uri new-uri]} db]
   (if (= "rename" kind)

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -8,7 +8,6 @@
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
-   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as string]
    [medley.core :as medley]
@@ -917,11 +916,9 @@
         namespace (shared/uri->namespace uri db)
         namespace-test (str namespace "-test")
         test-filename (shared/namespace+source-path->filename namespace-test source-path file-type)
-        test-uri (shared/filename->uri test-filename db)
-        test-namespace-file (io/file test-filename)]
-    (if (shared/file-exists? test-namespace-file)
-      (let [existing-text (shared/slurp-filename test-uri)
-            lines (count (string/split existing-text #"\n"))
+        test-uri (shared/filename->uri test-filename db)]
+    (if-let [existing-text (shared/slurp-uri test-uri)]
+      (let [lines (count (string/split existing-text #"\n"))
             test-text (format "(deftest %s\n  (is (= 1 1)))" (str function-name "-test"))
             test-zloc (z/up (z/of-string (str "\n" test-text)))]
         {:show-document-after-edit {:uri test-uri

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -68,10 +68,14 @@
 (defn directory? [^java.io.File f]
   (.isDirectory f))
 
-(defn slurp-filename
-  "Slurp filename f. Used for be able to with-refefs this function."
-  [^String f]
-  (slurp f))
+(defn slurp-uri
+  "Slurp uri, returning nil if anything goes wrong, and in particular when the
+  URI does not exist on disk. Also useful in with-redefs."
+  [^String uri]
+  (try
+    (slurp uri)
+    (catch Exception _
+      (logger/warn "couldn't read" uri))))
 
 (defn assoc-some
   "Assoc[iate] if the value is not nil. "

--- a/lib/test/clojure_lsp/refactor/transform_test.clj
+++ b/lib/test/clojure_lsp/refactor/transform_test.clj
@@ -951,7 +951,7 @@
       (let [test-code (h/code "(ns some.ns-test)"
                               "(deftest some-other-test)")]
         (with-redefs [shared/file-exists? #(not (string/ends-with? % "config.edn"))
-                      shared/slurp-filename (constantly test-code)]
+                      shared/slurp-uri (constantly test-code)]
           (h/load-code-and-locs test-code "file:///project/test/some/ns_test.clj")
           (let [zloc (h/load-code-and-zloc "(ns some.ns) (defn |foo [b] (+ 1 2))"
                                            "file:///project/src/some/ns.clj")


### PR DESCRIPTION
Sometimes editors use URIs that don't actually exist on disk. In these
cases, slurping will fail. This change introduces a tool to slurp more
carefully; it returns nil instead of throwing. Other code is adapted to
handle the potential absence of a file's text.

@ericdallo this is a fix for the bug you [noticed](https://github.com/clojure-lsp/clojure-lsp/pull/1117#issuecomment-1207264273) about renaming files.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
