### PR TITLE
Download launch4j directly from sourceforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,10 @@ jobs:
           bb: '0.9.161'
 
       - name: Install launch4j
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install launch4j
+        run: |
+          iwr -UserAgent "Wget" -URI "https://sourceforge.net/projects/launch4j/files/launch4j-3/3.14/launch4j-3.14-win32.exe/download" -OutFile "$env:TEMP/l4j-installer.exe"
+          Start-Process -Filepath "$env:TEMP/l4j-installer.exe" -ArgumentList "/S"
+        shell: pwsh
 
       - name: Generate embedded binary
         env:


### PR DESCRIPTION
Hi,

could you please consider a follow up PR to #1133  to address the intermittent connectivity failures when installing launch4j with the chocolatey package manager during CI testing on Windows.  It now tries to download directly from sourceforge, which appears to be a more reliable method.

error:
```
 Chocolatey v1.1.0
  Installing the following packages:
  launch4j
  By installing, you accept licenses for the packages.
  
  Progress: Downloading launch4j 3.14... 16%
  Progress: Downloading launch4j 3.14... 44%
  Progress: Downloading launch4j 3.14... 72%
  Progress: Downloading launch4j 3.14... 100%
  
  launch4j v3.14 [Approved]
  launch4j package files install completed. Performing other installation steps.
  Downloading launch4j 
    from 'https://sourceforge.net/projects/launch4j/files/launch4j-3/3.14/launch4j-3.14-win32.exe/download'
  ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://sourceforge.net/projects/launch4j/files/launch4j-3/3.14/launch4j-3.14-win32.exe/download'. Exception calling "GetResponse" with "0" argument(s): "The request was aborted: Could not create SSL/TLS secure channel." 
```
Thanks

- [x ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.


