### PR TITLE
Harmonize meaning of row, col, line and character

### DIFF
--- a/cli/integration-test/integration/fixture.clj
+++ b/cli/integration-test/integration/fixture.clj
@@ -18,25 +18,25 @@
   []
   [:shutdown {}])
 
-(defn completion-request [path row col]
+(defn completion-request [path line character]
   [:textDocument/completion
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
-(defn definition-request [path row col]
+(defn definition-request [path line character]
   [:textDocument/definition
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
-(defn declaration-request [path row col]
+(defn declaration-request [path line character]
   [:textDocument/declaration
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
-(defn implementation-request [path row col]
+(defn implementation-request [path line character]
   [:textDocument/implementation
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
 (defn formatting-full-request [path]
   [:textDocument/formatting
@@ -44,59 +44,59 @@
     :options {:tabSize 2
               :insertSpaces true}}])
 
-(defn prepare-rename-request [path row col]
+(defn prepare-rename-request [path line character]
   [:textDocument/prepareRename
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
-(defn rename-request [path new-name row col]
+(defn rename-request [path new-name line character]
   [:textDocument/rename
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}
+    :position {:line line :character character}
     :newName new-name}])
 
-(defn formatting-range-request [path start-row start-col end-row end-col]
+(defn formatting-range-request [path start-line start-character end-line end-character]
   [:textDocument/rangeFormatting
    {:textDocument {:uri (h/source-path->uri path)}
     :options {:tabSize 2
               :insertSpaces true}
-    :range {:start {:line start-row :character start-col}
-            :end {:line end-row :character end-col}}}])
+    :range {:start {:line start-line :character start-character}
+            :end {:line end-line :character end-character}}}])
 
 (defn document-symbol-request [path]
   [:textDocument/documentSymbol
    {:textDocument {:uri (h/source-path->uri path)}}])
 
-(defn document-highlight-request [path row col]
+(defn document-highlight-request [path line character]
   [:textDocument/documentHighlight
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
-(defn linked-editing-range-request [path row col]
+(defn linked-editing-range-request [path line character]
   [:textDocument/linkedEditingRange
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
-(defn code-action-request [path row col]
+(defn code-action-request [path line character]
   [:textDocument/codeAction
    {:textDocument {:uri (h/source-path->uri path)}
     :context      {:diagnostics []}
-    :range        {:start {:line row :character col}}}])
+    :range        {:start {:line line :character character}}}])
 
-(defn hover-request [path row col]
+(defn hover-request [path line character]
   [:textDocument/hover
    {:textDocument {:uri (h/source-path->uri path)}
-    :position     {:line row :character col}}])
+    :position     {:line line :character character}}])
 
 (defn execute-command-request [command & args]
   [:workspace/executeCommand
    {:command   command
     :arguments args}])
 
-(defn cursor-info-raw-request [path row col]
+(defn cursor-info-raw-request [path line character]
   ["clojure/cursorInfo/raw"
    {:textDocument {:uri (h/source-path->uri path)}
-    :position {:line row :character col}}])
+    :position {:line line :character character}}])
 
 (defn clojure-dependency-contents-request [uri]
   ["clojure/dependencyContents"
@@ -120,8 +120,8 @@
   [:textDocument/didChange
    {:textDocument {:uri (h/source-path->uri path)
                    :version version}
-    :contentChanges (map (fn [[text start-row start-col end-row end-col]]
+    :contentChanges (map (fn [[text start-line start-character end-line end-character]]
                            {:text text
-                            :range {:start {:line start-row :character start-col}
-                                    :end {:line end-row :character end-col}}})
+                            :range {:start {:line start-line :character start-character}
+                                    :end {:line end-line :character end-character}}})
                          changes)}])

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -149,23 +149,22 @@
 
 (defn positions-from-text
   "Takes text with a pipe `|` as a placeholder for cursor positions and returns the text without
-   the pipes alone with a vector of [line column] pairs representing the cursor positions (1-based)"
+   the pipes alone with a vector of [row col] pairs representing the cursor positions (1-based)"
   [text]
   (let [[_ _ text positions] (reduce
-                               (fn [[row column text positions] ch]
-                                 (cond
-                                   (= \| ch)
-                                   [row column text (conj positions [row column])]
+                               (fn [[row col text positions] ch]
+                                 (case ch
+                                   \|
+                                   [row col text (conj positions [row col])]
 
-                                   (= \newline ch)
-                                   [(inc row) 1 (str text ch) positions]
+                                   \newline
+                                   [(inc row) 1 (.append text ch) positions]
 
-                                   :else
-                                   [row (inc column) (str text ch) positions]))
-                               [1 1 "" []]
+                                   [row (inc col) (.append text ch) positions]))
+                               [1 1 (java.lang.StringBuilder.) []]
                                text)]
 
-    [text positions]))
+    [(str text) positions]))
 
 (def default-uri (file-uri "file:///a.clj"))
 
@@ -181,9 +180,9 @@
 (defn ->position [[row col]]
   {:line (dec row) :character (dec col)})
 
-(defn ->range [[row col] [end-row end-col]]
-  {:start {:line (dec row) :character (dec col)}
-   :end {:line (dec end-row) :character (dec end-col)}})
+(defn ->range [start end]
+  {:start (->position start)
+   :end (->position end)})
 
 (defn load-code-into-zloc-and-position
   "Load a `code` block into the kondo db at the provided `uri` and return a map

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -92,34 +92,34 @@ It should be possible to introduce most of the refactorings [here](https://githu
 #### More details
 
 Calling `executeCommand` with the following commands and additional args will notify the client with `applyEdit`.
-All commands expect the first three args to be `[document-uri, line, column]` (eg `["file:///home/snoe/file.clj", 13, 11]`)
+All commands expect the first three args to be `[document-uri, line, character]` (eg `["file:///home/snoe/file.clj", 13, 11]`)
 
-| done | command                 | args                                                                   | notes |
-|------|-------------------------|------------------------------------------------------------------------|-------|
-| √    | add-import-to-namespace | `[document-uri, line, column, import-name]`                            |       |
-| √    | add-missing-libspec     |                                                                        |       |
-| √    | clean-ns                |                                                                        |       |
-| √    | cycle-coll              |                                                                        |       |
-| √    | cycle-privacy           |                                                                        |       |
-| √    | expand-let              |                                                                        |       |
-| √    | extract-function        | `[document-uri, line, column, function-name]`                          |       |
-| √    | inline-symbol           |                                                                        |       |
-| √    | introduce-let           | `[document-uri, line, column, binding-name]`                           |       |
-| √    | move-to-let             | `[document-uri, line, column, binding-name]`                           |       |
-| √    | thread-first            |                                                                        |       |
-| √    | thread-first-all        |                                                                        |       |
-| √    | thread-last             |                                                                        |       |
-| √    | thread-last-all         |                                                                        |       |
-| √    | unwind-all              |                                                                        |       |
-| √    | unwind-thread           |                                                                        |       |
-| √    | resolve-macro-as        | `[document-uri, line, column, resolved-full-symbol kondo-config-path]` |       |
-| √    | create-test             |                                                                        |       |
+| done | command                 | args                                                                      | notes |
+|------|-------------------------|---------------------------------------------------------------------------|-------|
+| √    | add-import-to-namespace | `[document-uri, line, character, import-name]`                            |       |
+| √    | add-missing-libspec     |                                                                           |       |
+| √    | clean-ns                |                                                                           |       |
+| √    | cycle-coll              |                                                                           |       |
+| √    | cycle-privacy           |                                                                           |       |
+| √    | expand-let              |                                                                           |       |
+| √    | extract-function        | `[document-uri, line, character, function-name]`                          |       |
+| √    | inline-symbol           |                                                                           |       |
+| √    | introduce-let           | `[document-uri, line, character, binding-name]`                           |       |
+| √    | move-to-let             | `[document-uri, line, character, binding-name]`                           |       |
+| √    | thread-first            |                                                                           |       |
+| √    | thread-first-all        |                                                                           |       |
+| √    | thread-last             |                                                                           |       |
+| √    | thread-last-all         |                                                                           |       |
+| √    | unwind-all              |                                                                           |       |
+| √    | unwind-thread           |                                                                           |       |
+| √    | resolve-macro-as        | `[document-uri, line, character, resolved-full-symbol kondo-config-path]` |       |
+| √    | create-test             |                                                                           |       |
 
 See Vim client section for an example.
 
 Emacs provides all those refactorings via [lsp-mode](https://emacs-lsp.github.io/lsp-mode/)  with the `lsp-clojure-` prefix.
 
-Other clients might provide a higher level interface to `workspace/executeCommand` you need to pass the path, line and column numbers.
+Other clients might provide a higher level interface to `workspace/executeCommand` you need to pass the path, line and character numbers.
 
 ### Custom methods
 
@@ -181,7 +181,7 @@ Capability: none
 
 Method: `clojure/cursorInfo/log`
 
-Params: `[uri, line, column]` 
+Params: `[uri, line, character]` 
 
 Response: Any
 

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -23,11 +23,12 @@
   (when root-zloc
     (->> diagnostics
          (diagnostics-with-code #{"unresolved-namespace" "unresolved-symbol" "unresolved-var"})
-         (keep (fn [{{{:keys [line character] :as position} :start} :range :as diagnostic}]
-                 (when-let [zloc (parser/to-cursor root-zloc line character)]
-                   (assoc diagnostic
-                          :zloc     zloc
-                          :position position)))))))
+         (keep (fn [{{position :start} :range :as diagnostic}]
+                 (let [[row col] (shared/position->row-col position)]
+                   (when-let [zloc (parser/to-pos root-zloc row col)]
+                     (assoc diagnostic
+                            :zloc     zloc
+                            :position position))))))))
 
 (defn ^:private find-require-suggestions [uri db {:keys [position zloc]}]
   (->> (f.add-missing-libspec/find-require-suggestions zloc uri db)

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -167,19 +167,19 @@
               (f.diagnostic/sync-publish-diagnostics! (shared/filename->uri filename db) db)))
           (producer/refresh-code-lens producer))))))
 
-(defn ^:private offsets [lines line col end-line end-col]
+(defn ^:private offsets [lines line character end-line end-character]
   (loop [lines (seq lines)
          offset 0
          idx 0]
     (if (or (not lines)
             (= line idx))
-      [(+ offset col line)
+      [(+ offset character line)
        (loop [lines lines
               offset offset
               idx idx]
          (if (or (not lines)
                  (= end-line idx))
-           (+ offset end-col end-line)
+           (+ offset end-character end-line)
            (recur (next lines)
                   (+ offset (count (first lines)))
                   (inc idx))))]
@@ -187,9 +187,9 @@
              (+ offset (count (first lines)))
              (inc idx)))))
 
-(defn replace-text [original replacement line col end-line end-col]
+(defn replace-text [original replacement line character end-line end-character]
   (let [lines (string/split original #"\n") ;; don't use OS specific line delimiter!
-        [start-offset end-offset] (offsets lines line col end-line end-col)
+        [start-offset end-offset] (offsets lines line character end-line end-character)
         [prefix suffix] [(subs original 0 start-offset)
                          (subs original (min end-offset (count original)) (count original))]]
     (string/join [prefix replacement suffix])))

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -121,14 +121,14 @@
         , (conj filename)))))
 
 (defn hover
-  ([uri line column db*] (hover uri line column db* {}))
-  ([uri line column db* docs-config]
+  ([uri row col db*] (hover uri row col db* {}))
+  ([uri row col db* docs-config]
    (let [db @db*
          filename (shared/uri->filename uri)
-         cursor-element (q/find-element-under-cursor db filename line column)
+         cursor-element (q/find-element-under-cursor db filename row col)
          cursor-loc (some-> (f.file-management/force-get-document-text uri db*)
                             parser/safe-zloc-of-string
-                            (parser/to-pos line column))
+                            (parser/to-pos row col))
          func-position (some-> cursor-loc
                                edit/find-function-usage-name-loc
                                z/node
@@ -143,11 +143,11 @@
                    (q/find-element-under-cursor db filename (:row func-position) (:col func-position))
 
                    :else
-                   (loop [try-column column]
-                     (if-let [usage (q/find-element-under-cursor db filename line try-column)]
+                   (loop [try-col col]
+                     (if-let [usage (q/find-element-under-cursor db filename row try-col)]
                        usage
-                       (when (pos? try-column)
-                         (recur (dec try-column))))))
+                       (when (pos? try-col)
+                         (recur (dec try-col))))))
 
          definition (when element (q/find-definition db element))]
      (cond

--- a/lib/src/clojure_lsp/parser.clj
+++ b/lib/src/clojure_lsp/parser.clj
@@ -116,9 +116,6 @@
 (defn to-pos [zloc row col]
   (edit/find-at-pos zloc row col))
 
-(defn to-cursor [zloc line character]
-  (to-pos zloc (inc line) (inc character)))
-
 (defn lein-zloc->edn [zloc]
   (when-let [zloc (some-> zloc
                           (z/find-next-value z/next 'defproject)

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -356,14 +356,14 @@
          (medley/distinct-by :id))))
 
 (defn find-var-usages-under-form
-  [db filename line column end-line end-column]
+  [db filename row col end-row end-col]
   (let [local-usages (get-in db [:analysis filename :var-usages])]
     (filter (fn [element]
               (shared/inside? element
-                              {:name-row line
-                               :name-col column
-                               :name-end-row end-line
-                               :name-end-col end-column}))
+                              {:name-row row
+                               :name-col col
+                               :name-end-row end-row
+                               :name-end-col end-col}))
             local-usages)))
 
 (defmulti find-definition
@@ -632,49 +632,49 @@
   [_db element _]
   [element])
 
-(defn ^:private xf-under-cursor [line column]
+(defn ^:private xf-under-cursor [row col]
   (comp (mapcat val)
         (filter
           (fn [{:keys [name-row name-col name-end-row name-end-col]}]
             ;; TODO Probably should use q/inside? instead
-            (and (<= name-row line name-end-row)
-                 (<= name-col column name-end-col))))))
+            (and (<= name-row row name-end-row)
+                 (<= name-col col name-end-col))))))
 
 (defn find-element-under-cursor
-  [db filename line column]
-  (find-first (xf-under-cursor line column)
+  [db filename row col]
+  (find-first (xf-under-cursor row col)
               (get-in db [:analysis filename])))
 
 (defn find-all-elements-under-cursor
-  [db filename line column]
+  [db filename row col]
   (into []
-        (xf-under-cursor line column)
+        (xf-under-cursor row col)
         (get-in db [:analysis filename])))
 
-(defn find-definition-from-cursor [db filename line column]
+(defn find-definition-from-cursor [db filename row col]
   (try
-    (when-let [element (find-element-under-cursor db filename line column)]
+    (when-let [element (find-element-under-cursor db filename row col)]
       (find-definition db element))
     (catch Throwable e
       (logger/error e "can't find definition"))))
 
-(defn find-declaration-from-cursor [db filename line column]
+(defn find-declaration-from-cursor [db filename row col]
   (try
-    (when-let [element (find-element-under-cursor db filename line column)]
+    (when-let [element (find-element-under-cursor db filename row col)]
       (find-declaration db element))
     (catch Throwable e
       (logger/error e "can't find declaration"))))
 
-(defn find-implementations-from-cursor [db filename line column]
+(defn find-implementations-from-cursor [db filename row col]
   (try
-    (when-let [element (find-element-under-cursor db filename line column)]
+    (when-let [element (find-element-under-cursor db filename row col)]
       (find-implementations db element))
     (catch Throwable e
       (logger/error e "can't find implementation"))))
 
-(defn find-references-from-cursor [db filename line column include-declaration?]
+(defn find-references-from-cursor [db filename row col include-declaration?]
   (try
-    (when-let [element (find-element-under-cursor db filename line column)]
+    (when-let [element (find-element-under-cursor db filename row col)]
       (find-references db element include-declaration?))
     (catch Throwable e
       (logger/error e "can't find references"))))

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -746,10 +746,10 @@
             #{'let 'def})))
 
 (defn inline-symbol
-  [uri line column db]
-  (let [definition (q/find-definition-from-cursor db (shared/uri->filename uri) line column)]
+  [uri row col db]
+  (let [definition (q/find-definition-from-cursor db (shared/uri->filename uri) row col)]
     (when-let [op (inline-symbol? definition db)]
-      (let [references (q/find-references-from-cursor db (shared/uri->filename uri) line column false)
+      (let [references (q/find-references-from-cursor db (shared/uri->filename uri) row col false)
             def-uri    (shared/filename->uri (:filename definition) db)
             ;; TODO: use safe-zloc-of-file and handle nils
             def-loc    (some-> (parser/zloc-of-file db def-uri)

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -332,9 +332,13 @@
         (for [[k v] m]
           [(keyword k) v])))
 
-(defn position->line-column [position]
+(defn position->row-col [position]
   [(inc (:line position))
    (inc (:character position))])
+
+(defn row-col->position [row col]
+  {:line (max 0 (dec row))
+   :character (max 0 (dec col))})
 
 (defn debounce-all
   "Debounce in channel with ms miliseconds returning all values."
@@ -436,13 +440,13 @@
 
 (defn ->range [{:keys [name-row name-end-row name-col name-end-col row end-row col end-col] :as element}]
   (when element
-    {:start {:line (max 0 (dec (or name-row row))) :character (max 0 (dec (or name-col col)))}
-     :end {:line (max 0 (dec (or name-end-row end-row))) :character (max 0 (dec (or name-end-col end-col)))}}))
+    {:start (row-col->position (or name-row row) (or name-col col))
+     :end (row-col->position (or name-end-row end-row) (or name-end-col end-col))}))
 
 (defn ->scope-range [{:keys [name-row name-end-row name-col name-end-col row end-row col end-col] :as element}]
   (when element
-    {:start {:line (max 0 (dec (or row name-row))) :character (max 0 (dec (or col name-col)))}
-     :end {:line (max 0 (dec (or end-row name-end-row))) :character (max 0 (dec (or end-col name-end-col)))}}))
+    {:start (row-col->position (or row name-row) (or col name-col))
+     :end (row-col->position (or end-row name-end-row) (or end-col name-end-col))}))
 
 (def full-file-range
   (->range {:row 1 :col 1 :end-row 1000000 :end-col 1000000}))


### PR DESCRIPTION
clojure-lsp has three actively used ways of referring to a position in a
document.

* line, character: These are the terms used in the LSP spec, and are
  0-based.
* row, col: These are the terms used by rewrite-clj and clj-kondo and
  are 1-based.
* line, column: I'm not sure where these terms come from, perhaps vim or
  perhaps the Clojure parser. They are also 1-based.

Note that the first and third both use the term "line", but one is
0-based and the other is 1-based. While reading the code, the only way
to understand what "line" means is by looking at whether it's paired
with "character" or "column". And the second uses "col" while the third
uses "column", though they have different meanings.

To add to the cognitive burden, some code uses row/col when it
means line/character, or uses one set of terminology in var definitions,
but another at call sites.

This commit brings the naming into harmony. In 0-based scenarios, we use
line/character. In 1-based scenarios, we use row/col. We no longer use
line/column.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
