### PR TITLE
Separate dev, test and api databases; componentize chans

### DIFF
--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -496,11 +496,11 @@
   ;; We don't have an ENV=development flag, so the next best indication that
   ;; we're in a development environment is whether we're able to start an nREPL.
   (when-let [nrepl-port (nrepl/setup-nrepl)]
-    ;; We're in the development environment, so make the db* atom available
-    ;; globally as db/db*. In other environments it's empty (except for unit
-    ;; tests, which set it via a different mechanism).
-    (alter-var-root #'db/db* (constantly db*))
-    (swap! db/db* assoc :port nrepl-port)))
+    ;; Save the port in the db, so it can be reported in server-info.
+    (swap! db* assoc :port nrepl-port)
+    ;; In the development environment, make the db* atom available globally as
+    ;; db/db*, so it can be inspected in the nREPL.
+    (alter-var-root #'db/db* (constantly db*))))
 
 (defn run-server! []
   (lsp.server/discarding-stdout

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -457,8 +457,8 @@
        (recur))))
 
 (defn ^:private spawn-async-tasks!
-  [{:keys [producer current-changes-chan created-watched-files-chan edits-chan] :as components}]
-  (let [debounced-diags (shared/debounce-by db/diagnostics-chan diagnostics-debounce-ms :uri)
+  [{:keys [producer current-changes-chan diagnostics-chan created-watched-files-chan edits-chan] :as components}]
+  (let [debounced-diags (shared/debounce-by diagnostics-chan diagnostics-debounce-ms :uri)
         debounced-changes (shared/debounce-by current-changes-chan change-debounce-ms :uri)
         debounced-created-watched-files (shared/debounce-all created-watched-files-chan created-watched-files-debounce-ms)]
     (safe-async-task
@@ -518,6 +518,7 @@
                       :producer producer
                       :server server
                       :current-changes-chan (async/chan 1)
+                      :diagnostics-chan (async/chan 1)
                       :created-watched-files-chan (async/chan 1)
                       :edits-chan (async/chan 1)}]
       (logger/info "[SERVER]" "Starting server...")

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -457,9 +457,9 @@
        (recur))))
 
 (defn ^:private spawn-async-tasks!
-  [{:keys [producer] :as components}]
+  [{:keys [producer current-changes-chan] :as components}]
   (let [debounced-diags (shared/debounce-by db/diagnostics-chan diagnostics-debounce-ms :uri)
-        debounced-changes (shared/debounce-by db/current-changes-chan change-debounce-ms :uri)
+        debounced-changes (shared/debounce-by current-changes-chan change-debounce-ms :uri)
         debounced-created-watched-files (shared/debounce-all db/created-watched-files-chan created-watched-files-debounce-ms)]
     (safe-async-task
       :edits
@@ -516,7 +516,8 @@
           components {:db* db*
                       :logger timbre-logger
                       :producer producer
-                      :server server}]
+                      :server server
+                      :current-changes-chan (async/chan 1)}]
       (logger/info "[SERVER]" "Starting server...")
       (monitor-server-logs log-ch)
       (setup-dev-environment db*)

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -457,10 +457,10 @@
        (recur))))
 
 (defn ^:private spawn-async-tasks!
-  [{:keys [producer current-changes-chan] :as components}]
+  [{:keys [producer current-changes-chan created-watched-files-chan] :as components}]
   (let [debounced-diags (shared/debounce-by db/diagnostics-chan diagnostics-debounce-ms :uri)
         debounced-changes (shared/debounce-by current-changes-chan change-debounce-ms :uri)
-        debounced-created-watched-files (shared/debounce-all db/created-watched-files-chan created-watched-files-debounce-ms)]
+        debounced-created-watched-files (shared/debounce-all created-watched-files-chan created-watched-files-debounce-ms)]
     (safe-async-task
       :edits
       (when-let [edit (async/<!! db/edits-chan)]
@@ -517,7 +517,8 @@
                       :logger timbre-logger
                       :producer producer
                       :server server
-                      :current-changes-chan (async/chan 1)}]
+                      :current-changes-chan (async/chan 1)
+                      :created-watched-files-chan (async/chan 1)}]
       (logger/info "[SERVER]" "Starting server...")
       (monitor-server-logs log-ch)
       (setup-dev-environment db*)

--- a/cli/test/clojure_lsp/main_test.clj
+++ b/cli/test/clojure_lsp/main_test.clj
@@ -5,7 +5,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (def default-root (.getAbsolutePath (io/file "src")))
 

--- a/cli/test/clojure_lsp/server_test.clj
+++ b/cli/test/clojure_lsp/server_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest test-client-settings
   (testing "initializationOptions are null"

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -61,7 +61,8 @@
 (defn make-components []
   {:db* (atom (assoc db/initial-db :env :unit-test))
    :logger (->TestLogger)
-   :producer (->TestProducer)})
+   :producer (->TestProducer)
+   :current-changes-chan (async/chan 1)})
 
 (def components* (atom nil))
 (defn components [] (deref components*))
@@ -71,7 +72,6 @@
 
 (defn clean-db! []
   (reset! components* (make-components))
-  (alter-var-root #'db/current-changes-chan (constantly (async/chan 1)))
   (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
   (alter-var-root #'db/created-watched-files-chan (constantly (async/chan 1)))
   (alter-var-root #'db/edits-chan (constantly (async/chan 1))))

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -58,22 +58,22 @@
   (-debug [_this _fmeta _arg1 _arg2])
   (-debug [_this _fmeta _arg1 _arg2 _arg3]))
 
-(def components* (atom nil))
+(defn ^:private make-components []
+  {:db* (atom (assoc db/initial-db :env :unit-test))
+   :logger (->TestLogger)
+   :producer (->TestProducer)
+   :current-changes-chan (async/chan 1)
+   :diagnostics-chan (async/chan 1)
+   :created-watched-files-chan (async/chan 1)
+   :edits-chan (async/chan 1)})
+
+(def components* (atom (make-components)))
 (defn components [] (deref components*))
 
 (defn db* [] (:db* (components)))
 (defn db [] (deref (db*)))
 
-(defn reset-components! []
-  (reset! components*
-          {:db* (atom (assoc db/initial-db :env :unit-test))
-           :logger (->TestLogger)
-           :producer (->TestProducer)
-           :current-changes-chan (async/chan 1)
-           :diagnostics-chan (async/chan 1)
-           :created-watched-files-chan (async/chan 1)
-           :edits-chan (async/chan 1)}))
-
+(defn reset-components! [] (reset! components* (make-components)))
 (defn reset-components-before-test []
   (use-fixtures :each (fn [f] (reset-components!) (f))))
 

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -62,7 +62,8 @@
   {:db* (atom (assoc db/initial-db :env :unit-test))
    :logger (->TestLogger)
    :producer (->TestProducer)
-   :current-changes-chan (async/chan 1)})
+   :current-changes-chan (async/chan 1)
+   :created-watched-files-chan (async/chan 1)})
 
 (def components* (atom nil))
 (defn components [] (deref components*))
@@ -73,7 +74,6 @@
 (defn clean-db! []
   (reset! components* (make-components))
   (alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
-  (alter-var-root #'db/created-watched-files-chan (constantly (async/chan 1)))
   (alter-var-root #'db/edits-chan (constantly (async/chan 1))))
 
 (defn reset-db-after-test []

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -58,29 +58,24 @@
   (-debug [_this _fmeta _arg1 _arg2])
   (-debug [_this _fmeta _arg1 _arg2 _arg3]))
 
-(defn make-components []
-  {:db* (atom (assoc db/initial-db :env :unit-test))
-   :logger (->TestLogger)
-   :producer (->TestProducer)
-   :current-changes-chan (async/chan 1)
-   :diagnostics-chan (async/chan 1)
-   :created-watched-files-chan (async/chan 1)
-   :edits-chan (async/chan 1)})
-
 (def components* (atom nil))
 (defn components [] (deref components*))
 
 (defn db* [] (:db* (components)))
 (defn db [] (deref (db*)))
 
-(defn clean-db! []
-  (reset! components* (make-components)))
+(defn reset-components! []
+  (reset! components*
+          {:db* (atom (assoc db/initial-db :env :unit-test))
+           :logger (->TestLogger)
+           :producer (->TestProducer)
+           :current-changes-chan (async/chan 1)
+           :diagnostics-chan (async/chan 1)
+           :created-watched-files-chan (async/chan 1)
+           :edits-chan (async/chan 1)}))
 
-(defn reset-db-after-test []
-  (use-fixtures :each
-    (fn [f]
-      (clean-db!)
-      (f))))
+(defn reset-components-before-test []
+  (use-fixtures :each (fn [f] (reset-components!) (f))))
 
 (defn take-or-timeout [c timeout-ms]
   (let [timeout (async/timeout timeout-ms)

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -17,7 +17,6 @@
                  :file-meta {}})
 (defonce db* (atom initial-db))
 (defonce diagnostics-chan (async/chan 1))
-(defonce created-watched-files-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
 (def version 5)

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -16,7 +16,6 @@
                  :dep-graph {}
                  :file-meta {}})
 (defonce db* (atom initial-db))
-(defonce current-changes-chan (async/chan 1))
 (defonce diagnostics-chan (async/chan 1))
 (defonce created-watched-files-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -17,7 +17,6 @@
                  :file-meta {}})
 (defonce db* (atom initial-db))
 (defonce diagnostics-chan (async/chan 1))
-(defonce edits-chan (async/chan 1))
 
 (def version 5)
 

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -3,7 +3,6 @@
    [clojure-lsp.config :as config]
    [clojure-lsp.logger :as logger]
    [clojure-lsp.shared :as shared]
-   [clojure.core.async :as async]
    [clojure.java.io :as io]
    [cognitect.transit :as transit]))
 
@@ -16,7 +15,6 @@
                  :dep-graph {}
                  :file-meta {}})
 (defonce db* (atom initial-db))
-(defonce diagnostics-chan (async/chan 1))
 
 (def version 5)
 

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -264,10 +264,10 @@
   (swap! db* db-without-file uri filename)
   (f.diagnostic/publish-empty-diagnostics! uri))
 
-(defn did-change-watched-files [changes {:keys [db*] :as components}]
+(defn did-change-watched-files [changes {:keys [db* created-watched-files-chan] :as components}]
   (doseq [{:keys [uri type]} changes]
     (case type
-      :created (async/>!! db/created-watched-files-chan uri)
+      :created (async/>!! created-watched-files-chan uri)
       :changed (when (settings/get @db* [:compute-external-file-changes] true)
                  (shared/logging-task
                    :changed-watched-file

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -40,8 +40,8 @@
 (def cljfmt-config
   (memoize/ttl resolve-cljfmt-config :ttl/threshold memoize-ttl-threshold-milis))
 
-(defn formatting [uri db*]
-  (if-let [text (f.file-management/force-get-document-text uri db*)]
+(defn formatting [uri {:keys [db*] :as components}]
+  (if-let [text (f.file-management/force-get-document-text uri components)]
     (let [cljfmt-settings (cljfmt-config @db*)
           new-text (cljfmt/reformat-string text cljfmt-settings)]
       (if (= new-text text)

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -121,12 +121,12 @@
         , (conj filename)))))
 
 (defn hover
-  ([uri row col db*] (hover uri row col db* {}))
-  ([uri row col db* docs-config]
+  ([uri row col components] (hover uri row col components {}))
+  ([uri row col {:keys [db*] :as components} docs-config]
    (let [db @db*
          filename (shared/uri->filename uri)
          cursor-element (q/find-element-under-cursor db filename row col)
-         cursor-loc (some-> (f.file-management/force-get-document-text uri db*)
+         cursor-loc (some-> (f.file-management/force-get-document-text uri components)
                             parser/safe-zloc-of-string
                             (parser/to-pos row col))
          func-position (some-> cursor-loc

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -92,7 +92,7 @@
                :range (meta (z/node namespace-loc))}]
              (f.add-missing-libspec/cleaning-ns-edits uri db))))))
 
-(defn move-form [zloc source-uri db* dest-filename]
+(defn move-form [zloc source-uri {:keys [db*] :as components} dest-filename]
   (let [db @db*
         source-filename (shared/uri->filename source-uri)
         source-nses (q/ns-names-for-uri db source-uri source-filename)
@@ -123,7 +123,7 @@
                 refs (q/find-references db def-to-move false)
                 dest-refs (filter (comp #(= % dest-filename) :filename) refs)
                 per-file-usages (group-by (comp #(shared/filename->uri % db) :filename) refs)
-                insertion-loc (some-> (f.file-management/force-get-document-text dest-uri db*)
+                insertion-loc (some-> (f.file-management/force-get-document-text dest-uri components)
                                       z/of-string
                                       z/rightmost)
                 insertion-pos (meta (z/node insertion-loc))
@@ -145,7 +145,7 @@
                                             (fn [file-uri usages]
                                               (let [usage (first usages)
                                                     filename (:filename usage)
-                                                    file-loc (some-> (f.file-management/force-get-document-text file-uri db*)
+                                                    file-loc (some-> (f.file-management/force-get-document-text file-uri components)
                                                                      z/of-string)
                                                     db @db*
                                                     local-buckets (get-in db [:analysis filename])

--- a/lib/src/clojure_lsp/feature/refactor.clj
+++ b/lib/src/clojure_lsp/feature/refactor.clj
@@ -116,7 +116,7 @@
   (r.transform/create-test loc uri db components))
 
 (defmethod refactor :move-form [{:keys [loc uri args components]}]
-  (apply f.move-form/move-form loc uri (:db* components) args))
+  (apply f.move-form/move-form loc uri components args))
 
 (def available-refactors
   (->> refactor

--- a/lib/src/clojure_lsp/feature/signature_help.clj
+++ b/lib/src/clojure_lsp/feature/signature_help.clj
@@ -74,8 +74,8 @@
              (assoc-some :documentation (:doc definition))))
        arglist-strs))
 
-(defn signature-help [uri row col db*]
-  (when-let [function-loc (some-> (f.file-management/force-get-document-text uri db*)
+(defn signature-help [uri row col {:keys [db*] :as components}]
+  (when-let [function-loc (some-> (f.file-management/force-get-document-text uri components)
                                   parser/safe-zloc-of-string
                                   (parser/to-pos row col)
                                   edit/find-function-usage-name-loc)]

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -130,16 +130,16 @@
     (when (get-in @db [:documents (:uri text-document) :saved-on-disk])
       (swap! db #(update % :documents dissoc (:uri text-document)))))
 
-(defn did-change [{:keys [db*]} {:keys [text-document content-changes]}]
-  (f.file-management/did-change (:uri text-document) content-changes (:version text-document) db*))
+(defn did-change [components {:keys [text-document content-changes]}]
+  (f.file-management/did-change (:uri text-document) content-changes (:version text-document) components))
 
 (defn did-close [{:keys [db*]} {:keys [text-document]}]
   (shared/logging-task
     :did-close
     (f.file-management/did-close (:uri text-document) db*)))
 
-(defn did-change-watched-files [{:keys [db*]} {:keys [changes]}]
-  (f.file-management/did-change-watched-files changes db*))
+(defn did-change-watched-files [components {:keys [changes]}]
+  (f.file-management/did-change-watched-files changes components))
 
 (defn completion [{:keys [db*]} {:keys [text-document position]}]
   (shared/logging-results

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -95,7 +95,7 @@
           components)
         (let [db @db*]
           (when (settings/get db [:lint-project-files-after-startup?] true)
-            (f.diagnostic/publish-all-diagnostics! (-> db :settings :source-paths) db))
+            (f.diagnostic/publish-all-diagnostics! (-> db :settings :source-paths) components))
           (async/go
             (f.clojuredocs/refresh-cache! db*))
           (async/go
@@ -133,10 +133,10 @@
 (defn did-change [components {:keys [text-document content-changes]}]
   (f.file-management/did-change (:uri text-document) content-changes (:version text-document) components))
 
-(defn did-close [{:keys [db*]} {:keys [text-document]}]
+(defn did-close [components {:keys [text-document]}]
   (shared/logging-task
     :did-close
-    (f.file-management/did-close (:uri text-document) db*)))
+    (f.file-management/did-close (:uri text-document) components)))
 
 (defn did-change-watched-files [components {:keys [changes]}]
   (f.file-management/did-change-watched-files changes components))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -111,12 +111,12 @@
               (f.java-interop/retrieve-jdk-source-and-analyze! db*)))))
       (producer/show-message producer "No project-root-uri was specified, some features may not work properly." :warning nil))))
 
-(defn did-open [{:keys [producer db*]} {:keys [text-document]}]
+(defn did-open [{:keys [producer] :as components} {:keys [text-document]}]
   (shared/logging-task
     :did-open
     (let [uri (:uri text-document)
           text (:text text-document)]
-      (f.file-management/did-open uri text db* true)
+      (f.file-management/did-open uri text components true)
       (producer/refresh-test-tree producer [uri])))
   nil)
 
@@ -339,22 +339,22 @@
                (producer/show-document-request producer)))
         edit))))
 
-(defn hover [{:keys [db*]} {:keys [text-document position]}]
+(defn hover [components {:keys [text-document position]}]
   (shared/logging-task
     :hover
     (let [[row col] (shared/position->row-col position)]
-      (f.hover/hover (:uri text-document) row col db*))))
+      (f.hover/hover (:uri text-document) row col components))))
 
-(defn signature-help [{:keys [db*]} {:keys [text-document position _context]}]
+(defn signature-help [components {:keys [text-document position _context]}]
   (shared/logging-task
     :signature-help
     (let [[row col] (shared/position->row-col position)]
-      (f.signature-help/signature-help (:uri text-document) row col db*))))
+      (f.signature-help/signature-help (:uri text-document) row col components))))
 
-(defn formatting [{:keys [db*]} {:keys [text-document]}]
+(defn formatting [components {:keys [text-document]}]
   (shared/logging-task
     :formatting
-    (f.format/formatting (:uri text-document) db*)))
+    (f.format/formatting (:uri text-document) components)))
 
 (defn range-formatting [{:keys [db*]} {:keys [text-document range]}]
   (process-after-changes
@@ -425,18 +425,18 @@
       (f.call-hierarchy/prepare (:uri text-document) row col db*))))
 
 (defn call-hierarchy-incoming
-  [{:keys [db*]} {{:keys [uri range]} :item}]
+  [components {{:keys [uri range]} :item}]
   (shared/logging-task
     :call-hierarchy-incoming-calls
     (let [[row col] (shared/position->row-col (:start range))]
-      (f.call-hierarchy/incoming uri row col db*))))
+      (f.call-hierarchy/incoming uri row col components))))
 
 (defn call-hierarchy-outgoing
-  [{:keys [db*]} {{:keys [uri range]} :item}]
+  [components {{:keys [uri range]} :item}]
   (shared/logging-task
     :call-hierarchy-outgoing-calls
     (let [[row col] (shared/position->row-col (:start range))]
-      (f.call-hierarchy/outgoing uri row col db*))))
+      (f.call-hierarchy/outgoing uri row col components))))
 
 (defn linked-editing-ranges
   [{:keys [db*]} {:keys [text-document position]}]

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -135,19 +135,19 @@
     (f.file-management/did-change uri new-text (inc version) components)))
 
 (defn ^:private apply-workspace-rename-edit-summary!
-  [{:keys [old-uri new-uri]} db*]
+  [{:keys [old-uri new-uri]} {:keys [db*] :as components}]
   (let [old-file (-> old-uri shared/uri->filename io/file)
         new-file (-> new-uri shared/uri->filename io/file)]
     (io/make-parents new-file)
     (io/copy old-file new-file)
     (io/delete-file old-file)
     (f.file-management/did-close old-uri db*)
-    (f.file-management/did-open new-uri (slurp new-file) db* false)))
+    (f.file-management/did-open new-uri (slurp new-file) components false)))
 
 (defn ^:private apply-workspace-edit-summary!
-  [change {:keys [db*] :as components}]
+  [change components]
   (if (= :rename (:kind change))
-    (apply-workspace-rename-edit-summary! change db*)
+    (apply-workspace-rename-edit-summary! change components)
     (apply-workspace-change-edit-summary! change components))
   change)
 

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -80,8 +80,14 @@
 
   (refresh-test-tree [_this _uris]))
 
