### PR TITLE
Create more focused flame graphs when profiling

### DIFF
--- a/cli/dev/clojure_lsp/debug.clj
+++ b/cli/dev/clojure_lsp/debug.clj
@@ -28,8 +28,19 @@
   `(let [n# ~n]
      (println "profiling" n# "iterations")
      (let [time-start# (System/nanoTime)
-           result# (profiler/profile {:min-width 5
-                                      :return-file true}
+           result# (profiler/profile {:return-file true
+                                      :predefined-transforms
+                                      [{:type :remove
+                                        :what #"unknown_Java|thread_start"}
+                                       {:type :replace
+                                        :what #".*?(clojure-lsp.*)"
+                                        :replacement "$1"}
+                                       {:type :replace
+                                        :what #"(rewrite-clj.([^/]*)/[^;]*).*"
+                                        :replacement "$1"}
+                                       {:type :replace
+                                        :what #"(clj-kondo.core/[^;]*).*"
+                                        :replacement "$1"}]}
                                      (dotimes [_n# n#] ~body))
            elapsed-s# (/ (- (System/nanoTime) time-start#) 1e9)]
        (println "Profiled for" elapsed-s# "seconds. (Should be 5-10 seconds to have enough samples.)")


### PR DESCRIPTION
This takes advantage of the new [`:predefined-transforms`](http://clojure-goes-fast.com/blog/clj-async-profiler-100/#other-changes) feature in `clj-async-profiler` to remove some noise from the flame graphs.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
