### PR TITLE
Never omit stack traces when working on clojure-lsp

### DIFF
--- a/cli/build.clj
+++ b/cli/build.clj
@@ -65,7 +65,8 @@
 (defn debug-cli [opts]
   (uber-aot (merge opts {:extra-aliases [:debug :test]
                          :extra-dirs ["dev"]}))
-  (bin {:jvm-opts ["-Djdk.attach.allowAttachSelf=true"
+  (bin {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"
+                   "-Djdk.attach.allowAttachSelf=true"
                    "-Dclojure.core.async.go-checking=true"]}))
 
 (defn prod-cli [opts]

--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,7 @@
                                                              :tag "v0.8.3"
                                                              :sha "0d20256"}}}
            :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.68.1059"}}
+                  :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
                   :extra-paths ["lib/src"
                                 "cli/src"
                                 "common-test/src"


### PR DESCRIPTION
When developing clojure-lsp it's helpful to have stack traces. This configures the nREPLs provided by the debug build and by jacking-in to never optimize away stack traces.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