+(def db* (atom nil))
+
+(defn clean-db! [env]
+  (doto db*
+    (reset! (assoc db/initial-db :env env))))
+
 (defn ^:private build-components [options]
-  (let [db* db/db*]
+  (let [db* (if @db* db* (clean-db! nil))]
     {:db* db*
      :logger (doto (->CLILogger options)
                (logger/setup))

--- a/lib/test/clojure_lsp/classpath_test.clj
+++ b/lib/test/clojure_lsp/classpath_test.clj
@@ -5,7 +5,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest default-project-specs-test
   (with-redefs [shared/windows-os? false]

--- a/lib/test/clojure_lsp/classpath_test.clj
+++ b/lib/test/clojure_lsp/classpath_test.clj
@@ -5,6 +5,8 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
+(h/reset-db-after-test)
+
 (deftest default-project-specs-test
   (with-redefs [shared/windows-os? false]
     (testing "empty source-aliases"

--- a/lib/test/clojure_lsp/config_test.clj
+++ b/lib/test/clojure_lsp/config_test.clj
@@ -5,7 +5,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest resolve-config
   (testing "when user doesn't have a home config or a project config"

--- a/lib/test/clojure_lsp/dep_graph_test.clj
+++ b/lib/test/clojure_lsp/dep_graph_test.clj
@@ -175,7 +175,7 @@
       (is (not (nil? (get-in db [:documents "file:///aaa.clj"])))))
     #_(alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
     (with-redefs [shared/file-exists? (constantly false)]
-      (f.file-management/did-close "file:///aaa.clj" (h/db*)))
+      (f.file-management/did-close "file:///aaa.clj" (h/components)))
     (let [db (h/db)]
       (is (empty? (get-in db [:dep-graph 'aaa :dependencies])))
       (is (= '{ccc 1} (get-in db [:dep-graph 'aaa :dependents]))) ;; <-- no change, because ccc stil depends on aaa, even though aaa is now undefined

--- a/lib/test/clojure_lsp/dep_graph_test.clj
+++ b/lib/test/clojure_lsp/dep_graph_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.dep-graph-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.feature.file-management :as f.file-management]
    [clojure-lsp.shared :as shared]
@@ -36,13 +35,13 @@
                            :dependents {xxx 1, xxx.yyy 1},
                            :dependents-internal? false,
                            :dependents-langs {:clj 2}}}
-           (:dep-graph @db/db*)))
+           (:dep-graph (h/db))))
     (h/assert-submap
       '{:internal? false, :langs #{:clj}, :namespaces #{xxx} :filename "/some.jar:xxx.clj"}
-      (get-in @db/db* [:documents "zipfile:///some.jar::xxx.clj"]))
+      (get-in (h/db) [:documents "zipfile:///some.jar::xxx.clj"]))
     (h/assert-submap
       '{:internal? false, :langs #{:clj}, :namespaces #{xxx.yyy} :filename "/some.jar:xxx/yyy.clj"}
-      (get-in @db/db* [:documents "zipfile:///some.jar::xxx/yyy.clj"])))
+      (get-in (h/db) [:documents "zipfile:///some.jar::xxx/yyy.clj"])))
   (testing "initial internal analysis"
     (h/clean-db!)
     (load-code "/aaa.clj"
@@ -75,16 +74,16 @@
                            :dependents {aaa 1, bbb 1, ccc 1},
                            :dependents-internal? true,
                            :dependents-langs {:clj 3}}}
