### PR TITLE
Rename local usages of destructured keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   - Add support to imported java class on completion. #1193
   - Add new question to skip or retry classpath scan during startup if failed. 
   - Improve performance of processing of changed files outside editor calling clj-kondo in batch. #1205
+  - When renaming a keyword that is also a destructured key, rename its local usages too. #1192
 
 ## 2022.07.24-18.25.43
 


### PR DESCRIPTION
When renaming a keyword that is also a local definition, rename its usages too.

Fixes #1192.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
