### PR TITLE
Fix: publishing diagnostics at startup fills up the channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - Avoid exceptions when clients use URIs that don't exist on disk.
   - Fix documentation on completion items. #1181
   - Fix rename of defrecords. #1165
+  - Fix to send all diagnostics to client at startup, even in very large projects. #1153
 
 ## 2022.07.24-18.25.43
 

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -85,17 +85,17 @@
        (f)))))
 
 (defmacro let-mock-chans [bindings & body]
-  (assert (even? (count bindings)))
+  {:pre [(even? (count bindings))]}
   (let [bs (partition 2 bindings)
         let-bindings (mapcat (fn [[binding _]]
-                               `[~binding (async/chan 1)])
+                               [binding `(async/chan 1)])
                              bs)
-        alter-vars (map (fn [[binding chan-var]]
-                          `(alter-var-root ~chan-var (constantly ~binding)))
-                        bs)]
+        redef-bindings (mapcat (fn [[binding chan-var]]
+                                 [chan-var binding])
+                               bs)]
     `(let [~@let-bindings]
-       ~@alter-vars
-       ~@body)))
+       (with-redefs [~@redef-bindings]
+         ~@body))))
 
 (defn take-or-timeout [c timeout-ms]
   (let [timeout (async/timeout timeout-ms)

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -141,10 +141,10 @@
         (not= :off depend-level)
         (concat (clj-depend-violations->diagnostics filename depend-level db))))))
 