-           (:dep-graph @db/db*)))
+           (:dep-graph (h/db))))
     (h/assert-submap
       '{:internal? true, :langs #{:clj}, :namespaces #{aaa}, :filename "/aaa.clj"}
-      (get-in @db/db* [:documents "file:///aaa.clj"]))
+      (get-in (h/db) [:documents "file:///aaa.clj"]))
     (h/assert-submap
       '{:internal? true, :langs #{:clj}, :namespaces #{bbb}, :filename "/bbb.clj"}
-      (get-in @db/db* [:documents "file:///bbb.clj"]))
+      (get-in (h/db) [:documents "file:///bbb.clj"]))
     (h/assert-submap
       '{:internal? true, :langs #{:clj}, :namespaces #{ccc}, :filename "/ccc.clj"}
-      (get-in @db/db* [:documents "file:///ccc.clj"])))
+      (get-in (h/db) [:documents "file:///ccc.clj"])))
   (testing "extending initial external analysis with internal analysis"
     (h/clean-db!)
     (h/load-code-and-locs (h/code "(ns xxx"
@@ -92,7 +91,7 @@
                           (h/file-uri "jar:file:///some.jar!/xxx.clj"))
     (h/load-code-and-locs "(ns xxx.yyy)"
                           (h/file-uri "jar:file:///some.jar!/xxx/yyy.clj"))
-    (let [db @db/db*
+    (let [db (h/db)
           xxx (get-in db [:dep-graph 'xxx])
           xxx-yyy (get-in db [:dep-graph 'xxx.yyy])]
       (is (not (:internal? xxx)))
@@ -102,7 +101,7 @@
     (load-code "/aaa.clj"
                "(ns aaa"
                " (:require [xxx :as x]))")
-    (let [db @db/db*
+    (let [db (h/db)
           xxx (get-in db [:dep-graph 'xxx])
           xxx-yyy (get-in db [:dep-graph 'xxx.yyy])]
       (is (not (:internal? xxx)))
@@ -115,13 +114,13 @@
                "(ns bbb)")
     (load-code "/aaa.clj"
                "(ns aaa)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= '{clojure.core 1} (get-in db [:dep-graph 'aaa :dependencies])))
       (is (empty? (get-in db [:dep-graph 'bbb :dependents]))))
     (load-code "/aaa.clj"
                "(ns aaa"
                " (:require [bbb :as b]))")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (get-in db [:dep-graph 'aaa :dependencies 'bbb]))
       (is (get-in db [:dep-graph 'bbb :dependents 'aaa]))))
   (testing "removing dependency"
@@ -131,12 +130,12 @@
     (load-code "/aaa.clj"
                "(ns aaa"
                " (:require [bbb :as b]))")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (get-in db [:dep-graph 'aaa :dependencies 'bbb]))
       (is (get-in db [:dep-graph 'bbb :dependents 'aaa])))
     (load-code "/aaa.clj"
                "(ns aaa)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= '{clojure.core 1} (get-in db [:dep-graph 'aaa :dependencies])))
       (is (empty? (get-in db [:dep-graph 'bbb :dependents])))))
   (testing "removing duplicate dependency"
@@ -147,14 +146,14 @@
                "(ns aaa"
                " (:require [bbb :as b]"
                "           [bbb :as b2]))")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (get-in db [:dep-graph 'aaa :dependencies 'bbb]))
       (is (get-in db [:dep-graph 'bbb :dependents 'aaa]))
       (is (= '{b 1, b2 1} (get-in db [:dep-graph 'bbb :aliases]))))
     (load-code "/aaa.clj"
                "(ns aaa"
                " (:require [bbb :as b]))")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (get-in db [:dep-graph 'aaa :dependencies 'bbb]))
       (is (get-in db [:dep-graph 'bbb :dependents 'aaa]))
       (is (= '{b 1} (get-in db [:dep-graph 'bbb :aliases])))))
@@ -168,7 +167,7 @@
     (load-code "/ccc.clj"
                "(ns ccc"
                " (:require [aaa :as a]))")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (seq (get-in db [:dep-graph 'aaa :dependencies])))
       (is (= '{ccc 1} (get-in db [:dep-graph 'aaa :dependents])))
       (is (seq (get-in db [:dep-graph 'aaa :uris])))
@@ -176,8 +175,8 @@
       (is (not (nil? (get-in db [:documents "file:///aaa.clj"])))))
     #_(alter-var-root #'db/diagnostics-chan (constantly (async/chan 1)))
     (with-redefs [shared/file-exists? (constantly false)]
-      (f.file-management/did-close "file:///aaa.clj" db/db*))
-    (let [db @db/db*]
+      (f.file-management/did-close "file:///aaa.clj" (h/db*)))
+    (let [db (h/db)]
       (is (empty? (get-in db [:dep-graph 'aaa :dependencies])))
       (is (= '{ccc 1} (get-in db [:dep-graph 'aaa :dependents]))) ;; <-- no change, because ccc stil depends on aaa, even though aaa is now undefined
       (is (empty? (get-in db [:dep-graph 'aaa :uris])))
@@ -187,21 +186,21 @@
     (h/clean-db!)
     (load-code "/scratch.clj"
                "(def x 1)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= #{"file:///scratch.clj"} (get-in db [:dep-graph 'user :uris])))
       (is (= '#{user} (get-in db [:documents "file:///scratch.clj" :namespaces])))))
   (testing "with implicit dependency on clojure.core"
     (h/clean-db!)
     (load-code "/aaa.clj"
                "(ns aaa)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (get-in db [:dep-graph 'aaa :dependencies 'clojure.core]))
       (is (get-in db [:dep-graph 'clojure.core :dependents 'aaa]))))
   (testing "with implicit dependency on cljs.core"
     (h/clean-db!)
     (load-code "/aaa.cljs"
                "(ns aaa)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (get-in db [:dep-graph 'aaa :dependencies 'cljs.core]))
       (is (get-in db [:dep-graph 'cljs.core :dependents 'aaa])))))
 
@@ -217,7 +216,7 @@
                " (:require [ccc :as c]))")
     (load-code "/ccc.clj"
                "(ns ccc)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (are [expected namespace]
            (= expected (dep-graph/ns-uris db namespace))
         #{"file:///aaa.clj"} 'aaa
@@ -246,13 +245,13 @@
     (h/clean-db!)
     (load-code "/aaa.clj" "(ns aaa)")
     (h/load-code-and-locs "(ns bbb)" (h/file-uri "jar:file:///some.jar!/bbb.clj"))
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= ["file:///aaa.clj"] (dep-graph/internal-uris db)))))
   (testing "namespaces defined internally and externally"
     (h/clean-db!)
     (load-code "/aaa.clj" "(ns aaa)")
     (h/load-code-and-locs "(ns aaa)" (h/file-uri "jar:file:///some.jar!/aaa.clj"))
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= #{"file:///aaa.clj" "zipfile:///some.jar::aaa.clj"} (dep-graph/ns-uris db 'aaa)))
       (is (= ["file:///aaa.clj"] (dep-graph/ns-internal-uris db 'aaa)))
       (is (= ["file:///aaa.clj"] (dep-graph/internal-uris db)))))
@@ -261,7 +260,7 @@
     (load-code "/aaa.clj"
                "(ns aaa)"
                "(ns aaa2)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= #{"file:///aaa.clj"} (dep-graph/ns-uris db 'aaa)))
       (is (= #{"file:///aaa.clj"} (dep-graph/ns-uris db 'aaa2)))
       (is (= '#{aaa aaa2} (get-in db [:documents "file:///aaa.clj" :namespaces])))))
@@ -269,7 +268,7 @@
     (h/clean-db!)
     (load-code "/aaa.clj" "(ns aaa)")
     (load-code "/also/aaa.clj" "(ns aaa)")
-    (let [db @db/db*]
+    (let [db (h/db)]
       (is (= #{"file:///aaa.clj" "file:///also/aaa.clj"} (dep-graph/ns-uris db 'aaa)))
       (is (= '#{aaa} (get-in db [:documents "file:///aaa.clj" :namespaces])))
       (is (= '#{aaa} (get-in db [:documents "file:///also/aaa.clj" :namespaces]))))))

--- a/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
+++ b/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
@@ -6,7 +6,7 @@
    [clojure.test :refer [deftest is testing]]
    [rewrite-clj.zip :as z]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest resolve-best-alias-suggestions-test
   (testing "alias not exists"
@@ -201,38 +201,38 @@
 (deftest add-missing-libspec-test
   (testing "aliases"
     (testing "known aliases in project"
-      (h/clean-db!)
+      (h/reset-components!)
       (h/load-code-and-locs "(ns a (:require [foo.s :as s]))" "file:///b.clj")
       (is (= '(ns foo (:require [foo.s :as s]))
              (-> "(ns foo) |s/thing"
                  add-missing-libspec
                  as-sexp))))
     (testing "Do not add from wrong language"
-      (h/clean-db!)
+      (h/reset-components!)
       (h/load-code-and-locs "(ns a (:require [foo.s :as s]))" "file:///b.cljs")
       (h/load-code-and-locs "(ns foo.s)" "file:///c.cljs")
       (is (= nil
              (-> "(ns foo) |s/thing"
                  add-missing-libspec))))
     (testing "common ns aliases"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= '(ns foo (:require [clojure.set :as set]))
              (-> "(ns foo) |set/subset?"
                  add-missing-libspec
                  as-sexp))))
     (testing "Don't add an alias that already exists"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= nil
              (-> "(ns foo (:require [foo.set :as set])) |set/subset?"
                  add-missing-libspec))))
     (testing "Don't add a namespace that already exists, but fix alias."
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= "s/subset?"
              (-> "(ns foo (:require [clojure.set :as s])) |set/subset?"
                  add-missing-libspec
                  as-str))))
     (testing "Don't add a namespace that already exists, but fix alias."
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= "s/subset?"
              (-> "(ns foo (:require [clojure.set :as s])) |c.s/subset?"
                  add-missing-libspec
@@ -283,13 +283,13 @@
                    as-str))))))
   (testing "common refers"
     (testing "when require doesn't exists"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= '(ns foo (:require [clojure.test :refer [deftest]]))
              (-> "(ns foo) |deftest"
                  add-missing-libspec
                  as-sexp))))
     (testing "when already exists another require"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= '(ns foo (:require
                        [clojure.set :refer [subset?]]
                        [clojure.test :refer [deftest]]))
@@ -297,34 +297,34 @@
                  add-missing-libspec
                  as-sexp))))
     (testing "when already exists that ns with alias and no refers"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= '(ns foo (:require [clojure.test :as t :refer [testing]]))
              (-> "(ns foo (:require [clojure.test :as t])) |testing t/deftest"
                  add-missing-libspec
                  as-sexp))))
     (testing "when already exists that ns with another refer"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= '(ns foo (:require [clojure.test :refer [deftest testing]]))
              (-> "(ns foo (:require [clojure.test :refer [deftest]])) |testing deftest"
                  add-missing-libspec
                  as-sexp))))
     (testing "we don't add existing refers"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (nil? (add-missing-libspec "(ns foo (:require [clojure.test :refer [testing]])) |testing"))))
     (testing "we can add multiple refers"
-      (h/clean-db!)
+      (h/reset-components!)
       (is (= '(ns foo (:require
                        [clojure.test :refer [deftest is testing]]))
              (-> "(ns foo (:require [clojure.test :refer [deftest testing]])) |is deftest testing"
                  add-missing-libspec
                  as-sexp)))))
   (testing "when on invalid location"
-    (h/clean-db!)
+    (h/reset-components!)
     (is (nil? (-> "(ns foo) |;; comment"
                   add-missing-libspec)))))
 
 (defn add-import-to-namespace [code import-name & [settings]]
-  (h/clean-db!)
+  (h/reset-components!)
   (swap! (h/db*) shared/deep-merge {:settings (merge
                                               {:clean {:automatically-after-ns-refactor false}}
                                               settings)})

--- a/lib/test/clojure_lsp/feature/clean_ns_test.clj
+++ b/lib/test/clojure_lsp/feature/clean_ns_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.feature.clean-ns-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.clean-ns :as f.clean-ns]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
@@ -16,11 +15,11 @@
    (test-clean-ns db input-code expected-code in-form "file:///a.clj"))
   ([db input-code expected-code in-form uri]
    (h/clean-db!)
-   (swap! db/db* shared/deep-merge db)
+   (swap! (h/db*) shared/deep-merge db)
    (h/load-code-and-locs input-code (h/file-uri uri))
    (let [zloc (when in-form
                 (-> (z/of-string input-code) z/down z/right z/right))
-         [{:keys [loc range]}] (f.clean-ns/clean-ns-edits zloc (h/file-uri uri) @db/db*)]
+         [{:keys [loc range]}] (f.clean-ns/clean-ns-edits zloc (h/file-uri uri) (h/db))]
      (is (some? range))
      (is (= expected-code
             (z/root-string loc))))))

--- a/lib/test/clojure_lsp/feature/clean_ns_test.clj
+++ b/lib/test/clojure_lsp/feature/clean_ns_test.clj
@@ -6,7 +6,7 @@
    [clojure.test :refer [deftest is testing]]
    [rewrite-clj.zip :as z]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn- test-clean-ns
   ([db input-code expected-code]
@@ -14,7 +14,7 @@
   ([db input-code expected-code in-form]
    (test-clean-ns db input-code expected-code in-form "file:///a.clj"))
   ([db input-code expected-code in-form uri]
-   (h/clean-db!)
+   (h/reset-components!)
    (swap! (h/db*) shared/deep-merge db)
    (h/load-code-and-locs input-code (h/file-uri uri))
    (let [zloc (when in-form

--- a/lib/test/clojure_lsp/feature/destructure_keys_test.clj
+++ b/lib/test/clojure_lsp/feature/destructure_keys_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn ^:private can-destructure-zloc? [zloc]
   (f.destructure-keys/can-destructure-keys? zloc h/default-uri (h/db)))

--- a/lib/test/clojure_lsp/feature/destructure_keys_test.clj
+++ b/lib/test/clojure_lsp/feature/destructure_keys_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.feature.destructure-keys-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.destructure-keys :as f.destructure-keys]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
@@ -8,13 +7,13 @@
 (h/reset-db-after-test)
 
 (defn ^:private can-destructure-zloc? [zloc]
-  (f.destructure-keys/can-destructure-keys? zloc h/default-uri @db/db*))
+  (f.destructure-keys/can-destructure-keys? zloc h/default-uri (h/db)))
 
 (defn ^:private destructure-zloc [zloc]
-  (f.destructure-keys/destructure-keys zloc h/default-uri @db/db*))
+  (f.destructure-keys/destructure-keys zloc h/default-uri (h/db)))
 
 (defn ^:private as-string [changes]
-  (h/changes->code changes @db/db*))
+  (h/changes->code changes (h/db)))
 
 (defmacro ^:private assert-cannot-destructure [code]
   `(let [zloc# (h/load-code-and-zloc ~code)]

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn can-drag-zloc-backward? [zloc]
   (f.drag/can-drag-backward? zloc h/default-uri (h/db)))

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.feature.drag-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.drag :as f.drag]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
@@ -8,10 +7,10 @@
 (h/reset-db-after-test)
 
 (defn can-drag-zloc-backward? [zloc]
-  (f.drag/can-drag-backward? zloc h/default-uri @db/db*))
+  (f.drag/can-drag-backward? zloc h/default-uri (h/db)))
 
 (defn can-drag-zloc-forward? [zloc]
-  (f.drag/can-drag-forward? zloc h/default-uri @db/db*))
+  (f.drag/can-drag-forward? zloc h/default-uri (h/db)))
 
 (defn can-drag-code-backward? [code]
   (can-drag-zloc-backward? (h/load-code-and-zloc code)))
@@ -214,10 +213,10 @@
       (is (not (can-drag-code-forward? (h/code "(are [] (= 1 1) |1 2)")))))))
 
 (defn drag-zloc-backward [{:keys [zloc position]}]
-  (f.drag/drag-backward zloc position h/default-uri @db/db*))
+  (f.drag/drag-backward zloc position h/default-uri (h/db)))
 
 (defn drag-zloc-forward [{:keys [zloc position]}]
-  (f.drag/drag-forward zloc position h/default-uri @db/db*))
+  (f.drag/drag-forward zloc position h/default-uri (h/db)))
 
 (defn drag-code-backward [code]
   (drag-zloc-backward (h/load-code-into-zloc-and-position code)))
@@ -229,7 +228,7 @@
   (some-> change
           :changes-by-uri
           (get h/default-uri)
-          (h/changes->code @db/db*)))
+          (h/changes->code (h/db))))
 
 (defn- as-position [change]
   (when-let [{:keys [row col end-row end-col]} (some-> change

--- a/lib/test/clojure_lsp/feature/java_interop_test.clj
+++ b/lib/test/clojure_lsp/feature/java_interop_test.clj
@@ -1,19 +1,21 @@
 (ns clojure-lsp.feature.java-interop-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.java-interop :as f.java-interop]
+   [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]
    [medley.core :as medley]))
 
+(h/reset-db-after-test)
+
 (deftest uri->translated-uri-test
-  (is (= "" (f.java-interop/uri->translated-uri "" @db/db*)))
-  (is (= "/foo/bar.clj" (f.java-interop/uri->translated-uri "/foo/bar.clj" @db/db*)))
-  (is (= "file:///foo/bar.clj" (f.java-interop/uri->translated-uri "file:///foo/bar.clj" @db/db*)))
-  (is (= "jar:file:///foo/bar.clj" (f.java-interop/uri->translated-uri "jar:file:///foo/bar.clj" @db/db*)))
-  (is (= "jar:file:///foo.jar!/bar.clj" (f.java-interop/uri->translated-uri "jar:file:///foo.jar!/bar.clj" @db/db*)))
-  (is (= "jar:file:///foo.jar!/Bar.java" (f.java-interop/uri->translated-uri "jar:file:///foo.jar!/Bar.java" @db/db*)))
-  (is (= "zipfile:///foo.jar::/bar.clj" (f.java-interop/uri->translated-uri "zipfile:///foo.jar::/bar.clj" @db/db*)))
-  (is (= "zipfile:///foo.jar::/bar.java" (f.java-interop/uri->translated-uri "zipfile:///foo.jar::/bar.java" @db/db*))))
+  (is (= "" (f.java-interop/uri->translated-uri "" (h/db))))
+  (is (= "/foo/bar.clj" (f.java-interop/uri->translated-uri "/foo/bar.clj" (h/db))))
+  (is (= "file:///foo/bar.clj" (f.java-interop/uri->translated-uri "file:///foo/bar.clj" (h/db))))
+  (is (= "jar:file:///foo/bar.clj" (f.java-interop/uri->translated-uri "jar:file:///foo/bar.clj" (h/db))))
+  (is (= "jar:file:///foo.jar!/bar.clj" (f.java-interop/uri->translated-uri "jar:file:///foo.jar!/bar.clj" (h/db))))
+  (is (= "jar:file:///foo.jar!/Bar.java" (f.java-interop/uri->translated-uri "jar:file:///foo.jar!/Bar.java" (h/db))))
+  (is (= "zipfile:///foo.jar::/bar.clj" (f.java-interop/uri->translated-uri "zipfile:///foo.jar::/bar.clj" (h/db))))
+  (is (= "zipfile:///foo.jar::/bar.java" (f.java-interop/uri->translated-uri "zipfile:///foo.jar::/bar.java" (h/db)))))
 
 (defn ->decision [& args]
   (-> (apply #'f.java-interop/jdk-analysis-decision args)

--- a/lib/test/clojure_lsp/feature/java_interop_test.clj
+++ b/lib/test/clojure_lsp/feature/java_interop_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as medley]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest uri->translated-uri-test
   (is (= "" (f.java-interop/uri->translated-uri "" (h/db))))

--- a/lib/test/clojure_lsp/feature/move_form_test.clj
+++ b/lib/test/clojure_lsp/feature/move_form_test.clj
@@ -4,11 +4,11 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest move-form-test
   (testing "simple"
-    (h/clean-db!)
+    (h/reset-components!)
     (let [a-uri (h/file-uri "file:///a.clj")
           b-uri (h/file-uri "file:///b.clj")
           zloc (h/load-code-and-zloc (h/code "(ns apple)" "|(def bar inc)" "(bar 1)"))
@@ -24,7 +24,7 @@
                      ""
                      "(def bar inc)") b-results))))
   (testing "complex"
-    (h/clean-db!)
+    (h/reset-components!)
     (let [a-uri (h/file-uri "file:///a.clj")
           b-uri (h/file-uri "file:///b.clj")
           c-uri (h/file-uri "file:///c.clj")

--- a/lib/test/clojure_lsp/feature/move_form_test.clj
+++ b/lib/test/clojure_lsp/feature/move_form_test.clj
@@ -13,7 +13,7 @@
           b-uri (h/file-uri "file:///b.clj")
           zloc (h/load-code-and-zloc (h/code "(ns apple)" "|(def bar inc)" "(bar 1)"))
           _ (h/load-code-and-locs "(ns bread)" b-uri)
-          results (:changes-by-uri (move-form/move-form zloc a-uri (h/db*) "/b.clj"))
+          results (:changes-by-uri (move-form/move-form zloc a-uri (h/components) "/b.clj"))
           a-results (h/changes-by-uri->code results a-uri (h/db))
           b-results (h/changes-by-uri->code results b-uri (h/db))]
       (is (= (h/code "(ns apple "
@@ -55,7 +55,7 @@
           _ (h/load-code-and-locs (h/code "(ns fruit (:require [apple :as a] [bread :as b]))"
                                           "(a/bar 2)"
                                           "(b/foo 3)") f-uri)
-          results (:changes-by-uri (move-form/move-form zloc a-uri (h/db*) "/b.clj"))
+          results (:changes-by-uri (move-form/move-form zloc a-uri (h/components) "/b.clj"))
           a-results (h/changes-by-uri->code results a-uri (h/db))
           b-results (h/changes-by-uri->code results b-uri (h/db))
           c-results (h/changes-by-uri->code results c-uri (h/db))

--- a/lib/test/clojure_lsp/feature/move_form_test.clj
+++ b/lib/test/clojure_lsp/feature/move_form_test.clj
@@ -1,9 +1,10 @@
 (ns clojure-lsp.feature.move-form-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.move-form :as move-form]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
+
+(h/reset-db-after-test)
 
 (deftest move-form-test
   (testing "simple"
@@ -12,9 +13,9 @@
           b-uri (h/file-uri "file:///b.clj")
           zloc (h/load-code-and-zloc (h/code "(ns apple)" "|(def bar inc)" "(bar 1)"))
           _ (h/load-code-and-locs "(ns bread)" b-uri)
-          results (:changes-by-uri (move-form/move-form zloc a-uri db/db* "/b.clj"))
-          a-results (h/changes-by-uri->code results a-uri @db/db*)
-          b-results (h/changes-by-uri->code results b-uri @db/db*)]
+          results (:changes-by-uri (move-form/move-form zloc a-uri (h/db*) "/b.clj"))
+          a-results (h/changes-by-uri->code results a-uri (h/db))
+          b-results (h/changes-by-uri->code results b-uri (h/db))]
       (is (= (h/code "(ns apple "
                      "  (:require"
                      "   bread))"
@@ -54,13 +55,13 @@
           _ (h/load-code-and-locs (h/code "(ns fruit (:require [apple :as a] [bread :as b]))"
                                           "(a/bar 2)"
                                           "(b/foo 3)") f-uri)
-          results (:changes-by-uri (move-form/move-form zloc a-uri db/db* "/b.clj"))
-          a-results (h/changes-by-uri->code results a-uri @db/db*)
-          b-results (h/changes-by-uri->code results b-uri @db/db*)
-          c-results (h/changes-by-uri->code results c-uri @db/db*)
-          d-results (h/changes-by-uri->code results d-uri @db/db*)
-          e-results (h/changes-by-uri->code results e-uri @db/db*)
-          f-results (h/changes-by-uri->code results f-uri @db/db*)]
+          results (:changes-by-uri (move-form/move-form zloc a-uri (h/db*) "/b.clj"))
+          a-results (h/changes-by-uri->code results a-uri (h/db))
+          b-results (h/changes-by-uri->code results b-uri (h/db))
+          c-results (h/changes-by-uri->code results c-uri (h/db))
+          d-results (h/changes-by-uri->code results d-uri (h/db))
+          e-results (h/changes-by-uri->code results e-uri (h/db))
+          f-results (h/changes-by-uri->code results f-uri (h/db))]
       (is (= (h/code "(ns apple (:require [bread :as b]))"
                      ""
                      "(def qux 1)"

--- a/lib/test/clojure_lsp/feature/sort_map_test.clj
+++ b/lib/test/clojure_lsp/feature/sort_map_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest is testing]]
    [rewrite-clj.zip :as z]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest sortable-map?
   (is (not (f.sort-map/sortable-map-zloc (z/of-string "[]"))))

--- a/lib/test/clojure_lsp/feature/test_tree_test.clj
+++ b/lib/test/clojure_lsp/feature/test_tree_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest tree-test
   (testing "valid test tree"

--- a/lib/test/clojure_lsp/feature/test_tree_test.clj
+++ b/lib/test/clojure_lsp/feature/test_tree_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.feature.test-tree-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.test-tree :as f.test-tree]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest testing]]))
@@ -60,4 +59,4 @@
               :name-range {:start {:line 6 :character 5}
                            :end {:line 6 :character 12}}
               :kind :testing}]}]}]}}
-      (f.test-tree/tree "file:///a.clj" @db/db*))))
+      (f.test-tree/tree "file:///a.clj" (h/db)))))

--- a/lib/test/clojure_lsp/features/call_hierarchy_test.clj
+++ b/lib/test/clojure_lsp/features/call_hierarchy_test.clj
@@ -71,7 +71,7 @@
                :uri (h/file-uri "file:///some/c.clj")
                :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
                :selection-range {:start {:line 3 :character 3} :end {:line 3 :character 11}}}}]
-      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 (h/db*))))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 (h/components))))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -99,7 +99,7 @@
                :uri (h/file-uri "file:///some/b.clj")
                :range {:start {:line 5 :character 6} :end {:line 5 :character 14}}
                :selection-range {:start {:line 6 :character 3} :end {:line 6 :character 11}}}}]
-      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 (h/db*)))))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 (h/components)))))
 
 (deftest outgoing
   (h/load-code-and-locs core-code (h/file-uri "jar:file:///.m2/clojure.jar!/clojure/core.clj"))
@@ -118,7 +118,7 @@
              :uri (h/file-uri "file:///some/b.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 3 :character 3} :end {:line 3 :character 11}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 (h/db*))))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 (h/components))))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -138,7 +138,7 @@
              :uri (h/file-uri "file:///some/c.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 4 :character 3} :end {:line 4 :character 11}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 (h/db*))))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 (h/components))))
 
   (testing "with external elements"
     (h/assert-submaps
@@ -150,4 +150,4 @@
              :uri "zipfile:///.m2/clojure.jar::clojure/core.clj"
              :range {:start {:line 1 :character 6} :end {:line 1 :character 13}}
              :selection-range {:start {:line 2 :character 3} :end {:line 2 :character 10}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/d.clj") 2 7 (h/db*)))))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/d.clj") 2 7 (h/components)))))

--- a/lib/test/clojure_lsp/features/call_hierarchy_test.clj
+++ b/lib/test/clojure_lsp/features/call_hierarchy_test.clj
@@ -5,7 +5,7 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn code [& strings] (string/join "\n" strings))
 

--- a/lib/test/clojure_lsp/features/call_hierarchy_test.clj
+++ b/lib/test/clojure_lsp/features/call_hierarchy_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.call-hierarchy-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.call-hierarchy :as f.call-hierarchy]
    [clojure-lsp.test-helper :as h]
    [clojure.string :as string]
@@ -46,7 +45,7 @@
   (h/load-code-and-locs c-code (h/file-uri "file:///some/c.clj"))
   (h/load-code-and-locs d-code (h/file-uri "file:///some/d.clj"))
   (testing "single element"
-    (let [items (f.call-hierarchy/prepare (h/file-uri "file:///some/d.clj") 2 7 db/db*)]
+    (let [items (f.call-hierarchy/prepare (h/file-uri "file:///some/d.clj") 2 7 (h/db*))]
       (is (= 1 (count items)))
       (is (= {:name            "d-func []"
               :kind            :function
@@ -72,7 +71,7 @@
                :uri (h/file-uri "file:///some/c.clj")
                :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
                :selection-range {:start {:line 3 :character 3} :end {:line 3 :character 11}}}}]
-      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 db/db*)))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/d.clj") 2 7 (h/db*))))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -100,7 +99,7 @@
                :uri (h/file-uri "file:///some/b.clj")
                :range {:start {:line 5 :character 6} :end {:line 5 :character 14}}
                :selection-range {:start {:line 6 :character 3} :end {:line 6 :character 11}}}}]
-      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 db/db*))))
+      (f.call-hierarchy/incoming (h/file-uri "file:///some/c.clj") 3 7 (h/db*)))))
 
 (deftest outgoing
   (h/load-code-and-locs core-code (h/file-uri "jar:file:///.m2/clojure.jar!/clojure/core.clj"))
@@ -119,7 +118,7 @@
              :uri (h/file-uri "file:///some/b.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 3 :character 3} :end {:line 3 :character 11}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 db/db*)))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/a.clj") 3 7 (h/db*))))
 
   (testing "for multiple elements"
     (h/assert-submaps
@@ -139,7 +138,7 @@
              :uri (h/file-uri "file:///some/c.clj")
              :range {:start {:line 2 :character 6} :end {:line 2 :character 12}}
              :selection-range {:start {:line 4 :character 3} :end {:line 4 :character 11}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 db/db*)))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/b.clj") 3 7 (h/db*))))
 
   (testing "with external elements"
     (h/assert-submaps
@@ -151,4 +150,4 @@
              :uri "zipfile:///.m2/clojure.jar::clojure/core.clj"
              :range {:start {:line 1 :character 6} :end {:line 1 :character 13}}
              :selection-range {:start {:line 2 :character 3} :end {:line 2 :character 10}}}}]
-      (f.call-hierarchy/outgoing (h/file-uri "file:///some/d.clj") 2 7 db/db*))))
+      (f.call-hierarchy/outgoing (h/file-uri "file:///some/d.clj") 2 7 (h/db*)))))

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -7,7 +7,7 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn zloc-of [uri]
   (parser/safe-zloc-of-file (h/db) uri))

--- a/lib/test/clojure_lsp/features/code_lens_test.clj
+++ b/lib/test/clojure_lsp/features/code_lens_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest reference-code-lens
   (testing "common lens"

--- a/lib/test/clojure_lsp/features/code_lens_test.clj
+++ b/lib/test/clojure_lsp/features/code_lens_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.code-lens-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.code-lens :as f.code-lens]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
@@ -17,7 +16,7 @@
                                "  (+ a b (foo2)))\n"
                                "(s/defn baz []\n"
                                "  (bar 2 3))\n"))
-    (swap! db/db* assoc :kondo-config {})
+    (swap! (h/db*) assoc :kondo-config {})
     (h/assert-submaps
       [{}
        {:range
@@ -29,22 +28,22 @@
        {:range
         {:start {:line 4 :character 6} :end {:line 4 :character 9}}
         :data [(h/file-uri "file:///a.clj") 5 7]}]
-      (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") @db/db*)))
+      (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") (h/db))))
   (testing "defrecord"
     (h/load-code-and-locs (h/code "(defrecord MyRecord [])"
                                   "(MyRecord)"
                                   "(->MyRecord)"
                                   "(map->MyRecord)"))
-    (swap! db/db* assoc :kondo-config {})
+    (swap! (h/db*) assoc :kondo-config {})
     (is (= [{:range
              {:start {:line 0, :character 11}, :end {:line 0, :character 19}},
              :data [(h/file-uri "file:///a.clj") 1 12]}]
-           (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") @db/db*))))
+           (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "keyword definitions"
     (h/load-code-and-locs (h/code "(ns foo (:require [re-frame.core :as r]))"
                                   "(r/reg-event-db ::event identity)"
                                   "(r/reg-sub ::sub identity)"))
-    (swap! db/db* assoc :kondo-config {})
+    (swap! (h/db*) assoc :kondo-config {})
     (h/assert-submaps
       [{}
        {:range
@@ -53,16 +52,16 @@
        {:range
         {:start {:line 2, :character 11}, :end {:line 2, :character 16}},
         :data [(h/file-uri "file:///a.clj") 3 12]}]
-      (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") @db/db*)))
+      (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") (h/db))))
   (testing "namespaces definitions"
     (h/load-code-and-locs (h/code "(ns foo) (def a)"))
     (h/load-code-and-locs (h/code "(ns bar (:require [foo :as f])) f/a"))
-    (swap! db/db* assoc :kondo-config {})
+    (swap! (h/db*) assoc :kondo-config {})
     (h/assert-submaps
       [{:range
         {:start {:line 0, :character 4}, :end {:line 0, :character 7}}
         :data [(h/file-uri "file:///a.clj") 1 5]}]
-      (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") @db/db*))))
+      (f.code-lens/reference-code-lens (h/file-uri "file:///a.clj") (h/db)))))
 
 (deftest test-code-lens-resolve
   (h/load-code-and-locs (str "(ns some-ns)\n"
@@ -82,7 +81,7 @@
               :command {:title   "0 references"
                         :command "code-lens-references"
                         :arguments [(h/file-uri "file:///a.clj") 0 5]}}
-             (f.code-lens/resolve-code-lens (h/file-uri "file:///a.clj") 0 5 {:start {:line 0 :character 5} :end {:line 0 :character 12}} @db/db*))))
+             (f.code-lens/resolve-code-lens (h/file-uri "file:///a.clj") 0 5 {:start {:line 0 :character 5} :end {:line 0 :character 12}} (h/db)))))
     (testing "some lens"
       (is (= {:range   {:start {:line      1
                                 :character 5}
@@ -91,7 +90,7 @@
               :command {:title   "1 reference"
                         :command "code-lens-references"
                         :arguments [(h/file-uri "file:///a.clj") 2 6]}}
-             (f.code-lens/resolve-code-lens (h/file-uri "file:///a.clj") 2 6 {:start {:line 1 :character 5} :end {:line 1 :character 12}} @db/db*)))
+             (f.code-lens/resolve-code-lens (h/file-uri "file:///a.clj") 2 6 {:start {:line 1 :character 5} :end {:line 1 :character 12}} (h/db))))
       (is (= {:range   {:start {:line      2
                                 :character 7}
                         :end   {:line      2
@@ -99,7 +98,7 @@
               :command {:title   "1 reference"
                         :command "code-lens-references"
                         :arguments [(h/file-uri "file:///a.clj") 3 8]}}
-             (f.code-lens/resolve-code-lens (h/file-uri "file:///a.clj") 3 8 {:start {:line 2 :character 7} :end {:line 2 :character 11}} @db/db*))))
+             (f.code-lens/resolve-code-lens (h/file-uri "file:///a.clj") 3 8 {:start {:line 2 :character 7} :end {:line 2 :character 11}} (h/db)))))
     (testing "defrecord lens"
       (h/load-code-and-locs (h/code "(defrecord MyRecord [])"
                                     "(MyRecord)"
@@ -115,4 +114,4 @@
                (h/file-uri "file:///a.clj") 1 13
                {:start {:line 1 :character 5}
                 :end {:line 1 :character 12}}
-               @db/db*))))))
+               (h/db)))))))

--- a/lib/test/clojure_lsp/features/completion_test.clj
+++ b/lib/test/clojure_lsp/features/completion_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest test-completion
   (h/load-code-and-locs (h/code "(ns alpaca.ns (:require [user :as alpaca]))"

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -22,7 +22,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :info}}}})
     (h/assert-submaps
@@ -39,7 +39,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :warning}}}})
     (h/assert-submaps
@@ -56,7 +56,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :error}}}})
     (h/assert-submaps
@@ -73,7 +73,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :off}}}})
     (h/assert-submaps
@@ -90,7 +90,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
@@ -107,7 +107,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns}}}}})
     (h/assert-submaps
@@ -117,7 +117,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'foo}}}}})
     (h/assert-submaps
@@ -127,7 +127,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/a.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns/foo}}}}})
     (h/assert-submaps
@@ -137,7 +137,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/b.clj"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
@@ -147,7 +147,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/c.cljs"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
@@ -172,7 +172,7 @@
     (reset! findings [])
     (f.diagnostic/custom-lint-file!
       "/d.cljs"
-      @db/db*
+      (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps [] @findings)))
@@ -181,62 +181,62 @@
   (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///some_ns.clj"))
   (h/load-code-and-locs "(ns other-ns) (assert )" (h/file-uri "file:///other_ns.clj"))
   (testing "when linter level is :off"
-    (swap! db/db* shared/deep-merge {:settings {:linters {:clj-kondo {:level :off}}}})
+    (swap! (h/db*) shared/deep-merge {:settings {:linters {:clj-kondo {:level :off}}}})
     (is (= []
-           (f.diagnostic/find-diagnostics (h/file-uri "file:///some_ns.clj") @db/db*))))
+           (f.diagnostic/find-diagnostics (h/file-uri "file:///some_ns.clj") (h/db)))))
   (testing "when linter level is not :off but has matching :ns-exclude-regex"
     (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///project/src/some_ns.clj"))
-    (swap! db/db* merge {:project-root-uri (h/file-uri "file:///project")
+    (swap! (h/db*) merge {:project-root-uri (h/file-uri "file:///project")
                          :settings {:source-paths ["/project/src"]
                                     :linters {:clj-kondo {:ns-exclude-regex "some-ns.*"}}}})
     (is (= []
-           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/some_ns.clj") @db/db*))))
+           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/some_ns.clj") (h/db)))))
   (testing "when linter level is not :off"
-    (swap! db/db* merge {:settings {:linters {:clj-kondo {:level :error}}}})
+    (swap! (h/db*) merge {:settings {:linters {:clj-kondo {:level :error}}}})
     (h/assert-submaps [{:range {:start {:line 0 :character 29} :end {:line 0 :character 32}}
                         :message "Unused private var some-ns/foo"
                         :code "unused-private-var"
                         :tags [1]
                         :severity 2
                         :source "clj-kondo"}]
-                      (f.diagnostic/find-diagnostics (h/file-uri "file:///some_ns.clj") @db/db*)))
+                      (f.diagnostic/find-diagnostics (h/file-uri "file:///some_ns.clj") (h/db))))
   (testing "when linter is not specified"
-    (swap! db/db* merge {:settings {}})
+    (swap! (h/db*) merge {:settings {}})
     (h/assert-submaps [{:range {:start {:line 0 :character 29} :end {:line 0 :character 32}}
                         :message "Unused private var some-ns/foo"
                         :code "unused-private-var"
                         :tags [1]
                         :severity 2
                         :source "clj-kondo"}]
-                      (f.diagnostic/find-diagnostics (h/file-uri "file:///some_ns.clj") @db/db*)))
+                      (f.diagnostic/find-diagnostics (h/file-uri "file:///some_ns.clj") (h/db))))
   (testing "when inside expression?"
-    (swap! db/db* merge {:settings {}})
+    (swap! (h/db*) merge {:settings {}})
     (h/assert-submaps [{:range {:start {:line 0 :character 14} :end {:line 0 :character 23}}
                         :message "clojure.core/assert is called with 0 args but expects 1 or 2"
                         :code "invalid-arity"
                         :tags []
                         :severity 1
                         :source "clj-kondo"}]
-                      (f.diagnostic/find-diagnostics (h/file-uri "file:///other_ns.clj") @db/db*)))
+                      (f.diagnostic/find-diagnostics (h/file-uri "file:///other_ns.clj") (h/db))))
   (testing "when file is external"
     (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///some/place.jar:some/file.clj"))
-    (swap! db/db* merge {:project-root-uri (h/file-uri "file:///project")
+    (swap! (h/db*) merge {:project-root-uri (h/file-uri "file:///project")
                          :settings {:source-paths ["/project/src"]}})
     (is (= []
-           (f.diagnostic/find-diagnostics (h/file-uri "file:///some/place.jar:some/file.clj") @db/db*)))))
+           (f.diagnostic/find-diagnostics (h/file-uri "file:///some/place.jar:some/file.clj") (h/db))))))
 
 (deftest lint-clj-depend-findings
   (testing "when no clj-depend config is found"
-    (swap! db/db* shared/deep-merge {:project-root-uri (h/file-uri "file:///project")
+    (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")
                                      :settings {:source-paths ["/project/src"]}})
 
     (with-redefs [clj-depend/analyze (constantly {:violations [{:namespace 'bar :violation "Foo issue"}]})]
       (h/load-code-and-locs "(ns foo) (def a 1)" (h/file-uri "file:///project/src/foo.clj"))
       (h/load-code-and-locs "(ns bar (:require [foo :as f])) f/a" (h/file-uri "file:///project/src/bar.clj")))
     (is (= []
-           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") @db/db*))))
+           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") (h/db)))))
   (testing "when clj-depend config is found but linter level is :off"
-    (swap! db/db* shared/deep-merge {:settings {:source-paths ["/project/src"]
+    (swap! (h/db*) shared/deep-merge {:settings {:source-paths ["/project/src"]
                                                 :clj-depend {:layers {:foo {:defined-by ".*foo.*"
                                                                             :accessed-by-layers #{}}
                                                                       :bar {:defined-by ".*bar.*"
@@ -246,9 +246,9 @@
       (h/load-code-and-locs "(ns foo) (def a 1)" (h/file-uri "file:///project/src/foo.clj"))
       (h/load-code-and-locs "(ns bar (:require [foo :as f])) f/a" (h/file-uri "file:///project/src/bar.clj")))
     (is (= []
-           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") @db/db*))))
+           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") (h/db)))))
   (testing "when clj-depend config is found and a violation is present"
-    (swap! db/db* shared/deep-merge {:project-root-uri (h/file-uri "file:///project")
+    (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")
                                      :settings {:linters {:clj-depend {:level :info}}
                                                 :source-paths ["/project/src"]
                                                 :clj-depend {:layers {:foo {:defined-by ".*foo.*"
@@ -266,7 +266,7 @@
              :code "clj-depend"
              :severity 3
              :source "clj-depend"}]
-           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") @db/db*)))))
+           (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") (h/db))))))
 
 (deftest test-find-diagnostics
   (testing "wrong arity"

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -1,10 +1,10 @@
 (ns clojure-lsp.features.diagnostics-test
   (:require
    [clj-depend.api :as clj-depend]
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.diagnostics :as f.diagnostic]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
+   [clojure.core.async :as async]
    [clojure.test :refer [deftest is testing]]))
 
 (def findings (atom []))
@@ -187,8 +187,8 @@
   (testing "when linter level is not :off but has matching :ns-exclude-regex"
     (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///project/src/some_ns.clj"))
     (swap! (h/db*) merge {:project-root-uri (h/file-uri "file:///project")
-                         :settings {:source-paths ["/project/src"]
-                                    :linters {:clj-kondo {:ns-exclude-regex "some-ns.*"}}}})
+                          :settings {:source-paths ["/project/src"]
+                                     :linters {:clj-kondo {:ns-exclude-regex "some-ns.*"}}}})
     (is (= []
            (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/some_ns.clj") (h/db)))))
   (testing "when linter level is not :off"
@@ -221,14 +221,14 @@
   (testing "when file is external"
     (h/load-code-and-locs "(ns some-ns) (defn ^:private foo [a b] (+ a b))" (h/file-uri "file:///some/place.jar:some/file.clj"))
     (swap! (h/db*) merge {:project-root-uri (h/file-uri "file:///project")
-                         :settings {:source-paths ["/project/src"]}})
+                          :settings {:source-paths ["/project/src"]}})
     (is (= []
            (f.diagnostic/find-diagnostics (h/file-uri "file:///some/place.jar:some/file.clj") (h/db))))))
 
 (deftest lint-clj-depend-findings
   (testing "when no clj-depend config is found"
     (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")
-                                     :settings {:source-paths ["/project/src"]}})
+                                      :settings {:source-paths ["/project/src"]}})
 
     (with-redefs [clj-depend/analyze (constantly {:violations [{:namespace 'bar :violation "Foo issue"}]})]
       (h/load-code-and-locs "(ns foo) (def a 1)" (h/file-uri "file:///project/src/foo.clj"))
@@ -237,11 +237,11 @@
            (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") (h/db)))))
   (testing "when clj-depend config is found but linter level is :off"
     (swap! (h/db*) shared/deep-merge {:settings {:source-paths ["/project/src"]
-                                                :clj-depend {:layers {:foo {:defined-by ".*foo.*"
-                                                                            :accessed-by-layers #{}}
-                                                                      :bar {:defined-by ".*bar.*"
-                                                                            :accessed-by-layers #{:baz}}}}
-                                                :linters {:clj-depend {:level :off}}}})
+                                                 :clj-depend {:layers {:foo {:defined-by ".*foo.*"
+                                                                             :accessed-by-layers #{}}
+                                                                       :bar {:defined-by ".*bar.*"
+                                                                             :accessed-by-layers #{:baz}}}}
+                                                 :linters {:clj-depend {:level :off}}}})
     (with-redefs [clj-depend/analyze (constantly {:violations [{:namespace 'bar :violation "Foo issue"}]})]
       (h/load-code-and-locs "(ns foo) (def a 1)" (h/file-uri "file:///project/src/foo.clj"))
       (h/load-code-and-locs "(ns bar (:require [foo :as f])) f/a" (h/file-uri "file:///project/src/bar.clj")))
@@ -249,12 +249,12 @@
            (f.diagnostic/find-diagnostics (h/file-uri "file:///project/src/bar.clj") (h/db)))))
   (testing "when clj-depend config is found and a violation is present"
     (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")
-                                     :settings {:linters {:clj-depend {:level :info}}
-                                                :source-paths ["/project/src"]
-                                                :clj-depend {:layers {:foo {:defined-by ".*foo.*"
-                                                                            :accessed-by-layers #{}}
-                                                                      :bar {:defined-by ".*bar.*"
-                                                                            :accessed-by-layers #{:baz}}}}}})
+                                      :settings {:linters {:clj-depend {:level :info}}
+                                                 :source-paths ["/project/src"]
+                                                 :clj-depend {:layers {:foo {:defined-by ".*foo.*"
+                                                                             :accessed-by-layers #{}}
+                                                                       :bar {:defined-by ".*bar.*"
+                                                                             :accessed-by-layers #{:baz}}}}}})
 
     (with-redefs [clj-depend/analyze (constantly {:violations [{:namespace 'bar :message "Foo issue"}]})]
       (h/load-code-and-locs "(ns foo) (def a 1)" (h/file-uri "file:///project/src/foo.clj"))
@@ -289,19 +289,19 @@
                   (foo)
                   (foo 1)
                   (foo 1 ['a 'b])
-                  (foo 1 2 3 {:k 1 :v 2})"]
-        (h/let-mock-chans
-          [mock-diagnostics-chan db/diagnostics-chan]
-          (h/load-code-and-locs code)
-          (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
-            (is (= "file:///a.clj" uri))
-            (is (= ["user/foo is called with 3 args but expects 1 or 2"
-                    "user/baz is called with 1 arg but expects 3"
-                    "user/bar is called with 0 args but expects 1 or more"
-                    "user/foo is called with 3 args but expects 1 or 2"
-                    "user/foo is called with 0 args but expects 1 or 2"
-                    "user/foo is called with 4 args but expects 1 or 2"]
-                   (map :message diagnostics)))))))
+                  (foo 1 2 3 {:k 1 :v 2})"
+            mock-diagnostics-chan (async/chan 1)]
+        (h/load-code-and-locs code h/default-uri (assoc (h/components)
+                                                        :diagnostics-chan mock-diagnostics-chan))
+        (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
+          (is (= "file:///a.clj" uri))
+          (is (= ["user/foo is called with 3 args but expects 1 or 2"
+                  "user/baz is called with 1 arg but expects 3"
+                  "user/bar is called with 0 args but expects 1 or more"
+                  "user/foo is called with 3 args but expects 1 or 2"
+                  "user/foo is called with 0 args but expects 1 or 2"
+                  "user/foo is called with 4 args but expects 1 or 2"]
+                 (map :message diagnostics))))))
     (testing "for threading macros"
       (h/clean-db!)
       (let [code "(defn foo ([x] x) ([x y z] (z x y)))
@@ -324,19 +324,19 @@
                   (doto 1
                     (foo)
                     (foo 1)
-                    (bar))"]
-        (h/let-mock-chans
-          [mock-diagnostics-chan db/diagnostics-chan]
-          (h/load-code-and-locs code)
-          (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
-            (is (= "file:///a.clj" uri))
-            (is (= ["user/foo is called with 2 args but expects 1 or 3"
-                    "user/bar is called with 1 arg but expects 0"
-                    "user/bar is called with 1 arg but expects 0"
-                    "user/bar is called with 3 args but expects 0"
-                    "user/foo is called with 2 args but expects 1 or 3"
-                    "user/bar is called with 1 arg but expects 0"]
-                   (map :message diagnostics)))))))
+                    (bar))"
+            mock-diagnostics-chan (async/chan 1)]
+        (h/load-code-and-locs code h/default-uri (assoc (h/components)
+                                                        :diagnostics-chan mock-diagnostics-chan))
+        (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
+          (is (= "file:///a.clj" uri))
+          (is (= ["user/foo is called with 2 args but expects 1 or 3"
+                  "user/bar is called with 1 arg but expects 0"
+                  "user/bar is called with 1 arg but expects 0"
+                  "user/bar is called with 3 args but expects 0"
+                  "user/foo is called with 2 args but expects 1 or 3"
+                  "user/bar is called with 1 arg but expects 0"]
+                 (map :message diagnostics))))))
     (testing "with annotations"
       (h/clean-db!)
       (let [code "(defn foo {:added \"1.0\"} [x] (inc x))
@@ -344,14 +344,14 @@
                   (foo foo)
                   (foo foo foo)
                   (bar :a)
-                  (bar :a :b)"]
-        (h/let-mock-chans
-          [mock-diagnostics-chan db/diagnostics-chan]
-          (h/load-code-and-locs code)
-          (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
-            (is (= "file:///a.clj" uri))
-            (is (= ["user/foo is called with 2 args but expects 1"]
-                   (map :message diagnostics)))))))
+                  (bar :a :b)"
+            mock-diagnostics-chan (async/chan 1)]
+        (h/load-code-and-locs code h/default-uri (assoc (h/components)
+                                                        :diagnostics-chan mock-diagnostics-chan))
+        (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
+          (is (= "file:///a.clj" uri))
+          (is (= ["user/foo is called with 2 args but expects 1"]
+                 (map :message diagnostics))))))
     (testing "for schema defs"
       (h/clean-db!)
       (let [code "(ns user (:require [schema.core :as s]))
@@ -360,20 +360,20 @@
                     (str x y))
                   (foo)
                   (foo 1 2)
-                  (foo 1)"]
-        (h/let-mock-chans
-          [mock-diagnostics-chan db/diagnostics-chan]
-          (h/load-code-and-locs code)
-          (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
-            (is (= "file:///a.clj" uri))
-            (is (= ["user/foo is called with 0 args but expects 2"
-                    "user/foo is called with 1 arg but expects 2"]
-                   (map :message diagnostics))))))))
+                  (foo 1)"
+            mock-diagnostics-chan (async/chan 1)]
+        (h/load-code-and-locs code h/default-uri (assoc (h/components)
+                                                        :diagnostics-chan mock-diagnostics-chan))
+        (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
+          (is (= "file:///a.clj" uri))
+          (is (= ["user/foo is called with 0 args but expects 2"
+                  "user/foo is called with 1 arg but expects 2"]
+                 (map :message diagnostics)))))))
   (testing "custom unused namespace declaration"
     (h/clean-db!)
-    (h/let-mock-chans
-      [mock-diagnostics-chan db/diagnostics-chan]
-      (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///foo/bar.clj"))
+    (let [mock-diagnostics-chan (async/chan 1)]
+      (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///foo/bar.clj") (assoc (h/components)
+                                                                                     :diagnostics-chan mock-diagnostics-chan))
       (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
         (is (= "file:///foo/bar.clj" uri))
         (is (= [] diagnostics))))))

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -9,7 +9,7 @@
 
 (def findings (atom []))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest lint-project-public-vars
   (h/load-code-and-locs "(ns some-ns) (defn foo [a b] (+ a b))")
@@ -271,7 +271,7 @@
 (deftest test-find-diagnostics
   (testing "wrong arity"
     (testing "for argument destructuring"
-      (h/clean-db!)
+      (h/reset-components!)
       (let [code "(defn foo ([x] x) ([x y] (x y)))
                   (defn bar [y & rest] ((foo y y y) (bar rest)))
                   (defn baz [{x :x y :y :as long}
@@ -303,7 +303,7 @@
                   "user/foo is called with 4 args but expects 1 or 2"]
                  (map :message diagnostics))))))
     (testing "for threading macros"
-      (h/clean-db!)
+      (h/reset-components!)
       (let [code "(defn foo ([x] x) ([x y z] (z x y)))
                   (defn bar [] :bar)
                   (defn baz [arg & rest] (apply arg rest))
@@ -338,7 +338,7 @@
                   "user/bar is called with 1 arg but expects 0"]
                  (map :message diagnostics))))))
     (testing "with annotations"
-      (h/clean-db!)
+      (h/reset-components!)
       (let [code "(defn foo {:added \"1.0\"} [x] (inc x))
                   (defn ^:private bar ^String [^Class x & rest] (str x rest))
                   (foo foo)
@@ -353,7 +353,7 @@
           (is (= ["user/foo is called with 2 args but expects 1"]
                  (map :message diagnostics))))))
     (testing "for schema defs"
-      (h/clean-db!)
+      (h/reset-components!)
       (let [code "(ns user (:require [schema.core :as s]))
                   (s/defn foo :- s/Str
                     [x :- Long y :- Long]
@@ -370,7 +370,7 @@
                   "user/foo is called with 1 arg but expects 2"]
                  (map :message diagnostics)))))))
   (testing "custom unused namespace declaration"
-    (h/clean-db!)
+    (h/reset-components!)
     (let [mock-diagnostics-chan (async/chan 1)]
       (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///foo/bar.clj") (assoc (h/components)
                                                                                      :diagnostics-chan mock-diagnostics-chan))

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -7,7 +7,7 @@
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as medley]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest update-text
   (is (= "(comment\n   )" (#'f.file-management/replace-text "(comment)" "\n   " 0 8 0 8)))

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -112,12 +112,12 @@
 
 (deftest did-change-watched-files
   (testing "created file"
-    (h/let-mock-chans
-      [mock-created-chan db/created-watched-files-chan]
+    (let [mock-created-chan (async/chan 1)]
       (f.file-management/did-change-watched-files
         [{:type :created
           :uri h/default-uri}]
-        (h/components))
+        (assoc (h/components)
+               :created-watched-files-chan mock-created-chan))
       (is (= h/default-uri (h/take-or-timeout mock-created-chan 500)))))
   (testing "deleted file"
     (h/let-mock-chans

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -20,7 +20,7 @@
   (is (= "(+ 1 1)\n\n" (#'f.file-management/replace-text "(+ 1 1)\n" "\n" 1 0 1 0))))
 
 (deftest did-close
-  (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src/clj")}}
+  (swap! (h/db*) medley/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src/clj")}}
                                    :project-root-uri (h/file-uri "file:///user/project")})
   (h/load-code-and-locs "(ns foo) a b c" (h/file-uri "file:///user/project/src/clj/foo.clj"))
   (h/load-code-and-locs "(ns bar) d e f" (h/file-uri "file:///user/project/src/clj/bar.clj"))
@@ -29,23 +29,23 @@
     (h/let-mock-chans
       [mock-diagnostics-chan db/diagnostics-chan]
       (with-redefs [shared/file-exists? (constantly true)]
-        (f.file-management/did-close "file:///user/project/src/clj/foo.clj" db/db*))
-      (is (get-in @db/db* [:analysis "/user/project/src/clj/foo.clj"]))
-      (is (get-in @db/db* [:findings "/user/project/src/clj/foo.clj"]))
-      (is (get-in @db/db* [:file-meta "/user/project/src/clj/foo.clj"]))
-      (is (seq (get-in @db/db* [:dep-graph 'foo :uris])))
-      (is (get-in @db/db* [:documents "file:///user/project/src/clj/foo.clj"]))
+        (f.file-management/did-close "file:///user/project/src/clj/foo.clj" (h/db*)))
+      (is (get-in (h/db) [:analysis "/user/project/src/clj/foo.clj"]))
+      (is (get-in (h/db) [:findings "/user/project/src/clj/foo.clj"]))
+      (is (get-in (h/db) [:file-meta "/user/project/src/clj/foo.clj"]))
+      (is (seq (get-in (h/db) [:dep-graph 'foo :uris])))
+      (is (get-in (h/db) [:documents "file:///user/project/src/clj/foo.clj"]))
       (h/assert-no-take mock-diagnostics-chan 500)))
   (testing "when local file not exists on disk"
     (h/let-mock-chans
       [mock-diagnostics-chan db/diagnostics-chan]
       (with-redefs [shared/file-exists? (constantly false)]
-        (f.file-management/did-close "file:///user/project/src/clj/bar.clj" db/db*))
-      (is (nil? (get-in @db/db* [:analysis "/user/project/src/clj/bar.clj"])))
-      (is (nil? (get-in @db/db* [:findings "/user/project/src/clj/bar.clj"])))
-      (is (nil? (get-in @db/db* [:file-meta "/user/project/src/clj/bar.clj"])))
-      (is (not (seq (get-in @db/db* [:dep-graph 'bar :uris]))))
-      (is (nil? (get-in @db/db* [:documents "file:///user/project/src/clj/bar.clj"])))
+        (f.file-management/did-close "file:///user/project/src/clj/bar.clj" (h/db*)))
+      (is (nil? (get-in (h/db) [:analysis "/user/project/src/clj/bar.clj"])))
+      (is (nil? (get-in (h/db) [:findings "/user/project/src/clj/bar.clj"])))
+      (is (nil? (get-in (h/db) [:file-meta "/user/project/src/clj/bar.clj"])))
+      (is (not (seq (get-in (h/db) [:dep-graph 'bar :uris]))))
+      (is (nil? (get-in (h/db) [:documents "file:///user/project/src/clj/bar.clj"])))
       (is (= {:uri "file:///user/project/src/clj/bar.clj"
               :diagnostics []}
              (h/take-or-timeout mock-diagnostics-chan 500)))))
@@ -53,12 +53,12 @@
     (h/let-mock-chans
       [mock-diagnostics-chan db/diagnostics-chan]
       (with-redefs [shared/file-exists? (constantly false)]
-        (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" db/db*))
-      (is (get-in @db/db* [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
-      (is (get-in @db/db* [:findings "/some/path/to/jar.jar:/some/file.clj"]))
-      (is (get-in @db/db* [:file-meta "/some/path/to/jar.jar:/some/file.clj"]))
-      (is (seq (get-in @db/db* [:dep-graph 'some-jar :uris])))
-      (is (get-in @db/db* [:documents "file:///some/path/to/jar.jar:/some/file.clj"]))
+        (f.file-management/did-close "file:///some/path/to/jar.jar:/some/file.clj" (h/db*)))
+      (is (get-in (h/db) [:analysis "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (get-in (h/db) [:findings "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (get-in (h/db) [:file-meta "/some/path/to/jar.jar:/some/file.clj"]))
+      (is (seq (get-in (h/db) [:dep-graph 'some-jar :uris])))
+      (is (get-in (h/db) [:documents "file:///some/path/to/jar.jar:/some/file.clj"]))
       (h/assert-no-take mock-diagnostics-chan 500))))
 
 (deftest did-open
@@ -68,16 +68,16 @@
        mock-diagnostics-chan db/diagnostics-chan]
       (let [filename "/user/project/src/aaa/bbb.clj"
             uri (h/file-uri (str "file://" filename))]
-        (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+        (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                     :source-paths #{(h/file-path "/user/project/src")}}
                                          :project-root-uri (h/file-uri "file:///user/project")})
         (h/load-code-and-locs "" uri)
-        (is (get-in @db/db* [:analysis filename]))
-        (is (get-in @db/db* [:findings filename]))
-        (is (get-in @db/db* [:file-meta filename]))
+        (is (get-in (h/db) [:analysis filename]))
+        (is (get-in (h/db) [:findings filename]))
+        (is (get-in (h/db) [:file-meta filename]))
         ;; The ns won't be in the dep graph until after the edit adding it is applied.
-        (is (not (contains? (get @db/db* :dep-graph) 'aaa.bbb)))
-        (is (get-in @db/db* [:documents uri]))
+        (is (not (contains? (get (h/db) :dep-graph) 'aaa.bbb)))
+        (is (get-in (h/db) [:documents uri]))
         (testing "should publish empty diagnostics"
           (is (= {:uri uri, :diagnostics []}
                  (h/take-or-timeout mock-diagnostics-chan 500))))
@@ -103,9 +103,9 @@
                                       :range {:start {:line 1 :character 5}
                                               :end {:line 1 :character 8}}}]
                                     2
-                                    db/db*)
-      (is (= 2 (get-in @db/db* [:documents h/default-uri :v])))
-      (is (= edited-text (get-in @db/db* [:documents h/default-uri :text])))
+                                    (h/db*))
+      (is (= 2 (get-in (h/db) [:documents h/default-uri :v])))
+      (is (= edited-text (get-in (h/db) [:documents h/default-uri :text])))
       (is (= {:uri h/default-uri, :text edited-text, :version 2}
              (h/take-or-timeout mock-changes-chan 500))))))
 
@@ -116,7 +116,7 @@
       (f.file-management/did-change-watched-files
         [{:type :created
           :uri h/default-uri}]
-        db/db*)
+        (h/db*))
       (is (= h/default-uri (h/take-or-timeout mock-created-chan 500)))))
   (testing "deleted file"
     (h/let-mock-chans
@@ -124,12 +124,12 @@
       (f.file-management/did-change-watched-files
         [{:type :deleted
           :uri h/default-uri}]
-        db/db*)
+        (h/db*))
       (is (= {:uri h/default-uri, :diagnostics []}
              (h/take-or-timeout mock-diagnostics-chan 500))))))
 
 (deftest var-dependency-reference-filenames
-  (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
+  (swap! (h/db*) medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
                                    :project-root-uri (h/file-uri "file:///")})
   (h/load-code-and-locs (h/code "(ns a)"
                                 "(def a)"
@@ -138,11 +138,11 @@
                                 "(def x)"
                                 "a/a"
                                 "a/a") (h/file-uri "file:///src/b.clj"))
-  (let [db-before @db/db*]
+  (let [db-before (h/db)]
     (are [expected new-code]
          (do
            (h/load-code-and-locs new-code (h/file-uri "file:///src/b.clj"))
-           (let [db-after @db/db*]
+           (let [db-after (h/db)]
              (is (= expected
                     (f.file-management/reference-filenames "/src/b.clj" db-before db-after)))))
       ;; increasing
@@ -183,7 +183,7 @@
                   "x"))))
 
 (deftest kw-dependency-reference-filenames
-  (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
+  (swap! (h/db*) medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
                                    :project-root-uri (h/file-uri "file:///")})
   (h/load-code-and-locs (h/code "(ns aaa (:require [re-frame.core :as r]))"
                                 "(r/reg-event-db :aaa/command identity)"
@@ -194,11 +194,11 @@
                                 ":aaa/command"
                                 ":aaa/command")
                         (h/file-uri "file:///src/bbb.clj"))
-  (let [db-before @db/db*]
+  (let [db-before (h/db)]
     (are [expected new-code]
          (do
            (h/load-code-and-locs new-code (h/file-uri "file:///src/bbb.clj"))
-           (let [db-after @db/db*]
+           (let [db-after (h/db)]
              (is (= expected
                     (f.file-management/reference-filenames "/src/bbb.clj" db-before db-after)))))
       ;; increasing
@@ -239,7 +239,7 @@
                   ":bbb/command"))))
 
 (deftest var-dependent-reference-filenames
-  (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
+  (swap! (h/db*) medley/deep-merge {:settings {:source-paths #{(h/file-path "/src")}}
                                    :project-root-uri (h/file-uri "file:///")})
   (h/load-code-and-locs (h/code "(ns a)"
                                 "(def a)"
@@ -247,11 +247,11 @@
   (h/load-code-and-locs (h/code "(ns b (:require [a]))"
                                 "a/a"
                                 "a/c") (h/file-uri "file:///src/b.clj"))
-  (let [db-before @db/db*]
+  (let [db-before (h/db)]
     (are [expected new-code]
          (do
            (h/load-code-and-locs new-code (h/file-uri "file:///src/a.clj"))
-           (let [db-after @db/db*]
+           (let [db-after (h/db)]
              (is (= expected
                     (f.file-management/reference-filenames "/src/a.clj" db-before db-after)))))
       ;; remove existing
@@ -273,14 +273,14 @@
 
 (deftest will-rename-files
   (testing "when namespace matches old file"
-    (swap! db/db* shared/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src")}}
+    (swap! (h/db*) shared/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src")}}
                                      :project-root-uri (h/file-uri "file:///user/project")
                                      :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
 
     (let [old-uri (h/file-uri "file:///user/project/src/my/ns.clj")
           new-uri (h/file-uri "file:///user/project/src/my/new/ns.clj")]
       (h/load-code (h/code "(ns my.ns)") old-uri)
-      (let [db @db/db*]
+      (let [db (h/db)]
         (is (= {:document-changes
                 [{:text-document
                   {:version 0, :uri "file:///user/project/src/my/ns.clj"},
@@ -294,14 +294,14 @@
                  db))))))
   (testing "when namespace matches new file"
     ;; This happens when namespace was already changed by textDocument/rename
-    (swap! db/db* shared/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src")}}
+    (swap! (h/db*) shared/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src")}}
                                      :project-root-uri (h/file-uri "file:///user/project")
                                      :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
 
     (let [old-uri (h/file-uri "file:///user/project/src/my/ns.clj")
           new-uri (h/file-uri "file:///user/project/src/my/new/ns.clj")]
       (h/load-code (h/code "(ns my.new.ns)") old-uri)
-      (let [db @db/db*]
+      (let [db (h/db)]
         (is (= {:document-changes []}
                (f.file-management/will-rename-files
                  [{:old-uri old-uri

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -65,14 +65,15 @@
 (deftest did-open
   (testing "on an empty file"
     (h/let-mock-chans
-      [mock-edits-chan db/edits-chan
-       mock-diagnostics-chan db/diagnostics-chan]
-      (let [filename "/user/project/src/aaa/bbb.clj"
+      [mock-diagnostics-chan db/diagnostics-chan]
+      (let [mock-edits-chan (async/chan 1)
+            filename "/user/project/src/aaa/bbb.clj"
             uri (h/file-uri (str "file://" filename))]
         (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                     :source-paths #{(h/file-path "/user/project/src")}}
                                          :project-root-uri (h/file-uri "file:///user/project")})
-        (h/load-code-and-locs "" uri)
+        (h/load-code-and-locs "" uri (assoc (h/components)
+                                            :edits-chan mock-edits-chan))
         (is (get-in (h/db) [:analysis filename]))
         (is (get-in (h/db) [:findings filename]))
         (is (get-in (h/db) [:file-meta filename]))

--- a/lib/test/clojure_lsp/features/format_test.clj
+++ b/lib/test/clojure_lsp/features/format_test.clj
@@ -13,18 +13,18 @@
   (testing "when custom config file doesn't exists"
     (with-redefs [shared/file-exists? (constantly false)]
       (is (= "(a)\n(b c d)"
-             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") (h/db*))))))))
+             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") (h/components))))))))
   (testing "when custom config file exists"
     (with-redefs [shared/file-exists? (constantly true)
                   slurp (constantly "{}")]
       (is (= "(a)\n(b c d)"
-             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") (h/db*)))))))))
+             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") (h/components)))))))))
 
 (deftest test-formatting-noop
   (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
   (h/load-code-and-locs "(a)\n(b c d)")
   (with-redefs [shared/file-exists? (constantly false)]
-    (let [r (f.format/formatting (h/file-uri "file:///a.clj") (h/db*))]
+    (let [r (f.format/formatting (h/file-uri "file:///a.clj") (h/components))]
       (is (empty? r))
       (is (vector? r)))))
 

--- a/lib/test/clojure_lsp/features/format_test.clj
+++ b/lib/test/clojure_lsp/features/format_test.clj
@@ -5,7 +5,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest test-formatting
   (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})

--- a/lib/test/clojure_lsp/features/format_test.clj
+++ b/lib/test/clojure_lsp/features/format_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.format-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.format :as f.format]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
@@ -9,23 +8,23 @@
 (h/reset-db-after-test)
 
 (deftest test-formatting
-  (swap! db/db* shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
+  (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
   (h/load-code-and-locs "(a  )\n(b c d)")
   (testing "when custom config file doesn't exists"
     (with-redefs [shared/file-exists? (constantly false)]
       (is (= "(a)\n(b c d)"
-             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") db/db*)))))))
+             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") (h/db*))))))))
   (testing "when custom config file exists"
     (with-redefs [shared/file-exists? (constantly true)
                   slurp (constantly "{}")]
       (is (= "(a)\n(b c d)"
-             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") db/db*))))))))
+             (:new-text (first (f.format/formatting (h/file-uri "file:///a.clj") (h/db*)))))))))
 
 (deftest test-formatting-noop
-  (swap! db/db* shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
+  (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
   (h/load-code-and-locs "(a)\n(b c d)")
   (with-redefs [shared/file-exists? (constantly false)]
-    (let [r (f.format/formatting (h/file-uri "file:///a.clj") db/db*)]
+    (let [r (f.format/formatting (h/file-uri "file:///a.clj") (h/db*))]
       (is (empty? r))
       (is (vector? r)))))
 
@@ -33,10 +32,10 @@
   (let [[[row col] [end-row end-col] :as positions] (h/load-code-and-locs code)]
     (let [position-count (count positions)]
        (assert (= 2 position-count) (format "Expected two cursors, got %s" position-count)))
-    (f.format/range-formatting (h/file-uri "file:///a.clj") {:row row :col col :end-row end-row :end-col end-col} @db/db*)))
+    (f.format/range-formatting (h/file-uri "file:///a.clj") {:row row :col col :end-row end-row :end-col end-col} (h/db))))
 
 (deftest test-range-formatting
-  (swap! db/db* shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
+  (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///project")})
   (testing "when custom config file doesn't exists"
     (with-redefs [shared/file-exists? (constantly false)]
       (is (= [{:range {:start {:line 0 :character 0}

--- a/lib/test/clojure_lsp/features/hover_test.clj
+++ b/lib/test/clojure_lsp/features/hover_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.hover-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.hover :as f.hover]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
@@ -16,7 +15,7 @@
   ([row col]
    (hover row col {}))
   ([row col opts]
-   (f.hover/hover (h/file-uri "file:///a.clj") row col db/db* opts)))
+   (f.hover/hover (h/file-uri "file:///a.clj") row col (h/db*) opts)))
 
 (def ^:private capabilities-markdown {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
 (def ^:private settings-one-line {:settings {:hover {:arity-on-same-line? true}}})
@@ -26,12 +25,12 @@
 (def ^:private settings-edits-warning {:settings {:completion {:additional-edits-warning-text "* includes additional edits"}}})
 
 (defmacro with-db [temp-config & body]
-  `(let [db-before# @db/db*]
+  `(let [db-before# (h/db)]
      (try
-       (swap! db/db* shared/deep-merge ~temp-config)
+       (swap! (h/db*) shared/deep-merge ~temp-config)
        ~@body
        (finally
-         (reset! db/db* db-before#)))))
+         (reset! (h/db*) db-before#)))))
 
 (deftest test-hover
   (with-db
@@ -283,4 +282,4 @@
                    :value "some-a"}
                   "Some cool docstring"
                   "/some_a.clj"]
-                 (:contents (f.hover/hover (h/file-uri "file:///some_b.clj") row col db/db*)))))))))
+                 (:contents (f.hover/hover (h/file-uri "file:///some_b.clj") row col (h/db*))))))))))

--- a/lib/test/clojure_lsp/features/hover_test.clj
+++ b/lib/test/clojure_lsp/features/hover_test.clj
@@ -15,7 +15,7 @@
   ([row col]
    (hover row col {}))
   ([row col opts]
-   (f.hover/hover (h/file-uri "file:///a.clj") row col (h/db*) opts)))
+   (f.hover/hover (h/file-uri "file:///a.clj") row col (h/components) opts)))
 
 (def ^:private capabilities-markdown {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}})
 (def ^:private settings-one-line {:settings {:hover {:arity-on-same-line? true}}})
@@ -282,4 +282,4 @@
                    :value "some-a"}
                   "Some cool docstring"
                   "/some_a.clj"]
-                 (:contents (f.hover/hover (h/file-uri "file:///some_b.clj") row col (h/db*))))))))))
+                 (:contents (f.hover/hover (h/file-uri "file:///some_b.clj") row col (h/components))))))))))

--- a/lib/test/clojure_lsp/features/hover_test.clj
+++ b/lib/test/clojure_lsp/features/hover_test.clj
@@ -6,7 +6,7 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn ^:private join [coll]
   (string/join "\n" coll))

--- a/lib/test/clojure_lsp/features/linked_editing_range_test.clj
+++ b/lib/test/clojure_lsp/features/linked_editing_range_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest ranges
   (h/load-code-and-locs

--- a/lib/test/clojure_lsp/features/linked_editing_range_test.clj
+++ b/lib/test/clojure_lsp/features/linked_editing_range_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.linked-editing-range-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.linked-editing-range :as f.linked-editing-range]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest testing]]))
@@ -26,9 +25,9 @@
       {:ranges [{:start {:line 2, :character 6}, :end {:line 2, :character 9}}
                 {:start {:line 4, :character 1}, :end {:line 4, :character 4}}
                 {:start {:line 6, :character 0}, :end {:line 6, :character 3}}]}
-      (f.linked-editing-range/ranges (h/file-uri "file:///a.clj") 5 2 @db/db*)))
+      (f.linked-editing-range/ranges (h/file-uri "file:///a.clj") 5 2 (h/db))))
   (testing "when some reference is on another file"
     (h/assert-submap
       {:error {:code :invalid-params
                :message "There are references on other files for this symbol"}}
-      (f.linked-editing-range/ranges (h/file-uri "file:///a.clj") 6 2 @db/db*))))
+      (f.linked-editing-range/ranges (h/file-uri "file:///a.clj") 6 2 (h/db)))))

--- a/lib/test/clojure_lsp/features/rename_test.clj
+++ b/lib/test/clojure_lsp/features/rename_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.rename-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.rename :as f.rename]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
@@ -16,14 +15,14 @@
                                                    (h/file-uri "file:///a.cljc"))]
     (testing "should not rename plain keywords"
       (let [[row col] a-start
-            result (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col @db/db*)]
+            result (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col (h/db))]
         (is (= {:error {:code :invalid-params
                         :message "Can't rename, only namespaced keywords can be renamed."}}
                result))))
 
     (testing "should rename local in destructure but not keywords"
       (let [[row col] a-binding-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":b" row col (h/db)))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text "b" :range (h/->range a-binding-start a-binding-stop)}
                  {:new-text "b" :range (h/->range a-local-usage-start a-local-usage-stop)}]}
@@ -38,7 +37,7 @@
                            (h/file-uri "file:///b.cljc"))]
     (testing "renaming only the name"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":hello/bar" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":hello/bar" row col (h/db)))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":hello/bar" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -46,7 +45,7 @@
                changes))))
     (testing "renaming only the namespace"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/foo" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/foo" row col (h/db)))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":bye/foo" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -54,7 +53,7 @@
                changes))))
     (testing "renaming namespace and name"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/bar" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":bye/bar" row col (h/db)))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":bye/bar" :range (h/->range a-start a-stop)}]
                 (h/file-uri "file:///b.cljc")
@@ -76,21 +75,21 @@
                                            (h/file-uri "file:///c.cljc"))]
     (testing "should rename local in destructure with ':' and keywords if namespaced"
       (let [[row col] a-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/c" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/c" row col (h/db)))]
         (is (= {(h/file-uri "file:///a.cljc")
                 [{:new-text ":a/c" :range (h/->range a-start a-stop)}
                  {:new-text ":a/c" :range (h/->range a-binding-start a-binding-stop)}]}
                changes))))
     (testing "should rename local in destructure without ':' and keywords if namespaced"
       (let [[row col] b-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":c/e" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":c/e" row col (h/db)))]
         (is (= {(h/file-uri "file:///b.cljc")
                 [{:new-text ":c/e" :range (h/->range b-start b-stop)}
                  {:new-text "c/e" :range (h/->range b-binding-start b-binding-stop)}]}
                changes))))
     (testing "should rename local in destructure with namespace on :keys"
       (let [[row col] c-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///c.cljc") ":e/f" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///c.cljc") ":e/f" row col (h/db)))]
         (is (= {(h/file-uri "file:///c.cljc")
                 [{:new-text ":e/f" :range (h/->range c-start c-stop)}
                  {:new-text "f" :range (h/->range c-binding-start c-binding-stop)}]}
@@ -118,13 +117,13 @@
           (h/file-uri "file:///b.cljc"))]
     (testing "renaming keywords renames correctly namespaced maps as well"
       (let [[row col] a-b-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/g" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///a.cljc") ":a/g" row col (h/db)))]
         (is (= {(h/file-uri "file:///a.cljc") [{:new-text ":a/g" :range (h/->range a-b-start a-b-stop)}
                                                {:new-text ":g" :range (h/->range b-ns-start b-ns-stop)}]}
                changes))))
     (testing "renaming from aliased namespace to namespace"
       (let [[row col] h1-start
-            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":hello/world" row col @db/db*))]
+            changes (:changes (f.rename/rename-from-position (h/file-uri "file:///b.cljc") ":hello/world" row col (h/db)))]
         (is (= {(h/file-uri "file:///b.cljc") [{:new-text ":hello/world" :range (h/->range h1-start h1-stop)}
                                                {:new-text ":hello/world" :range (h/->range h2-start h2-stop)}]}
                changes))))
@@ -137,7 +136,7 @@
 (deftest rename-namespaces
   (testing "when client has valid source-paths but no document-changes capability"
     (h/clean-db!)
-    (swap! db/db* shared/deep-merge
+    (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///my-project")
             :settings {:source-paths #{(h/file-path "/my-project/src") (h/file-path "/my-project/test")}}
             :client-capabilities {:workspace {:workspace-edit {:document-changes false}}}})
@@ -145,10 +144,10 @@
     (h/assert-submap
       {:error {:code :invalid-params
                :message "Can't rename namespace, client does not support file renames."}}
-      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))
+      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 (h/db))))
   (testing "when client has document-changes capability but no valid source-paths"
     (h/clean-db!)
-    (swap! db/db* shared/deep-merge
+    (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///my-project")
             :settings {:source-paths #{(h/file-path "/my-project/bla")}}
             :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
@@ -156,10 +155,10 @@
     (h/assert-submap
       {:error {:code :invalid-params
                :message "Can't rename namespace, invalid source-paths. Are project :source-paths configured correctly?"}}
-      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))
+      (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 (h/db))))
   (testing "when source-paths are valid and client capabilities has document-changes"
     (h/clean-db!)
-    (swap! db/db* shared/deep-merge
+    (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///my-project")
             :settings {:source-paths #{(h/file-path "/my-project/src") (h/file-path "/my-project/test")}}
             :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
@@ -174,7 +173,7 @@
              {:kind "rename"
               :old-uri (h/file-uri "file:///my-project/src/foo/bar_baz.clj")
               :new-uri (h/file-uri "file:///my-project/src/foo/baz_qux.clj")}]}
-           (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 @db/db*)))))
+           (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 (h/db))))))
 
 (deftest rename-defrecord
   (h/clean-db!)
@@ -188,7 +187,7 @@
                                                                      "(|map->Foo| {:a 1})"
                                                                      "|Foo|"))
         [start-row start-col] def-start-pos
-        result (:changes (f.rename/rename-from-position h/default-uri "Bar" start-row start-col @db/db*))]
+        result (:changes (f.rename/rename-from-position h/default-uri "Bar" start-row start-col (h/db)))]
     (is (= {h/default-uri [{:new-text "Bar" :range (h/->range def-start-pos def-end-pos)}
                            {:new-text "Bar" :range (h/->range use1-start-pos use1-end-pos)}
                            {:new-text "->Bar" :range (h/->range use2-start-pos use2-end-pos)}
@@ -200,26 +199,26 @@
   (testing "rename local var"
     (h/clean-db!)
     (let [[[row col]] (h/load-code-and-locs "(let [|a 1] a)")
-          result (f.rename/prepare-rename h/default-uri row col @db/db*)]
+          result (f.rename/prepare-rename h/default-uri row col (h/db))]
       (is (= {:start {:line 0, :character 6}, :end {:line 0, :character 7}}
              result))))
   (testing "should not rename when on unnamed element"
     (h/clean-db!)
     (let [[[row col]] (h/load-code-and-locs "|[]")
-          result (f.rename/prepare-rename h/default-uri row col @db/db*)]
+          result (f.rename/prepare-rename h/default-uri row col (h/db))]
       (is (= {:error {:code :invalid-params
                       :message "Can't rename, no element found."}}
              result))))
   (testing "should not rename plain keywords"
     (h/clean-db!)
     (let [[[row col]] (h/load-code-and-locs "|:a")
-          result (f.rename/prepare-rename h/default-uri row col @db/db*)]
+          result (f.rename/prepare-rename h/default-uri row col (h/db))]
       (is (= {:error {:code :invalid-params
                       :message "Can't rename, only namespaced keywords can be renamed."}}
              result))))
   (testing "when client has valid source-paths but no document-changes capability"
     (h/clean-db!)
-    (swap! db/db* shared/deep-merge
+    (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///")
             :settings {:source-paths #{(h/file-path "/")}}
             :client-capabilities {:workspace {:workspace-edit {:document-changes false}}}})
@@ -227,10 +226,10 @@
       (h/assert-submap
         {:error {:code :invalid-params
                  :message "Can't rename namespace, client does not support file renames."}}
-        (f.rename/prepare-rename h/default-uri row col @db/db*))))
+        (f.rename/prepare-rename h/default-uri row col (h/db)))))
   (testing "when client has document-changes capability but no valid source-paths"
     (h/clean-db!)
-    (swap! db/db* shared/deep-merge
+    (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///")
             :settings {:source-paths #{(h/file-path "/bla")}}
             :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}})
@@ -238,4 +237,4 @@
       (h/assert-submap
         {:error {:code :invalid-params
                  :message "Can't rename namespace, invalid source-paths. Are project :source-paths configured correctly?"}}
-        (f.rename/prepare-rename h/default-uri row col @db/db*)))))
+        (f.rename/prepare-rename h/default-uri row col (h/db))))))

--- a/lib/test/clojure_lsp/features/rename_test.clj
+++ b/lib/test/clojure_lsp/features/rename_test.clj
@@ -5,7 +5,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest rename-simple-keywords
   (let [[a-start _a-stop
@@ -135,7 +135,7 @@
 
 (deftest rename-namespaces
   (testing "when client has valid source-paths but no document-changes capability"
-    (h/clean-db!)
+    (h/reset-components!)
     (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///my-project")
             :settings {:source-paths #{(h/file-path "/my-project/src") (h/file-path "/my-project/test")}}
@@ -146,7 +146,7 @@
                :message "Can't rename namespace, client does not support file renames."}}
       (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 (h/db))))
   (testing "when client has document-changes capability but no valid source-paths"
-    (h/clean-db!)
+    (h/reset-components!)
     (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///my-project")
             :settings {:source-paths #{(h/file-path "/my-project/bla")}}
@@ -157,7 +157,7 @@
                :message "Can't rename namespace, invalid source-paths. Are project :source-paths configured correctly?"}}
       (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 (h/db))))
   (testing "when source-paths are valid and client capabilities has document-changes"
-    (h/clean-db!)
+    (h/reset-components!)
     (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///my-project")
             :settings {:source-paths #{(h/file-path "/my-project/src") (h/file-path "/my-project/test")}}
@@ -176,7 +176,7 @@
            (f.rename/rename-from-position (h/file-uri "file:///my-project/src/foo/bar_baz.clj") "foo.baz-qux" 1 5 (h/db))))))
 
 (deftest rename-defrecord
-  (h/clean-db!)
+  (h/reset-components!)
   (let [[def-start-pos def-end-pos
          use1-start-pos use1-end-pos
          use2-start-pos use2-end-pos
@@ -197,27 +197,27 @@
 
 (deftest prepare-rename
   (testing "rename local var"
-    (h/clean-db!)
+    (h/reset-components!)
     (let [[[row col]] (h/load-code-and-locs "(let [|a 1] a)")
           result (f.rename/prepare-rename h/default-uri row col (h/db))]
       (is (= {:start {:line 0, :character 6}, :end {:line 0, :character 7}}
              result))))
   (testing "should not rename when on unnamed element"
-    (h/clean-db!)
+    (h/reset-components!)
     (let [[[row col]] (h/load-code-and-locs "|[]")
           result (f.rename/prepare-rename h/default-uri row col (h/db))]
       (is (= {:error {:code :invalid-params
                       :message "Can't rename, no element found."}}
              result))))
   (testing "should not rename plain keywords"
-    (h/clean-db!)
+    (h/reset-components!)
     (let [[[row col]] (h/load-code-and-locs "|:a")
           result (f.rename/prepare-rename h/default-uri row col (h/db))]
       (is (= {:error {:code :invalid-params
                       :message "Can't rename, only namespaced keywords can be renamed."}}
              result))))
   (testing "when client has valid source-paths but no document-changes capability"
-    (h/clean-db!)
+    (h/reset-components!)
     (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///")
             :settings {:source-paths #{(h/file-path "/")}}
@@ -228,7 +228,7 @@
                  :message "Can't rename namespace, client does not support file renames."}}
         (f.rename/prepare-rename h/default-uri row col (h/db)))))
   (testing "when client has document-changes capability but no valid source-paths"
-    (h/clean-db!)
+    (h/reset-components!)
     (swap! (h/db*) shared/deep-merge
            {:project-root-uri (h/file-uri "file:///")
             :settings {:source-paths #{(h/file-path "/bla")}}

--- a/lib/test/clojure_lsp/features/resolve_macro_test.clj
+++ b/lib/test/clojure_lsp/features/resolve_macro_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.resolve-macro-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
@@ -20,9 +19,9 @@
     (h/load-code-and-locs b-code (h/file-uri "file:///b.clj"))
     (testing "inside a macro usage"
       (is (= 'some-ns/foo
-             (f.resolve-macro/find-full-macro-symbol-to-resolve (h/zloc-from-code a-code) (h/file-uri "file:///a.clj") @db/db*))))
+             (f.resolve-macro/find-full-macro-symbol-to-resolve (h/zloc-from-code a-code) (h/file-uri "file:///a.clj") (h/db)))))
     (testing "not inside a macro usage"
-      (is (not (f.resolve-macro/find-full-macro-symbol-to-resolve (h/zloc-from-code b-code) (h/file-uri "file:///a.clj") @db/db*))))))
+      (is (not (f.resolve-macro/find-full-macro-symbol-to-resolve (h/zloc-from-code b-code) (h/file-uri "file:///a.clj") (h/db)))))))
 
 (deftest resolve-macro-as
   (let [code (h/code "(ns some-ns)"
@@ -32,4 +31,4 @@
     (h/load-code-and-locs code)
     (testing "resolving macro as def"
       (is (= "{:lint-as {some-ns/foo clojure.core/def}}\n"
-             (#'f.resolve-macro/resolve-macro-as (h/zloc-from-code code) (h/file-uri "file:///a.clj") "clojure.core/def" ".any-clj-kondo/config.edn" @db/db*))))))
+             (#'f.resolve-macro/resolve-macro-as (h/zloc-from-code code) (h/file-uri "file:///a.clj") "clojure.core/def" ".any-clj-kondo/config.edn" (h/db)))))))

--- a/lib/test/clojure_lsp/features/resolve_macro_test.clj
+++ b/lib/test/clojure_lsp/features/resolve_macro_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest find-full-macro-symbol-to-resolve
   (let [a-code (h/code "(ns some-ns)"

--- a/lib/test/clojure_lsp/features/semantic_tokens_test.clj
+++ b/lib/test/clojure_lsp/features/semantic_tokens_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.semantic-tokens-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
    [clojure-lsp.test-helper :as h]
    [clojure.string :as string]
@@ -80,7 +79,7 @@
             0 1 3 2 0
             2 0 3 2 0
             1 1 7 3 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "macro refered tokens"
     (h/load-code-and-locs
       (code "(ns some.ns (:require [clojure.test :refer [deftest]]))"
@@ -91,24 +90,24 @@
             0 8 7 3 0
             1 1 7 3 0
             0 8 9 2 1]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "macro core tokens"
     (h/load-code-and-locs (code "(comment 1)"))
     (is (= [0 1 7 3 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "function definition tokens"
     (h/load-code-and-locs (code "(def foo 1)"
                                 "foo"))
     (is (= [0 1 3 3 0
             0 4 3 2 1
             1 0 3 2 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "variable with defaultLibrary modifier tokens"
     (h/load-code-and-locs (code "(def *anything*) *anything*"))
     (is (= [0 1 3 3 0
             0 4 10 2 1
             0 12 10 6 2]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "type alias for function tokens"
     (h/load-code-and-locs (code "(ns some.ns (:require [foo.bar :as fb]))"
                                 "fb/some-foo-bar"))
@@ -118,7 +117,7 @@
             1 0 2 1 0
             0 2 1 8 0
             0 1 12 2 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "type alias for macro tokens"
     (h/load-code-and-locs (code "(ns some.ns (:require [clojure.test :as test]))"
                                 "test/deftest"))
@@ -128,7 +127,7 @@
             1 0 4 1 0
             0 4 1 8 0
             0 1 7 3 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   #_(testing "java classes for function tokens"
       (h/load-code-and-locs (code "(ns some.ns)"
                                   "^java.lang.String \"\""
@@ -149,7 +148,7 @@
                                 "(.equals \"some-string\" \"other-string\")"))
     (is (= [0 4 7 0 0
             1 1 7 7 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "keywords for keyword tokens"
     (h/load-code-and-locs (code "(ns some.ns (:require [foo :as foo]))"
                                 ":foo"
@@ -172,7 +171,7 @@
             1 0 5 1 0
             0 5 1 8 0
             0 1 9 4 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "locals destructuring for variable tokens"
     (h/load-code-and-locs (code "(fn [{:keys [foo bar]}])"))
     (is (= [0 1 2 3 0
@@ -180,7 +179,7 @@
             0 0 5 4 0
             0 7 3 6 0
             0 4 3 6 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db)))))
   (testing "defrecord/deftype"
     (h/load-code-and-locs (code "(defrecord Something []"
                                 "  Otherthing"
@@ -191,7 +190,7 @@
             0 0 9 2 1
             2 1 11 7 4
             0 13 4 6 0]
-           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") @db/db*)))))
+           (semantic-tokens/full-tokens (h/file-uri "file:///a.clj") (h/db))))))
 
 (deftest range-tokens
   (testing "tokens only for range"
@@ -203,4 +202,4 @@
             "baz"))
     (is (= [2 0 3 2 0
             1 1 7 3 0]
-           (semantic-tokens/range-tokens (h/file-uri "file:///a.clj") {:name-row 3 :name-col 0 :name-end-row 4 :name-end-col 0} @db/db*)))))
+           (semantic-tokens/range-tokens (h/file-uri "file:///a.clj") {:name-row 3 :name-col 0 :name-end-row 4 :name-end-col 0} (h/db))))))

--- a/lib/test/clojure_lsp/features/semantic_tokens_test.clj
+++ b/lib/test/clojure_lsp/features/semantic_tokens_test.clj
@@ -5,7 +5,7 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (defn ^:private ->token
   [usage token-type]

--- a/lib/test/clojure_lsp/features/signature_help_test.clj
+++ b/lib/test/clojure_lsp/features/signature_help_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.signature-help-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.signature-help :as f.signature-help]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
@@ -10,13 +9,13 @@
 (deftest signature-help-unavailable
   (testing "insider defn"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b]| (bar 1 2))")]
-      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col db/db*)))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/db*))))))
   (testing "inside let binding"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b] (let [a 1]| (bar 1 2)))")]
-      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col db/db*)))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/db*))))))
   (testing "inside unknown function"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b] (let [a 1] (bar |1 2)))")]
-      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col db/db*))))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/db*)))))))
 
 (deftest signature-help-cursor-position
   (let [[[before-r before-c]
@@ -32,31 +31,31 @@
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") before-r before-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") before-r before-c (h/db*)))))
     (testing "after function name"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c (h/db*)))))
     (testing "on first arg"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c (h/db*)))))
     (testing "on second arg"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c (h/db*)))))
     (testing "outside function"
       (is (= nil
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") outside-r outside-c db/db*))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") outside-r outside-c (h/db*)))))))
 
 (deftest signature-help-multiple-definitions
   (let [[[after-r after-c]] (h/load-code-and-locs
@@ -69,7 +68,7 @@
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c db/db*))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c (h/db*)))))))
 
 (deftest signature-help-multiple-signatures
   (testing "With fixed arities"
@@ -94,7 +93,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/db*)))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -105,7 +104,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/db*)))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -116,7 +115,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/db*)))))
       (testing "three arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -127,7 +126,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c (h/db*)))))
       (testing "four arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -138,7 +137,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c db/db*))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c (h/db*)))))))
   (testing "With & rest arity only"
     (let [[[zero-r zero-c]
            [one-r one-c]
@@ -152,19 +151,19 @@
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/db*)))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [& rest])"
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/db*)))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [& rest])"
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c db/db*))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/db*)))))))
   (testing "With fixed arities and & rest arity"
     (let [[[zero-r zero-c]
            [one-r one-c]
@@ -185,7 +184,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/db*)))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -194,7 +193,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/db*)))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -203,7 +202,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/db*)))))
       (testing "three arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -212,7 +211,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c db/db*))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c (h/db*)))))
       (testing "four arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -221,7 +220,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c db/db*)))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c (h/db*))))))))
 
 (deftest signature-help-active-parameter
   (let [[[first-arg-r first-arg-c]
@@ -236,25 +235,25 @@
                                          {:label "& more"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c (h/db*)))))
     (testing "on second arg"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c (h/db*)))))
     (testing "on third arg"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") third-arg-r third-arg-c db/db*))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") third-arg-r third-arg-c (h/db*)))))
     (testing "on end of the function"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") end-function-r end-function-c db/db*))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") end-function-r end-function-c (h/db*)))))))

--- a/lib/test/clojure_lsp/features/signature_help_test.clj
+++ b/lib/test/clojure_lsp/features/signature_help_test.clj
@@ -9,13 +9,13 @@
 (deftest signature-help-unavailable
   (testing "insider defn"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b]| (bar 1 2))")]
-      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/db*))))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/components))))))
   (testing "inside let binding"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b] (let [a 1]| (bar 1 2)))")]
-      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/db*))))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/components))))))
   (testing "inside unknown function"
     (let [[[row col]] (h/load-code-and-locs "(defn foo [a b] (let [a 1] (bar |1 2)))")]
-      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/db*)))))))
+      (is (= nil (f.signature-help/signature-help (h/file-uri "file:///a.clj") row col (h/components)))))))
 
 (deftest signature-help-cursor-position
   (let [[[before-r before-c]
@@ -31,31 +31,31 @@
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") before-r before-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") before-r before-c (h/components)))))
     (testing "after function name"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c (h/components)))))
     (testing "on first arg"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c (h/components)))))
     (testing "on second arg"
       (is (= {:signatures [{:label "(bar [a b])"
                             :parameters [{:label "a"}
                                          {:label "b"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c (h/components)))))
     (testing "outside function"
       (is (= nil
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") outside-r outside-c (h/db*)))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") outside-r outside-c (h/components)))))))
 
 (deftest signature-help-multiple-definitions
   (let [[[after-r after-c]] (h/load-code-and-locs
@@ -68,7 +68,7 @@
                                          {:label "b"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c (h/db*)))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") after-r after-c (h/components)))))))
 
 (deftest signature-help-multiple-signatures
   (testing "With fixed arities"
@@ -93,7 +93,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/components)))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -104,7 +104,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/components)))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -115,7 +115,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/components)))))
       (testing "three arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -126,7 +126,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c (h/components)))))
       (testing "four arity"
         (is (= {:signatures [{:label "(bar [a b])"
                               :parameters [{:label "a"}
@@ -137,7 +137,7 @@
                                            {:label "c"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c (h/db*)))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c (h/components)))))))
   (testing "With & rest arity only"
     (let [[[zero-r zero-c]
            [one-r one-c]
@@ -151,19 +151,19 @@
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/components)))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [& rest])"
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/components)))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [& rest])"
                               :parameters [{:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/db*)))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/components)))))))
   (testing "With fixed arities and & rest arity"
     (let [[[zero-r zero-c]
            [one-r one-c]
@@ -184,7 +184,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") zero-r zero-c (h/components)))))
       (testing "one arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -193,7 +193,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 0}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") one-r one-c (h/components)))))
       (testing "two arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -202,7 +202,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") two-r two-c (h/components)))))
       (testing "three arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -211,7 +211,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c (h/db*)))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") three-r three-c (h/components)))))
       (testing "four arity"
         (is (= {:signatures [{:label "(bar [a])"
                               :parameters [{:label "a"}]}
@@ -220,7 +220,7 @@
                                            {:label "& rest"}]}]
                 :active-parameter 0
                 :active-signature 1}
-               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c (h/db*))))))))
+               (f.signature-help/signature-help (h/file-uri "file:///a.clj") four-r four-c (h/components))))))))
 
 (deftest signature-help-active-parameter
   (let [[[first-arg-r first-arg-c]
@@ -235,25 +235,25 @@
                                          {:label "& more"}]}]
               :active-parameter 0
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") first-arg-r first-arg-c (h/components)))))
     (testing "on second arg"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") second-arg-r second-arg-c (h/components)))))
     (testing "on third arg"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") third-arg-r third-arg-c (h/db*)))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") third-arg-r third-arg-c (h/components)))))
     (testing "on end of the function"
       (is (= {:signatures [{:label "(bar [a & more])"
                             :parameters [{:label "a"}
                                          {:label "& more"}]}]
               :active-parameter 1
               :active-signature 0}
-             (f.signature-help/signature-help (h/file-uri "file:///a.clj") end-function-r end-function-c (h/db*)))))))
+             (f.signature-help/signature-help (h/file-uri "file:///a.clj") end-function-r end-function-c (h/components)))))))

--- a/lib/test/clojure_lsp/features/signature_help_test.clj
+++ b/lib/test/clojure_lsp/features/signature_help_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest signature-help-unavailable
   (testing "insider defn"

--- a/lib/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/lib/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -4,7 +4,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest workspace-symbols
   (h/load-code-and-locs (h/code "(ns foo.alpaca.ns (:require [clojure.string :as string]))"

--- a/lib/test/clojure_lsp/features/workspace_symbols_test.clj
+++ b/lib/test/clojure_lsp/features/workspace_symbols_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.features.workspace-symbols-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.feature.workspace-symbols :as f.workspace-symbols]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
@@ -57,7 +56,7 @@
              :kind :variable,
              :location {:range {:start {:line 2, :character 11}, :end {:line 2, :character 18}},
                         :uri (h/file-uri "file:///b.clj")}}]
-           (f.workspace-symbols/workspace-symbols "" @db/db*))))
+           (f.workspace-symbols/workspace-symbols "" (h/db)))))
   (testing "querying a specific function using fuzzy search"
     (is (= [;; a.clj
             {:name "foo.alpaca.ns"
@@ -81,4 +80,4 @@
              :location {:range {:start {:line 1, :character 0}, :end {:line 1, :character 53}},
                         :uri (h/file-uri "file:///b.clj")},
              :name "goats-from-alpacas"}]
-           (f.workspace-symbols/workspace-symbols "alpaca" @db/db*)))))
+           (f.workspace-symbols/workspace-symbols "alpaca" (h/db))))))

--- a/lib/test/clojure_lsp/parser_test.clj
+++ b/lib/test/clojure_lsp/parser_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [are deftest is testing]]
    [rewrite-clj.zip :as z]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest safe-zloc-of-string
   (are [s] (= s (z/root-string (parser/safe-zloc-of-string s)))

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -5,11 +5,11 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest internal-analysis
   (testing "when dependency-scheme is zip"
-    (h/clean-db!)
+    (h/reset-components!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
@@ -23,7 +23,7 @@
 
 (deftest external-analysis
   (testing "when dependency-scheme is zip"
-    (h/clean-db!)
+    (h/reset-components!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
@@ -181,7 +181,7 @@
 
 (deftest find-last-order-by-project-analysis
   (testing "with pred that applies for both project and external analysis"
-    (h/clean-db!)
+    (h/reset-components!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (let [element (#'q/find-last-order-by-project-analysis
@@ -190,7 +190,7 @@
                    (h/db))]
       (is (= (h/file-path "/a.clj") (:filename element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
-    (h/clean-db!)
+    (h/reset-components!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
@@ -644,7 +644,7 @@
         {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
         (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r-cljs bar-c-cljs))))
   (testing "when a macro is require-macros on cljs, being the var-definition on a clj/cljc file."
-    (h/clean-db!)
+    (h/reset-components!)
     (h/load-code-and-locs (h/code "(ns some.foo) (defmacro bar [& body] @body)") (h/file-uri "file:///some/foo.clj"))
     (h/load-code-and-locs (h/code "(ns some.foo (:require-macros [some.foo])) (def baz)") (h/file-uri "file:///some/foo.cljs"))
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns a (:require [some.foo :as f])) (f/|bar 1)") (h/file-uri "file:///a.cljs"))

--- a/lib/test/clojure_lsp/refactor/edit_test.clj
+++ b/lib/test/clojure_lsp/refactor/edit_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest is testing]]
    [rewrite-clj.zip :as z]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest find-at-pos
   (is (= "foo/bar" (-> "(foo/bar 1)" z/of-string (edit/find-at-pos 1 2) z/string)))
@@ -87,7 +87,7 @@
                z/sexpr)))))
 
 (defn ^:private assert-function-name [code]
-  (h/clean-db!)
+  (h/reset-components!)
   (h/load-code-and-locs code)
   (let [zloc (-> code z/of-string (z/find-next-value z/next 'd))]
     (is (= "foo"

--- a/lib/test/clojure_lsp/settings_test.clj
+++ b/lib/test/clojure_lsp/settings_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.settings-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
@@ -37,16 +36,16 @@
     (is (= #{:foo} (settings/parse-source-aliases [:foo b])))))
 
 (deftest all-test
-  (swap! db/db* shared/deep-merge {:settings {:a {:b {:c 2}}}})
+  (swap! (h/db*) shared/deep-merge {:settings {:a {:b {:c 2}}}})
   (is (= {:a {:b {:c 2}}}
-         (settings/all @db/db*))))
+         (settings/all (h/db)))))
 
 (deftest get-test
-  (swap! db/db* shared/deep-merge {:settings {:a {:b {:c 2}}}})
-  (is (= 2 (settings/get @db/db* [:a :b :c])))
-  (is (= {:c 2} (settings/get @db/db* [:a :b])))
-  (is (= {:b {:c 2}} (settings/get @db/db* [:a])))
-  (is (= 10 (settings/get @db/db* [:d] 10))))
+  (swap! (h/db*) shared/deep-merge {:settings {:a {:b {:c 2}}}})
+  (is (= 2 (settings/get (h/db) [:a :b :c])))
+  (is (= {:c 2} (settings/get (h/db) [:a :b])))
+  (is (= {:b {:c 2}} (settings/get (h/db) [:a])))
+  (is (= 10 (settings/get (h/db) [:d] 10))))
 
 (deftest clean-client-settings-test
   (let [raw-settings {:linters

--- a/lib/test/clojure_lsp/settings_test.clj
+++ b/lib/test/clojure_lsp/settings_test.clj
@@ -5,7 +5,7 @@
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest kwd-string-test
   (is (= :foo (settings/kwd-string :foo)))

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.shared-test
   (:require
-   [clojure-lsp.db :as db]
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
    [clojure.test :refer [deftest is testing]]
@@ -48,55 +47,55 @@
   (testing "when it is not a jar"
     (h/clean-db!)
     (is (= (if h/windows? "file:///c:/some%20project/foo/bar_baz.clj" "file:///some%20project/foo/bar_baz.clj")
-           (shared/filename->uri (h/file-path "/some project/foo/bar_baz.clj") @db/db*))))
+           (shared/filename->uri (h/file-path "/some project/foo/bar_baz.clj") (h/db)))))
   (testing "when it is a jar via zipfile"
     (h/clean-db!)
     (is (= (if h/windows? "zipfile:///c:/home/some/.m2/some-jar.jar::clojure/core.clj" "zipfile:///home/some/.m2/some-jar.jar::clojure/core.clj")
-           (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj") @db/db*))))
+           (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj") (h/db)))))
   (testing "when it is a jar via jarfile"
-    (swap! db/db* shared/deep-merge {:settings {:dependency-scheme "jar"}})
+    (swap! (h/db*) shared/deep-merge {:settings {:dependency-scheme "jar"}})
     (is (= (if h/windows? "jar:file:///c:/home/some/.m2/some-jar.jar!/clojure/core.clj" "jar:file:///home/some/.m2/some-jar.jar!/clojure/core.clj")
-           (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj") @db/db*))))
+           (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj") (h/db)))))
   (testing "Windows URIs"
     (h/clean-db!)
     (is (= (when h/windows? "file:///c:/c.clj")
-           (when h/windows? (shared/filename->uri "c:\\c.clj" @db/db*))))))
+           (when h/windows? (shared/filename->uri "c:\\c.clj" (h/db)))))))
 
 (deftest uri->namespace
   (testing "when don't have a project root"
     (h/clean-db!)
-    (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") @db/db*))))
+    (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root and not a source-path"
-    (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                 :source-paths #{(h/file-uri "file:///user/project/bla")}}
                                      :project-root-uri (h/file-uri "file:///user/project")})
-    (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") @db/db*))))
+    (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root and a source-path"
-    (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                 :source-paths #{(h/file-path "/user/project/src")}}
                                      :project-root-uri (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
-           (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") @db/db*))))
+           (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root a source-path on mono repos"
-    (swap! db/db* medley/deep-merge {:settings {:auto-add-ns-to-new-files? true
+    (swap! (h/db*) medley/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                 :source-paths #{(h/file-path "/user/project/src/clj")
                                                                 (h/file-path "/user/project/src/cljs")}}
                                      :project-root-uri (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
-           (shared/uri->namespace (h/file-uri "file:///user/project/src/clj/foo/bar.clj") @db/db*))))
+           (shared/uri->namespace (h/file-uri "file:///user/project/src/clj/foo/bar.clj") (h/db)))))
   (testing "when it has a project root and nested source-paths"
-    (swap! db/db* shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                 :source-paths #{(h/file-path "/user/project/src")
                                                                 (h/file-path "/user/project/src/some")}}
                                      :project-root-uri (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
-           (shared/uri->namespace (h/file-uri "file:///user/project/src/some/foo/bar.clj") @db/db*))))
+           (shared/uri->namespace (h/file-uri "file:///user/project/src/some/foo/bar.clj") (h/db)))))
   (testing "when an invalid source-path with a valid source-path prefixing it"
-    (swap! db/db* medley/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src/clj")}}
+    (swap! (h/db*) medley/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src/clj")}}
                                      :project-root-uri (h/file-uri "file:///user/project")})
     (with-redefs [shared/directory? (constantly true)]
       (is (= nil
-             (shared/uri->namespace (h/file-uri "file:///user/project/src/cljs/foo/bar.clj") @db/db*))))))
+             (shared/uri->namespace (h/file-uri "file:///user/project/src/cljs/foo/bar.clj") (h/db)))))))
 
 (deftest conform-uri
   (testing "lower case drive letter and encode colons"

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as medley]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest deep-merge
   (testing "simple deep merge"
@@ -45,11 +45,11 @@
 
 (deftest filename->uri
   (testing "when it is not a jar"
-    (h/clean-db!)
+    (h/reset-components!)
     (is (= (if h/windows? "file:///c:/some%20project/foo/bar_baz.clj" "file:///some%20project/foo/bar_baz.clj")
            (shared/filename->uri (h/file-path "/some project/foo/bar_baz.clj") (h/db)))))
   (testing "when it is a jar via zipfile"
-    (h/clean-db!)
+    (h/reset-components!)
     (is (= (if h/windows? "zipfile:///c:/home/some/.m2/some-jar.jar::clojure/core.clj" "zipfile:///home/some/.m2/some-jar.jar::clojure/core.clj")
            (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj") (h/db)))))
   (testing "when it is a jar via jarfile"
@@ -57,13 +57,13 @@
     (is (= (if h/windows? "jar:file:///c:/home/some/.m2/some-jar.jar!/clojure/core.clj" "jar:file:///home/some/.m2/some-jar.jar!/clojure/core.clj")
            (shared/filename->uri (h/file-path "/home/some/.m2/some-jar.jar:clojure/core.clj") (h/db)))))
   (testing "Windows URIs"
-    (h/clean-db!)
+    (h/reset-components!)
     (is (= (when h/windows? "file:///c:/c.clj")
            (when h/windows? (shared/filename->uri "c:\\c.clj" (h/db)))))))
 
 (deftest uri->namespace
   (testing "when don't have a project root"
-    (h/clean-db!)
+    (h/reset-components!)
     (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root and not a source-path"
     (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true

--- a/lib/test/clojure_lsp/source_paths_test.clj
+++ b/lib/test/clojure_lsp/source_paths_test.clj
@@ -5,7 +5,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
-(h/reset-db-after-test)
+(h/reset-components-before-test)
 
 (deftest classpath->source-paths
   (testing "when classpath is empty"


### PR DESCRIPTION
This PR improves the development experience when working on clojure-lsp itself.

With the lsp4clj refactoring, components—including db*—are threaded through handlers instead of referenced as global variables.

In development, the handler's db* is also put in the global variable db/db*. This is for convenience when using the nREPL, so you can inspect the contents of the db outside of a handler function.

Unfortunately, the tests also use the db/db* global variable. What this means is that if you start the nREPL and then run a test, the test-helper/clean-db! fixture clears the contents of the handler's db*. With an empty db, all the navigation and refactorings stop working. So, you could do one or the other—have a working lsp, or run tests—but not both.

Similarly, four channels were stored as global variables in the db namespace (diagnostics-chan, et. al.) The tests clobber these channels. So, after running a test, the client would stop receiving messages, leading to freezes and timeouts.

This PR gives the tests their own db*. It also turns the channels into components. Together these allow you to run tests and have a working lsp. db/db* still exists, but is only ever populated in dev. It's the same object as the handler uses.

This PR also gives the API its own db*. This db* is a little different than the others, because it needs to be preserved between calls into the API.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
