### PR TITLE
Avoid camelCasing server-info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Fix documentation on completion items. #1181
   - Fix rename of defrecords. #1165
   - Fix to send all diagnostics to client at startup, even in very large projects. #1153
+  - Fix to preserve kebab-casing in server-info-raw. #1195
 
 ## 2022.07.24-18.25.43
 

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -104,7 +104,8 @@
     (-> element :name name)))
 
 (defn add-unresolved [completion-item unresolved-type args]
-  (update-in completion-item [:data "unresolved"] (fnil conj []) [unresolved-type args]))
+  (update-in completion-item [:data "unresolved"] (fnil conj [])
+             [unresolved-type (shared/preserve-kebab-case args)]))
 
 (defn ^:private completion-item-with-documentation
   [completion-item element var-name db* docs-config]
@@ -139,9 +140,9 @@
     ;; client supports postponing the expensive edit calculation
     (add-unresolved completion-item
                     "alias"
-                    {"ns-to-add"    (name ns-to-add)
-                     "alias-to-add" (name alias-to-add)
-                     "uri"          uri})
+                    {:ns-to-add    (name ns-to-add)
+                     :alias-to-add (name alias-to-add)
+                     :uri          uri})
     ;; client can't postpone the edit calculation, so do it now, even though it's expensive
     (completion-item-with-alias-edit completion-item cursor-loc alias-to-add ns-to-add db)))
 
@@ -180,10 +181,10 @@
       kind (assoc :kind kind)
       detail (assoc :detail detail)
       :always (completion-item-with-unresolved-documentation
-                {"name" (-> element :name str)
-                 "filename" (:filename element)
-                 "name-row" (:name-row element)
-                 "name-col" (:name-col element)}
+                {:name (-> element :name str)
+                 :filename (:filename element)
+                 :name-row (:name-row element)
+                 :name-col (:name-col element)}
                 resolve-support))))
 
 (defn ^:private name-matches-xf [matches-fn]
@@ -369,9 +370,9 @@
                    :detail   (str ns-name "/" sym-name)
                    :priority priority}
                   (completion-item-with-unresolved-documentation
-                    {"filename" filename
-                     "name"     sym-name
-                     "ns"       ns-name}
+                    {:filename filename
+                     :name     sym-name
+                     :ns       ns-name}
                     resolve-support)))))
         symbols))
 

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -18,7 +18,7 @@
 (set! *warn-on-reflection* true)
 
 (defn resolve-user-cljfmt-config [db]
-  (when-let [project-root (shared/uri->filename (:project-root-uri db))]
+  (when-let [project-root (some-> db :project-root-uri shared/uri->filename)]
     (let [config-path (settings/get db [:cljfmt-config-path] ".cljfmt.edn")
           cljfmt-config-file (if (string/starts-with? config-path "/")
                                (io/file config-path)

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -261,7 +261,8 @@
       :info
       nil)))
 
-(def server-info-raw #'server-info)
+(defn server-info-raw [components]
+  (shared/preserve-kebab-case (server-info components)))
 
 (defn ^:private cursor-info [{:keys [db*]} [uri line character]]
   (let [db @db*
@@ -287,8 +288,9 @@
 (defn cursor-info-raw [components {:keys [text-document position]}]
   (shared/logging-task
     :cursor-info-raw
-    (cursor-info components
-                 [(:uri text-document) (:line position) (:character position)])))
+    (-> components
+        (cursor-info [(:uri text-document) (:line position) (:character position)])
+        (shared/preserve-kebab-case))))
 
 (defn clojuredocs-raw [{:keys [db*]} {:keys [sym-name sym-ns]}]
   (shared/logging-task

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -1,5 +1,7 @@
 (ns clojure-lsp.shared
   (:require
+   [camel-snake-kebab.core :as csk]
+   [camel-snake-kebab.extras :as cske]
    [clojure-lsp.logger :as logger]
    [clojure.core.async :refer [<! >! alts! chan go-loop timeout]]
    [clojure.java.io :as io]
@@ -473,3 +475,11 @@
                                       paths)]
     {:new-checksums new-checksums
      :paths-not-on-checksum paths-not-on-checksum}))
+
+(defn preserve-kebab-case
+  "Recursively convert map keywords to kebab-case strings, to avoid automatic
+  camelCase conversion that happens in lsp4clj. This is useful when the client
+  expects Clojure style JSON, or when a map needs to be round-tripped from
+  clojure-lsp to the client and back without case changes."
+  [m]
+  (cske/transform-keys csk/->kebab-case-string m))

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -300,3 +300,15 @@
             "1 reference"]
            (map #(get-in % [:command :title])
                 resolved-code-lenses)))))
+
+(deftest server-info-raw
+  (testing "returns kebab-case strings, to avoid camelCase conversion of keywords"
+    (is (seq (get (handlers/server-info-raw h/components) "server-version")))))
+
+(deftest cursor-info-raw
+  (testing "returns kebab-case strings, to avoid camelCase conversion of keywords"
+    (let [[row-and-col] (h/load-code-and-locs "(ns |a)")]
+      (is (seq (get (handlers/cursor-info-raw h/components
+                                              {:text-document {:uri h/default-uri}
+                                               :position (h/->position row-and-col)})
+                    "elements"))))))


### PR DESCRIPTION
Clients expect `server-info-raw` to return JSON with map keys that are
kebab-cased strings. The automatic camelCasing in lsp4clj was breaking
this. This commit fixes `server-info-raw` by switching back to kebab-case.
It also adds a helper for preserving case in other places, such as
completion resolution args.

Fixes #1195 

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