-(defn publish-diagnostic!* [diagnostic]
+(defn ^:private publish-diagnostic!* [diagnostic]
   (async/put! db/diagnostics-chan diagnostic))
 
-(defn publish-all-diagnostics!* [diagnostics]
+(defn ^:private publish-all-diagnostics!* [diagnostics]
   (async/onto-chan! db/diagnostics-chan diagnostics false))
 
 (defn publish-diagnostics! [uri db]

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -95,8 +95,7 @@
           components)
         (let [db @db*]
           (when (settings/get db [:lint-project-files-after-startup?] true)
-            (async/thread
-              (f.diagnostic/publish-all-diagnostics! (-> db :settings :source-paths) db)))
+            (f.diagnostic/publish-all-diagnostics! (-> db :settings :source-paths) db))
           (async/go
             (f.clojuredocs/refresh-cache! db*))
           (async/go

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -291,7 +291,7 @@
                   (foo 1 ['a 'b])
                   (foo 1 2 3 {:k 1 :v 2})"]
         (h/let-mock-chans
-          [mock-diagnostics-chan #'db/diagnostics-chan]
+          [mock-diagnostics-chan db/diagnostics-chan]
           (h/load-code-and-locs code)
           (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
             (is (= "file:///a.clj" uri))
@@ -326,7 +326,7 @@
                     (foo 1)
                     (bar))"]
         (h/let-mock-chans
-          [mock-diagnostics-chan #'db/diagnostics-chan]
+          [mock-diagnostics-chan db/diagnostics-chan]
           (h/load-code-and-locs code)
           (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
             (is (= "file:///a.clj" uri))
@@ -346,7 +346,7 @@
                   (bar :a)
                   (bar :a :b)"]
         (h/let-mock-chans
-          [mock-diagnostics-chan #'db/diagnostics-chan]
+          [mock-diagnostics-chan db/diagnostics-chan]
           (h/load-code-and-locs code)
           (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
             (is (= "file:///a.clj" uri))
@@ -362,7 +362,7 @@
                   (foo 1 2)
                   (foo 1)"]
         (h/let-mock-chans
-          [mock-diagnostics-chan #'db/diagnostics-chan]
+          [mock-diagnostics-chan db/diagnostics-chan]
           (h/load-code-and-locs code)
           (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
             (is (= "file:///a.clj" uri))
@@ -372,7 +372,7 @@
   (testing "custom unused namespace declaration"
     (h/clean-db!)
     (h/let-mock-chans
-      [mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-diagnostics-chan db/diagnostics-chan]
       (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///foo/bar.clj"))
       (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
         (is (= "file:///foo/bar.clj" uri))

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -27,7 +27,7 @@
   (h/load-code-and-locs "(ns some-jar)" (h/file-uri "file:///some/path/to/jar.jar:/some/file.clj"))
   (testing "when file exists on disk"
     (h/let-mock-chans
-      [mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-diagnostics-chan db/diagnostics-chan]
       (with-redefs [shared/file-exists? (constantly true)]
         (f.file-management/did-close "file:///user/project/src/clj/foo.clj" db/db*))
       (is (get-in @db/db* [:analysis "/user/project/src/clj/foo.clj"]))
@@ -38,7 +38,7 @@
       (h/assert-no-take mock-diagnostics-chan 500)))
   (testing "when local file not exists on disk"
     (h/let-mock-chans
-      [mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-diagnostics-chan db/diagnostics-chan]
       (with-redefs [shared/file-exists? (constantly false)]
         (f.file-management/did-close "file:///user/project/src/clj/bar.clj" db/db*))
       (is (nil? (get-in @db/db* [:analysis "/user/project/src/clj/bar.clj"])))
@@ -51,7 +51,7 @@
              (h/take-or-timeout mock-diagnostics-chan 500)))))
   (testing "when file is external we do not remove analysis"
     (h/let-mock-chans
-      [mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-diagnostics-chan db/diagnostics-chan]
       (with-redefs [shared/file-exists? (constantly false)]
         (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" db/db*))
       (is (get-in @db/db* [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
@@ -64,8 +64,8 @@
 (deftest did-open
   (testing "on an empty file"
     (h/let-mock-chans
-      [mock-edits-chan #'db/edits-chan
-       mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-edits-chan db/edits-chan
+       mock-diagnostics-chan db/diagnostics-chan]
       (let [filename "/user/project/src/aaa/bbb.clj"
             uri (h/file-uri (str "file://" filename))]
         (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
@@ -92,7 +92,7 @@
 
 (deftest did-change
   (h/let-mock-chans
-    [mock-changes-chan #'db/current-changes-chan]
+    [mock-changes-chan db/current-changes-chan]
     (let [original-text (h/code "(ns aaa)"
                                 "(def foo 1)")
           edited-text (h/code "(ns aaa)"
@@ -112,7 +112,7 @@
 (deftest did-change-watched-files
   (testing "created file"
     (h/let-mock-chans
-      [mock-created-chan #'db/created-watched-files-chan]
+      [mock-created-chan db/created-watched-files-chan]
       (f.file-management/did-change-watched-files
         [{:type :created
           :uri h/default-uri}]
@@ -120,7 +120,7 @@
       (is (= h/default-uri (h/take-or-timeout mock-created-chan 500)))))
   (testing "deleted file"
     (h/let-mock-chans
-      [mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-diagnostics-chan db/diagnostics-chan]
       (f.file-management/did-change-watched-files
         [{:type :deleted
           :uri h/default-uri}]

--- a/lib/test/clojure_lsp/features/resolve_macro_test.clj
+++ b/lib/test/clojure_lsp/features/resolve_macro_test.clj
@@ -3,7 +3,6 @@
    [clojure-lsp.db :as db]
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.test-helper :as h]
-   [clojure.core.async :as async]
    [clojure.test :refer [deftest is testing]]))
 
 (h/reset-db-after-test)
@@ -26,7 +25,6 @@
       (is (not (f.resolve-macro/find-full-macro-symbol-to-resolve (h/zloc-from-code b-code) (h/file-uri "file:///a.clj") @db/db*))))))
 
 (deftest resolve-macro-as
-  (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
   (let [code (h/code "(ns some-ns)"
                      "(defmacro foo [name] `(def ~name))"
                      "(foo my|-fn)"

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -28,7 +28,7 @@
   (testing "opening a existing file"
     (h/clean-db!)
     (h/let-mock-chans
-      [mock-diagnostics-chan #'db/diagnostics-chan]
+      [mock-diagnostics-chan db/diagnostics-chan]
       (let [_ (h/load-code-and-locs "(ns a) (when)")]
         (is (some? (get-in @db/db* [:analysis (h/file-path "/a.clj")])))
         (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
@@ -44,7 +44,7 @@
                          :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}
                          :project-root-uri (h/file-uri "file:///project")})
     (h/let-mock-chans
-      [mock-edits-chan #'db/edits-chan]
+      [mock-edits-chan db/edits-chan]
       (h/load-code-and-locs "" (h/file-uri "file:///project/src/foo/bar.clj"))
       (h/assert-submaps
         [{:edits [{:range {:start {:line 0, :character 0}
@@ -59,7 +59,7 @@
                          :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}
                          :project-root-uri (h/file-uri "file:///project")})
     (h/let-mock-chans
-      [mock-edits-chan #'db/edits-chan]
+      [mock-edits-chan db/edits-chan]
       (h/load-code-and-locs "" (h/file-uri "file:///project/src/foo/baz.edn"))
       (h/assert-no-take mock-edits-chan 500)
       (is (some? (get-in @db/db* [:analysis (h/file-path "/project/src/foo/baz.edn")]))))))


### PR DESCRIPTION
At startup clojure-lsp analyzes project files with clj-kondo. clj-kondo finds diagnostics (a.k.a. lint) and clojure-lsp sends those diagnostics to the editor by spooling them onto a core.async channel called `db/diagnostics-chan`. As described in #1153, in very large projects (thousands of namespaces) this can lead to an exception "Assert failed: No more than 1024 pending puts are allowed on a single channel." When this happens the editor doesn't receive all the diagnostics.

To explain, let me tell a story.

Sometimes I find myself standing in line at the grocery store alone, waiting while my wife looks for "one more thing." This is a useful model for reasoning about core.async.

At the core.async grocery store, shoppers wander around picking out items and putting them in their cart. They wheel their carts to the checkout area, and here's where things get weird. At this store, you aren't allowed to put an item on a conveyor (`chan`) yourself. Instead each conveyor has an attendant. You hand an item to the attendant, who puts it on the conveyor for you. There isn't even a line. Many people can hand items to the attendant all at once.

Usually the cashier is quick and keeps the conveyor empty, so the attendant can place each new item immediately. But sometimes the cashier gets behind. If things back up, the attendant has a basket of their own. They'll keep taking the shopper's items, storing them in their own basket until the cashier catches up.

The attendant has space for 1024 items in their basket. Any more than that, and as you hand an item over, poof! it disappears (`No more than 1024 pending puts are allowed on a single channel`).

As a shopper you have three options as you hand an item to the attendant.

If you don't care whether your item makes it onto the conveyor, you can hand it over and walk away (`put!`), getting back to shopping.

Even if you're the only person in the store, this can cause problems. If you revisit checkout many times in a row, walking away each time, you can accidentally fill up the basket.

To try to avoid this problem, you can wait until you see the attendant put the item on the conveyor (`>!!`) before returning to your shopping. This still doesn't guarantee the attendant's basket won't fill up. If there are other shoppers, they could all come to checkout at the same time. But at least you know you won't cause a problem by yourself.

Some shoppers feel like waiting is a waste of their time so the store has arranged a third option.

With a little ceremony (`go`) you can _hire someone else_ to wait with your cart. The hiring process takes a moment to set up (HR benefit forms) but is usually quite fast, so shoppers love this option. The new worker will hand the items in the cart to the attendant one at a time, waiting to see each one reach the conveyor `>!`. If the cart has only one item (`go` and a single `>!`) this [isn't much different](https://github.com/clojure/core.async/wiki/Go-Block-Best-Practices#general-advice) than walking away (`put!`). But if the cart has several items, the new worker will wait for each one to reach the conveyor before giving the attendant another (`go-loop` and `>!`, or more simply `onto-chan!`). This lets you continue your shopping, with more confidence that your items won't overwhelm the attendant.

Coming back to this bug...

Suppose your project has 1200 files. At startup, clojure-lsp calls `sync-publish-diagnostics!` in a loop, once for each file. Each one of these invokes `(put! diagnostics-chan diagnostic)`. This is like making 1200 trips to checkout, walking away after handing over a single item each time. The attendant ends up with too many items and poof! some of them disappear. You might think you could fix this by calling `(go (>! diagnostics-chan diagnostic))` in a loop instead, and indeed, there are places where we were doing that. But this won't work either. It's like hiring 1200 new workers, each with one item in their cart. The new workers wouldn't coordinate with each other. They'd each hand their single item over, the attendant would get 1200 items all at once, and again, poof!

When looked at this way, there a few possible fixes. You could make the conveyor longer (i.e., `(chan 1000)`), effectively giving the attendant some extra space in addition to their basket. But I think it's better to hire only one worker, with 1200 items in their cart. They can hand items to the attendant one at a time, waiting for each one to reach the conveyor before handing over another. The attendant's basket is much less likely to fill up this way. (It's still possible of course—there are other shoppers in the store.)

This commit changes the code so that whenever we have several file's worth of diagnostics, we add them to the diagnostics channel with `onto-chan!`. That is, we hire one worker with a very full cart, instead of walking away after each item or hiring thousands of workers each with single-item carts.

That's the main fix.

This commit also removes the test-specific pathways through the diagnostics code. These pathways were put into place to avoid test flakiness. That was working—the tests haven't been flaky lately—but not for the reason we thought. To understand what I mean and why I don't think the test-specific pathways are necessary, let's start with some very old code, before any flakiness fixes were in place.

```clojure
;; flaky
(defn maybe-publish [{:keys [publish?]} diagnostic]
  (when publish?
    (go (>! db/diagnostics-chan diagnostic))))

(deftest diagnostics-should-not-always-be-published
  (maybe-publish {:publish? true} diagnostic)
  (let [mock-chan (chan 1)]
    (alter-var-root #'db/diagnostics-chan mock-chan)
    (maybe-publish {:publish? false} diagnostic)
    (is (= :timeout (h/take-or-timeout mock-chan 200 :timeout)))))
```

These tests were flaky. The final line would fail occasionally, because a message _was_ put on the mock-chan. That meant that sometimes `>!` from the first line of the test didn't actually run until _after_ the mock-chan was installed with `alter-var-root`.

The original fix for the flakiness looked like this:

```clojure
;; not flaky
(defn maybe-publish [{:keys [publish? env]} diagnostic]
  (when publish?
    (if (= :test env)
      (put! db/diagnostics-chan diagnostic)
      (go (>! db/diagnostics-chan diagnostic)))))

(deftest diagnostics-should-not-always-be-published
  (maybe-publish {:publish? true, :env :test} diagnostic)
  (let [mock-chan (chan 1)]
    (alter-var-root #'db/diagnostics-chan mock-chan)
    (maybe-publish {:publish? false, :env :test} diagnostic)
    (is (= :timeout (h/take-or-timeout mock-chan 200 :timeout)))))
```

This worked—these tests weren't flaky. That seemed to prove that `put!` was somehow "less asynchronous".

But wait! Earlier I pointed out that the Clojure docs say `go` + `>!` isn't much different than `put!`. And I'll go further and link to the [docs](https://clojuredocs.org/clojure.core.async/put!) that say `put!` "Asynchronously puts a val into port." So how did using a different but equivalent thing which is also asynchronous fix flakiness caused by asynchronicity?

Let's go back to the grocery store. Remember what I said about hiring a new worker and how it takes a moment? What I meant is that the body of a `go` block is executed asynchronously. And this is the key.

When you write `(go (>! db/diagnostics-chan diagnostic))` then you are _picking which channel_ to put the message on asynchronously. Since the choice is asynchronous, you could pick before or after `alter-var-root`. If it's before, you pick the original channel, and the tests will pass. But if it's after, you pick the mock-chan, and the tests will fail.

While the first new worker is filling out their HR forms (`go`), the attendant, conveyor and cashier are being replaced with temporary versions (`alter-var-root`). If the worker fills out their forms fast enough, then they put (`>!`) the item on the original conveyor. But if they're too slow, they put the item, incorrectly, on the temporary conveyor.

The **real** fix is to pick the channel before you start any asynchronous task. That's why using `(put! db/diagnostics-chan diagnostic)` fixed the flakiness. That code picks the channel, _then_ runs the async code in `put!`. If you're going to use `go`, you have to tell each worker which conveyor to use before they start filling out their HR forms. Indeed, it's possible to avoid the flakiness, while still using `go` + `>!`, by making a very small change to the original flaky code:

```clojure
;; not flaky
(defn maybe-publish [{:keys [publish?]} diagnostic]
  (when publish?
    (let [ch db/diagnostics-chan] ;; pick channel before running async code
      (go (>! ch diagnostic)))))
```

Either style—picking the channel before running `go`, or using `put!`—fix the flaky code. And despite what we originally thought, they are both equally asynchronous. And `put!` is shorter. So as far as I can see, there's no reason not to use `put!` in production and in tests, so that's what I've switched it to.

The fact that we thought `put!` was "less asynchronous" is why pathways that used `put!` were named "sync", and pathways that used `go` + `>!` were named "async". That terminology is misleading, so I've removed it.

As a final note, there's an even deeper problem still, which is that `db/diagnostics-chan` is a global variable. If instead of holding the channels in global vars, we threaded them through the app (as components perhaps, as we do with `db*` as of recently), it would be much easier and safer to provide a mock-chan in tests. That's another refactoring, for a later time.

Fixes #1153, I hope.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
