### PR TITLE
Avoid NPE when checking drag action from uneval node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Editor
+  - Fix to avoid error when checking code actions from an #_x uneval node. #1227
+
 ## 2022.09.01-15.27.31
 
 - General

--- a/lib/src/clojure_lsp/feature/drag.clj
+++ b/lib/src/clojure_lsp/feature/drag.clj
@@ -472,7 +472,7 @@
   ;; inside the :quote. As the sole child it isn't draggable. In this and
   ;; similar cases, we move up one node, to the :quote, and drag it within the
   ;; :vector.
-  (let [parent-zloc (z-up zloc)]
+  (let [parent-zloc (z/up zloc)] ;; intentionally not z-up, to avoid NPE when on uneval
     (if (and (n/inner? (z/node parent-zloc))
              (not (contains? #{:map :set :vector :forms :list :fn} (z/tag parent-zloc))))
       [parent-zloc (z-up parent-zloc)]

--- a/lib/test/clojure_lsp/feature/drag_test.clj
+++ b/lib/test/clojure_lsp/feature/drag_test.clj
@@ -38,6 +38,8 @@
                                               ""
                                               " :b 2"
                                               "|}")))))
+  (testing "on uneval"
+    (is (not (can-drag-code-backward? (h/code "[#_a #_|b]")))))
   (testing "on first entry"
     (is (not (can-drag-code-backward? "[|1]")))
     (is (not (can-drag-code-backward? "#{|1 2 3}")))


### PR DESCRIPTION
Fixes #1227

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
