### PR TITLE
Indexes analysis and findings by URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - End dep-graph-queries experiment; clojure-lsp now uses the dep-graph to optimize queries whenever possible
   - Bump clj-kondo to `2022.09.09-20220918.164105-17`. #1226 
   - Fix issue with changes being reporting with spurious and incorrect line endings on MS-Windows text files. #1211
+  - Index internal data by URI instead of filename, to minimize conversion between these formats when running queries. #1207
 
 - Editor
   - Fix to avoid error when checking code actions from an #_x uneval node. #1227

--- a/cli/integration-test/integration/completion_test.clj
+++ b/cli/integration-test/integration/completion_test.clj
@@ -30,7 +30,7 @@
         [{:label "definterface"
           :kind 3
           :detail "clojure.core/definterface"
-          :data {:unresolved [["documentation" {:filename "/clojure.core.clj"
+          :data {:unresolved [["documentation" {:uri "file:///clojure.core.clj"
                                                 :name "definterface"
                                                 :ns "clojure.core"}]]}}]
         (lsp/request! (fixture/completion-request "completion/a.clj" 2 3))))
@@ -41,7 +41,7 @@
           :detail "Insert public defn"
           :insertText "defn ${1:name} [$2]\n  $0"
           :insertTextFormat 2
-          :data {:unresolved [["documentation" {:filename "/clojure.core.clj"
+          :data {:unresolved [["documentation" {:uri "file:///clojure.core.clj"
                                                 :name "defn"
                                                 :ns "clojure.core"}]]
                  :snippet-kind 3}}]

--- a/cli/integration-test/integration/cursor_info_test.clj
+++ b/cli/integration-test/integration/cursor_info_test.clj
@@ -31,6 +31,6 @@
           element (:element first-element)
           definition (:definition first-element)]
       (is (not (nil? first-element)))
-      (is (= (:filename element) (:filename definition)))
+      (is (= (:uri element) (:uri definition)))
       (is (= (:name-row element) (:name-row definition)))
       (is (= (:name-col element) (:name-col definition))))))

--- a/lib/src/clojure_lsp/clj_depend.clj
+++ b/lib/src/clojure_lsp/clj_depend.clj
@@ -16,11 +16,14 @@
       (when (shared/file-exists? clj-depend-config-file)
         (edn/read-string {} (slurp clj-depend-config-file))))))
 
-(defn analyze-filename! [filename db]
+(defn analyze-uri! [uri db]
   (when-let [project-root (some-> db :project-root-uri shared/uri->filename)]
     (let [config (resolve-user-clj-depend-config project-root db)]
       (when (seq config)
-        (when-let [namespace (some-> filename (shared/filename->namespace db) symbol)]
+        ;; NOTE probably can't use dep-graph to find nses of uri, because
+        ;; dep-graph won't exist until after kondo analysis is done, which is
+        ;; run in parallel to clj-depend.
+        (when-let [namespace (some-> uri (shared/uri->namespace db) symbol)]
           (-> {:violations {namespace []}}
               (medley/deep-merge
                 (-> (clj-depend/analyze {:project-root (io/file project-root)

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -12,11 +12,10 @@
 
 (def initial-db {:documents {}
                  :processing-changes #{}
-                 :dep-graph {}
-                 :file-meta {}})
+                 :dep-graph {}})
 (defonce db* (atom initial-db))
 
-(def version 5)
+(def version 6)
 
 (defn ^:private sqlite-db-file [project-root]
   (io/file (str project-root) ".lsp" ".cache" "sqlite.db"))

--- a/lib/src/clojure_lsp/feature/call_hierarchy.clj
+++ b/lib/src/clojure_lsp/feature/call_hierarchy.clj
@@ -23,6 +23,8 @@
              (name el-name))
      :kind (f.document-symbol/element->symbol-kind parent-element)
      :tags (cond-> [] deprecated (conj 1))
+     ;; TODO Consider using URI for display purposes, especially if we support
+     ;; remote LSP connections
      :detail (or (some-> ns str) (shared/uri->filename el-uri))
      :uri uri
      :range (shared/->range parent-element)

--- a/lib/src/clojure_lsp/feature/call_hierarchy.clj
+++ b/lib/src/clojure_lsp/feature/call_hierarchy.clj
@@ -17,20 +17,20 @@
 
 (defn ^:private element-by-uri->call-hierarchy-item
   [{:keys [uri parent-element usage-element]}]
-  (let [{:keys [ns filename arglist-strs deprecated] el-name :name} parent-element]
+  (let [{:keys [ns arglist-strs deprecated] el-uri :uri el-name :name} parent-element]
     {:name (if arglist-strs
              (str (name el-name) " " (some->> arglist-strs (remove nil?) (string/join " ")))
              (name el-name))
      :kind (f.document-symbol/element->symbol-kind parent-element)
      :tags (cond-> [] deprecated (conj 1))
-     :detail (or (some-> ns str) filename)
+     :detail (or (some-> ns str) (shared/uri->filename el-uri))
      :uri uri
      :range (shared/->range parent-element)
      :selection-range (shared/->range usage-element)}))
 
 (defn prepare [uri row col db*]
   (let [db @db*
-        cursor-element (q/find-element-under-cursor db (shared/uri->filename uri) row col)]
+        cursor-element (q/find-element-under-cursor db uri row col)]
     [(element-by-uri->call-hierarchy-item
        {:uri uri
         :usage-element cursor-element
@@ -39,21 +39,21 @@
 (defn ^:private parent-var-def
   "Returns var def analysis element that surrounds the element at row/col (or
   that is the element at that position)."
-  [root-zloc db filename row col]
+  [root-zloc db uri row col]
   (when-let [{:keys [row col]} (some-> root-zloc
                                        (parser/to-pos row col)
                                        (edit/find-var-definition-name-loc)
                                        z/node
                                        meta)]
-    (when-let [definition (q/find-element-under-cursor db filename row col)]
+    (when-let [definition (q/find-element-under-cursor db uri row col)]
       (when (or (identical? :var-definitions (:bucket definition))
                 (and (identical? :var-usages (:bucket definition))
                      (:defmethod definition)))
         definition))))
 
 (defn ^:private element->incoming-usage-by-uri
-  [db {:keys [uri root-zloc]} {:keys [name-row name-col filename] :as element}]
-  (when-let [parent-element (parent-var-def root-zloc db filename name-row name-col)]
+  [db root-zloc {:keys [name-row name-col uri] :as element}]
+  (when-let [parent-element (parent-var-def root-zloc db uri name-row name-col)]
     {:uri uri
      :usage-element element
      :parent-element parent-element}))
@@ -61,39 +61,30 @@
 (defn ^:private element->outgoing-usage-by-uri
   [db element]
   (when-let [definition (q/find-definition db element)]
-    (let [def-filename (:filename definition)
-          definition-uri (if (shared/plain-uri? def-filename)
-                           def-filename
-                           (shared/filename->uri def-filename db))]
-      {:uri definition-uri
-       :usage-element element
-       :parent-element definition})))
+    {:uri (:uri definition)
+     :usage-element element
+     :parent-element definition}))
 
 (defn incoming [uri row col {:keys [db*] :as components}]
   (let [db @db*
-        references (q/find-references-from-cursor db (shared/uri->filename uri) row col false)
-        filenames (->> references (map :filename) distinct)
-        file-meta (zipmap filenames
-                          (map (fn [filename]
-                                 (let [uri (shared/filename->uri filename db)]
-                                   {:uri uri
-                                    :root-zloc (safe-zloc-of-forced-uri components uri)}))
-                               filenames))
+        references (q/find-references-from-cursor db uri row col false)
+        uris (->> references (map :uri) distinct)
+        root-zlocs (zipmap uris
+                           (map #(safe-zloc-of-forced-uri components %) uris))
         db @db*]
     (->> references
          (keep (fn [element]
-                 (element->incoming-usage-by-uri db (get file-meta (:filename element)) element)))
+                 (element->incoming-usage-by-uri db (get root-zlocs (:uri element)) element)))
          (mapv (fn [element-by-uri]
                  {:from-ranges []
                   :from (element-by-uri->call-hierarchy-item element-by-uri)})))))
 
 (defn outgoing [uri row col {:keys [db*] :as components}]
-  (let [filename (shared/uri->filename uri)
-        root-zloc (safe-zloc-of-forced-uri components uri)
+  (let [root-zloc (safe-zloc-of-forced-uri components uri)
         db @db*]
-    (when-let [definition (parent-var-def root-zloc db filename row col)]
+    (when-let [definition (parent-var-def root-zloc db uri row col)]
       (->> (q/find-var-usages-under-form db
-                                         filename
+                                         uri
                                          (:name-row definition)
                                          (:name-col definition)
                                          (:end-row definition)

--- a/lib/src/clojure_lsp/feature/clauses.clj
+++ b/lib/src/clojure_lsp/feature/clauses.clj
@@ -273,7 +273,7 @@
                                               :name-end-row end-row
                                               :name-end-col end-col}]
                                    #(shared/inside? % scope)))
-                  elements (->> (get-in db [:analysis (shared/uri->filename uri)])
+                  elements (->> (get-in db [:analysis uri])
                                 (mapcat val)
                                 (filter (enclosed-by? (z/node vector-zloc))))]
               (->> child-nodes

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -3,7 +3,6 @@
    [clojure-lsp.queries :as q]
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.settings :as settings]
-   [clojure-lsp.shared :as shared]
    [clojure.set :as set]
    [clojure.string :as string]
    [rewrite-clj.node :as n]
@@ -210,13 +209,13 @@
           z/up))))
 
 (defn ^:private remove-unused-duplicate-requires
-  [node {:keys [filename db]}]
+  [node {:keys [uri db]}]
   (if-let [alias (some-> node
                          z/down
                          (z/find-next-value ':as)
                          z/right
                          z/sexpr)]
-    (let [local-var-usages (get-in db [:analysis filename :var-usages])
+    (let [local-var-usages (get-in db [:analysis uri :var-usages])
           used-alias? (some #(= alias (:alias %))
                             local-var-usages)]
       (if used-alias?
@@ -431,14 +430,13 @@
         ns-loc (edit/find-namespace safe-loc)]
     (when ns-loc
       (let [ns-inner-blocks-indentation (resolve-ns-inner-blocks-identation db)
-            filename (shared/uri->filename uri)
-            unused-aliases* (future (q/find-unused-aliases db filename))
-            unused-refers* (future (q/find-unused-refers db filename))
-            unused-imports* (future (q/find-unused-imports db filename))
-            duplicate-requires* (future (q/find-duplicate-requires db filename))
+            unused-aliases* (future (q/find-unused-aliases db uri))
+            unused-refers* (future (q/find-unused-refers db uri))
+            unused-imports* (future (q/find-unused-imports db uri))
+            duplicate-requires* (future (q/find-duplicate-requires db uri))
             clean-ctx {:db db
                        :old-ns-loc ns-loc
-                       :filename filename
+                       :uri uri
                        :unused-aliases @unused-aliases*
                        :unused-refers @unused-refers*
                        :unused-imports @unused-imports*

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -8,7 +8,6 @@
    [clojure-lsp.feature.sort-clauses :as f.sort-clauses]
    [clojure-lsp.feature.thread-get :as f.thread-get]
    [clojure-lsp.parser :as parser]
-   [clojure-lsp.queries :as q]
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.refactor.transform :as r.transform]
    [clojure-lsp.shared :as shared]
@@ -339,8 +338,7 @@
         can-destructure-keys?* (future (f.destructure-keys/can-destructure-keys? zloc uri db))
         can-restructure-keys?* (future (f.restructure-keys/can-restructure-keys? zloc uri db))
         can-extract-to-def?* (future (r.transform/can-extract-to-def? zloc))
-        definition (q/find-definition-from-cursor db (shared/uri->filename uri) row col)
-        inline-symbol?* (future (r.transform/inline-symbol? definition db))
+        inline-symbol?* (future (r.transform/inline-symbol? uri row col db))
         can-add-let? (or (z/skip-whitespace z/right zloc)
                          (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))]
     (cond-> []

--- a/lib/src/clojure_lsp/feature/code_lens.clj
+++ b/lib/src/clojure_lsp/feature/code_lens.clj
@@ -20,40 +20,31 @@
 (defn ^:private test-references->string [references]
   (references->string references " test"))
 
-(defn ^:private var-definitions-lens [db filename]
-  (->> (q/find-var-definitions db filename true)
-       (remove (partial q/exclude-public-definition? (:kondo-config db)))))
-
-(defn ^:private keyword-definitions-lens
-  [db filename]
-  (->> (q/find-keyword-definitions db filename)
-       (remove (partial q/exclude-public-definition? (:kondo-config db)))))
-
 (defn reference-code-lens [uri db]
-  (let [filename (shared/uri->filename uri)]
-    (into []
-          (map (fn [element]
-                 {:range (shared/->range element)
-                  :data  [uri (:name-row element) (:name-col element)]}))
-          (concat (q/find-namespace-definitions db filename)
-                  (var-definitions-lens db filename)
-                  (keyword-definitions-lens db filename)))))
+  (into []
+        (map (fn [element]
+               {:range (shared/->range element)
+                :data  [uri (:name-row element) (:name-col element)]}))
+        (concat (q/find-namespace-definitions db uri)
+                (->> (concat (q/find-var-definitions db uri true)
+                             (q/find-keyword-definitions db uri))
+                     (remove (partial q/exclude-public-definition? (:kondo-config db)))))))
 
-(defn test-reference? [source-path {:keys [filename]}]
-  (and source-path
-       (not (string/starts-with? filename source-path))
-       (string/includes? filename "_test.")))
+(defn ^:private test-reference? [source-uri reference-uri]
+  (and source-uri
+       ;; when in test file, don't count usages of helpers as test references
+       (not (string/starts-with? reference-uri source-uri))
+       (string/includes? reference-uri "_test.")))
 
 (defn resolve-code-lens [uri row col range db]
-  (let [filename (shared/uri->filename uri)
-        segregate-lens? (settings/get db [:code-lens :segregate-test-references] true)
-        references (q/find-references-from-cursor db filename row col false)]
+  (let [segregate-lens? (settings/get db [:code-lens :segregate-test-references] true)
+        references (q/find-references-from-cursor db uri row col false)]
     (if segregate-lens?
-      (let [source-path (->> (settings/get db [:source-paths])
-                             (filter #(string/starts-with? filename %))
-                             first)
-            main-references (filter (complement (partial test-reference? source-path)) references)
-            test-references (filter (partial test-reference? source-path) references)]
+      (let [source-uri (some-> uri
+                               (shared/uri->source-path (settings/get db [:source-paths]))
+                               (shared/filename->uri db))
+            main-references (remove (comp (partial test-reference? source-uri) :uri) references)
+            test-references (filter (comp (partial test-reference? source-uri) :uri) references)]
         (if (seq test-references)
           {:range range
            :command {:title (str (main-references->string main-references)

--- a/lib/src/clojure_lsp/feature/destructure_keys.clj
+++ b/lib/src/clojure_lsp/feature/destructure_keys.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure-lsp.queries :as q]
    [clojure-lsp.refactor.edit :as edit]
-   [clojure-lsp.shared :as shared]
    [medley.core :as medley]
    [rewrite-clj.node :as n]
    [rewrite-clj.zip :as z]))
@@ -20,9 +19,8 @@
 
 (defn local-to-destructure [zloc uri db]
   (when zloc
-    (let [filename (shared/uri->filename uri)
-          {:keys [row col]} (meta (z/node zloc))]
-      (when-let [def-elem (q/find-definition-from-cursor db filename row col)]
+    (let [{:keys [row col]} (meta (z/node zloc))]
+      (when-let [def-elem (q/find-definition-from-cursor db uri row col)]
         (when (= :locals (:bucket def-elem))
           (let [top-zloc (edit/to-top zloc)
                 def-zloc (edit/find-at-pos top-zloc (:row def-elem) (:col def-elem))

--- a/lib/src/clojure_lsp/feature/document_symbol.clj
+++ b/lib/src/clojure_lsp/feature/document_symbol.clj
@@ -31,17 +31,17 @@
 (defn ^:private symbol-order [{:keys [selection-range]}]
   [(:line (:start selection-range)) (:character (:start selection-range))])
 
-(defn document-symbols [db filename]
-  (let [namespace-definition (q/find-namespace-definition-by-filename db filename)]
+(defn document-symbols [db uri]
+  (let [namespace-definition (q/find-namespace-definition-by-uri db uri)]
     [{:name (or (some-> namespace-definition :name name)
-                filename)
+                (shared/uri->filename uri))
       :kind (element->symbol-kind namespace-definition)
       :range shared/full-file-range
       :selection-range (if namespace-definition
                          (shared/->scope-range namespace-definition)
                          shared/full-file-range)
-      :children (->> (concat (q/find-var-definitions db filename true)
-                             (q/find-defmethods db filename))
+      :children (->> (concat (q/find-var-definitions db uri true)
+                             (q/find-defmethods db uri))
                      (map element->document-symbol)
                      (sort-by symbol-order)
                      vec)}]))

--- a/lib/src/clojure_lsp/feature/document_symbol.clj
+++ b/lib/src/clojure_lsp/feature/document_symbol.clj
@@ -34,6 +34,8 @@
 (defn document-symbols [db uri]
   (let [namespace-definition (q/find-namespace-definition-by-uri db uri)]
     [{:name (or (some-> namespace-definition :name name)
+                ;; TODO Consider using URI for display purposes, especially if
+                ;; we support remote LSP connections
                 (shared/uri->filename uri))
       :kind (element->symbol-kind namespace-definition)
       :range shared/full-file-range

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -36,7 +36,7 @@
 (defn did-open [uri text {:keys [db* edits-chan] :as components} allow-create-ns]
   (load-document! uri text db*)
   (let [kondo-result* (future (lsp.kondo/run-kondo-on-text! text uri db*))
-        depend-result* (future (lsp.depend/analyze-filename! (shared/uri->filename uri) @db*))
+        depend-result* (future (lsp.depend/analyze-uri! uri @db*))
         kondo-result @kondo-result*
         depend-result @depend-result*]
     (swap! db* (fn [state-db]
@@ -69,77 +69,76 @@
   defs to usages, but it includes the attributes we care about."
   (juxt :ns :name :private :fixed-arities :defined-by))
 
-(defn reference-filenames [filename db-before db-after]
-  (let [uri (shared/filename->uri filename db-before)
-        old-local-buckets (get-in db-before [:analysis filename])
-        new-local-buckets (get-in db-after [:analysis filename])
+(defn reference-uris [uri db-before db-after]
+  (let [old-local-buckets (get-in db-before [:analysis uri])
+        new-local-buckets (get-in db-after [:analysis uri])
         changed-var-definitions (find-changed-elems old-local-buckets new-local-buckets :var-definitions definition-signature)
         changed-var-usages (find-changed-elems old-local-buckets new-local-buckets :var-usages q/var-usage-signature)
         changed-kw-usages (find-changed-elems old-local-buckets new-local-buckets :keyword-usages q/kw-signature)
         project-db (-> db-after
                        q/db-with-internal-analysis
                        ;; don't notify self
-                       (update :analysis dissoc filename))
-        var-dependent-filenames (when (seq changed-var-definitions)
-                                  (let [def-signs (into #{}
-                                                        (mapcat q/var-definition-signatures)
-                                                        changed-var-definitions)
-                                        usage-of-changed-def? (fn [var-usage]
-                                                                (contains? def-signs (q/var-usage-signature var-usage)))]
-                                    (into #{}
-                                          (keep (fn [[filename {:keys [var-usages]}]]
-                                                  (when (some usage-of-changed-def? var-usages)
-                                                    filename)))
-                                          (q/uri-dependents-analysis project-db uri))))
-        var-dependency-filenames (when (seq changed-var-usages)
-                                   ;; If definition is in both a clj and cljs file, and this is a clj
-                                   ;; usage, we are careful to notify only the clj file. But, it wouldn't
-                                   ;; really hurt to notify both files. So, if it helps readability,
-                                   ;; maintenance, or symmetry with `dependent-filenames`, we could look
-                                   ;; at just signature, not signature and lang.
-                                   (let [usage-signs->langs (->> changed-var-usages
-                                                                 (reduce (fn [result usage]
-                                                                           (assoc result (q/var-usage-signature usage) (q/elem-langs usage)))
-                                                                         {}))
-                                         def-of-changed-usage? (fn [var-def]
-                                                                 (when-let [usage-langs (some usage-signs->langs
-                                                                                              (q/var-definition-signatures var-def))]
-                                                                   (some usage-langs (q/elem-langs var-def))))]
-                                     (into #{}
-                                           (keep (fn [[filename {:keys [var-definitions]}]]
-                                                   (when (some def-of-changed-usage? var-definitions)
-                                                     filename)))
-                                           (q/uri-dependencies-analysis project-db uri))))
-        kw-dependency-filenames (when (seq changed-kw-usages)
-                                  (let [usage-signs (into #{}
-                                                          (map q/kw-signature)
-                                                          changed-kw-usages)
-                                        def-of-changed-usage? (fn [kw-def]
-                                                                (contains? usage-signs (q/kw-signature kw-def)))]
-                                    (into #{}
-                                          (keep (fn [[filename {:keys [keyword-definitions]}]]
-                                                  (when (some def-of-changed-usage? keyword-definitions)
-                                                    filename)))
-                                          (:analysis project-db))))]
+                       (update :analysis dissoc uri))
+        var-dependent-uri (when (seq changed-var-definitions)
+                            (let [def-signs (into #{}
+                                                  (mapcat q/var-definition-signatures)
+                                                  changed-var-definitions)
+                                  usage-of-changed-def? (fn [var-usage]
+                                                          (contains? def-signs (q/var-usage-signature var-usage)))]
+                              (into #{}
+                                    (keep (fn [[uri {:keys [var-usages]}]]
+                                            (when (some usage-of-changed-def? var-usages)
+                                              uri)))
+                                    (q/uri-dependents-analysis project-db uri))))
+        var-dependency-uris (when (seq changed-var-usages)
+                              ;; If definition is in both a clj and cljs file, and this is a clj
+                              ;; usage, we are careful to notify only the clj file. But, it wouldn't
+                              ;; really hurt to notify both files. So, if it helps readability,
+                              ;; maintenance, or symmetry with `var-dependent-uris`, we could look
+                              ;; at just signature, not signature and lang.
+                              (let [usage-signs->langs (->> changed-var-usages
+                                                            (reduce (fn [result usage]
+                                                                      (assoc result (q/var-usage-signature usage) (q/elem-langs usage)))
+                                                                    {}))
+                                    def-of-changed-usage? (fn [var-def]
+                                                            (when-let [usage-langs (some usage-signs->langs
+                                                                                         (q/var-definition-signatures var-def))]
+                                                              (some usage-langs (q/elem-langs var-def))))]
+                                (into #{}
+                                      (keep (fn [[uri {:keys [var-definitions]}]]
+                                              (when (some def-of-changed-usage? var-definitions)
+                                                uri)))
+                                      (q/uri-dependencies-analysis project-db uri))))
+        kw-dependency-uris (when (seq changed-kw-usages)
+                             (let [usage-signs (into #{}
+                                                     (map q/kw-signature)
+                                                     changed-kw-usages)
+                                   def-of-changed-usage? (fn [kw-def]
+                                                           (contains? usage-signs (q/kw-signature kw-def)))]
+                               (into #{}
+                                     (keep (fn [[uri {:keys [keyword-definitions]}]]
+                                             (when (some def-of-changed-usage? keyword-definitions)
+                                               uri)))
+                                     (:analysis project-db))))]
     ;; TODO: see note on `notify-references` We may want to handle these
     ;; sets of files differently.
-    (set/union (or var-dependent-filenames #{})
-               (or var-dependency-filenames #{})
-               (or kw-dependency-filenames #{}))))
+    (set/union (or var-dependent-uri #{})
+               (or var-dependency-uris #{})
+               (or kw-dependency-uris #{}))))
 
-(defn analyze-reference-filenames! [filenames db*]
-  (let [result (lsp.kondo/run-kondo-on-reference-filenames! filenames db*)]
+(defn analyze-reference-uris! [uris db*]
+  (let [result (lsp.kondo/run-kondo-on-reference-uris! uris db*)]
     (swap! db* lsp.kondo/db-with-results result)))
 
-(defn ^:private notify-references [filename db-before db-after {:keys [db* producer] :as components}]
+(defn ^:private notify-references [uri db-before db-after {:keys [db* producer] :as components}]
   (async/thread
     (shared/logging-task
       :notify-references
-      (let [filenames (shared/logging-task
-                        :reference-files/find
-                        (reference-filenames filename db-before db-after))]
-        (when (seq filenames)
-          (logger/debug "Analyzing references for files:" filenames)
+      (let [uris (shared/logging-task
+                   :reference-files/find
+                   (reference-uris uri db-before db-after))]
+        (when (seq uris)
+          (logger/debug "Analyzing references for files:" uris)
           (shared/logging-task
             :reference-files/analyze
             ;; TODO: We process the dependent and dependency files together, but
@@ -161,8 +160,8 @@
             ;; kondo. See
             ;; https://github.com/clojure-lsp/clojure-lsp/issues/1027 and
             ;; https://github.com/clojure-lsp/clojure-lsp/issues/1028.
-            (analyze-reference-filenames! filenames db*))
-          (f.diagnostic/publish-all-diagnostics! filenames components)
+            (analyze-reference-uris! uris db*))
+          (f.diagnostic/publish-all-diagnostics! uris components)
           (producer/refresh-code-lens producer))))))
 
 (defn ^:private offsets [lines line character end-line end-character]
@@ -230,31 +229,30 @@
       new-text)))
 
 (defn analyze-changes [{:keys [uri text version]} {:keys [producer db*] :as components}]
-  (let [filename (shared/uri->filename uri)]
-    (loop [state-db @db*]
-      (when (>= version (get-in state-db [:documents uri :v] -1))
-        (let [kondo-result* (future
-                              (shared/logging-time
-                                (str "changes analyzed by clj-kondo took %s")
-                                (lsp.kondo/run-kondo-on-text! text uri db*)))
-              depend-result* (future
-                               (shared/logging-time
-                                 (str "changes analyzed by clj-depend took %s")
-                                 (lsp.depend/analyze-filename! filename state-db)))
-              kondo-result @kondo-result*
-              depend-result @depend-result*
-              old-db @db*]
-          (if (compare-and-set! db* state-db
-                                (-> state-db
-                                    (lsp.kondo/db-with-results kondo-result)
-                                    (lsp.depend/db-with-results depend-result)
-                                    (update :processing-changes disj uri)))
-            (let [db @db*]
-              (f.diagnostic/publish-diagnostics! uri components)
-              (when (settings/get db [:notify-references-on-file-change] true)
-                (notify-references filename old-db db components))
-              (producer/refresh-test-tree producer [uri]))
-            (recur @db*)))))))
+  (loop [state-db @db*]
+    (when (>= version (get-in state-db [:documents uri :v] -1))
+      (let [kondo-result* (future
+                            (shared/logging-time
+                              (str "changes analyzed by clj-kondo took %s")
+                              (lsp.kondo/run-kondo-on-text! text uri db*)))
+            depend-result* (future
+                             (shared/logging-time
+                               (str "changes analyzed by clj-depend took %s")
+                               (lsp.depend/analyze-uri! uri state-db)))
+            kondo-result @kondo-result*
+            depend-result @depend-result*
+            old-db @db*]
+        (if (compare-and-set! db* state-db
+                              (-> state-db
+                                  (lsp.kondo/db-with-results kondo-result)
+                                  (lsp.depend/db-with-results depend-result)
+                                  (update :processing-changes disj uri)))
+          (let [db @db*]
+            (f.diagnostic/publish-diagnostics! uri components)
+            (when (settings/get db [:notify-references-on-file-change] true)
+              (notify-references uri old-db db components))
+            (producer/refresh-test-tree producer [uri]))
+          (recur @db*))))))
 
 (defn did-change [uri changes version {:keys [db* current-changes-chan]}]
   (let [old-text (get-in @db* [:documents uri :text])
@@ -273,45 +271,44 @@
                  "Watched files analyzed, took %s"
                  (lsp.kondo/run-kondo-on-paths! filenames db* {:external? false} nil))]
     (swap! db* lsp.kondo/db-with-results result)
-    (f.diagnostic/publish-all-diagnostics! filenames components)
+    (f.diagnostic/publish-all-diagnostics! uris components)
     (producer/refresh-test-tree producer uris)
     (doseq [uri uris]
       (when (get-in @db* [:documents uri :v])
         (when-let [text (shared/slurp-uri uri)]
           (swap! db* assoc-in [:documents uri :text] text))))))
 
-(defn ^:private db-without-file [state-db uri filename]
+(defn ^:private db-without-uri [state-db uri]
   (-> state-db
-      (dep-graph/remove-file uri filename)
+      (dep-graph/remove-doc uri)
       (shared/dissoc-in [:documents uri])
-      (shared/dissoc-in [:analysis filename])
-      (shared/dissoc-in [:findings filename])))
+      (shared/dissoc-in [:analysis uri])
+      (shared/dissoc-in [:findings uri])))
 
-(defn ^:private file-deleted [{:keys [db*], :as components} uri filename]
-  (swap! db* db-without-file uri filename)
-  (f.diagnostic/publish-empty-diagnostics! uri components))
+(defn ^:private files-deleted [{:keys [db*], :as components} uris]
+  (swap! db* #(reduce db-without-uri % uris))
+  (f.diagnostic/publish-empty-diagnostics! uris components))
 
 (defn did-change-watched-files
   [changes
    {:keys [db* watched-files-chan] :as components}]
-  (doseq [{:keys [uri type]} changes]
-    (case type
-      :created (async/>!! watched-files-chan uri)
-      :changed (when (settings/get @db* [:compute-external-file-changes] true)
-                 (async/>!! watched-files-chan uri))
-      :deleted (shared/logging-task
-                 :delete-watched-file
-                 (file-deleted components uri (shared/uri->filename uri))))))
+  (let [{:keys [created changed deleted]} (group-by :type changes)
+        observe-changed? (settings/get @db* [:compute-external-file-changes] true)]
+    (doseq [created-or-changed (concat created (when observe-changed? changed))]
+      (async/>!! watched-files-chan (:uri created-or-changed)))
+    (when (seq deleted)
+      (shared/logging-task
+        :delete-watched-files
+        (files-deleted components (map :uri deleted))))))
 
 (defn did-close [uri {:keys [db*] :as components}]
   (let [filename (shared/uri->filename uri)
         source-paths (settings/get @db* [:source-paths])
         external-filename? (shared/external-filename? filename source-paths)]
-    (when external-filename?
-      (f.diagnostic/publish-empty-diagnostics! uri components))
-    (when (and (not external-filename?)
-               (not (shared/file-exists? (io/file filename))))
-      (file-deleted components uri filename))))
+    (if external-filename?
+      (f.diagnostic/publish-empty-diagnostics! [uri] components)
+      (when (not (shared/file-exists? (io/file filename)))
+        (files-deleted components [uri])))))
 
 (defn force-get-document-text
   "Get document text from db, if document not found, tries to open the document"
@@ -334,13 +331,11 @@
                                  config-files)]
 
     (when config-file-saved?
-      (let [all-opened-filenames (->> (:documents db)
-                                      (keep (fn [[uri document]]
-                                              (when (:v document)
-                                                (shared/uri->filename uri))))
-                                      set)]
-        (analyze-reference-filenames! all-opened-filenames db*)
-        (f.diagnostic/publish-all-diagnostics! all-opened-filenames components)
+      (let [all-opened-uris (->> (:documents db)
+                                 (keep (fn [[uri document]] (when (:v document) uri)))
+                                 set)]
+        (analyze-reference-uris! all-opened-uris db*)
+        (f.diagnostic/publish-all-diagnostics! all-opened-uris components)
         (producer/refresh-code-lens producer)))))
 
 (defn did-save [uri {:keys [db*] :as components}]
@@ -350,9 +345,8 @@
 (defn will-rename-files [files db]
   (->> files
        (keep (fn [{:keys [old-uri new-uri]}]
-               (let [old-filename (shared/uri->filename old-uri)
-                     new-ns (shared/uri->namespace new-uri db)
-                     old-ns-definition (q/find-namespace-definition-by-filename db old-filename)]
+               (let [new-ns (shared/uri->namespace new-uri db)
+                     old-ns-definition (q/find-namespace-definition-by-uri db old-uri)]
                  (when (and new-ns
                             old-ns-definition
                             (not= new-ns (name (:name old-ns-definition))))

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -89,6 +89,8 @@
                      (docstring->formatted-markdown doc)
                      doc))
         clojuredocs (f.clojuredocs/find-hover-docs-for sym-name sym-ns db*)
+        ;; TODO Consider using URI for display purposes, especially if we
+        ;; support remote LSP connections
         filename (shared/uri->filename uri)]
     (if markdown?
       {:kind "markdown"

--- a/lib/src/clojure_lsp/feature/linked_editing_range.clj
+++ b/lib/src/clojure_lsp/feature/linked_editing_range.clj
@@ -6,9 +6,8 @@
 (set! *warn-on-reflection* true)
 
 (defn ranges [uri row col db]
-  (let [filename (shared/uri->filename uri)
-        elements (q/find-references-from-cursor db filename row col true)
-        same-file-references-only? (= 1 (count (keys (group-by :filename elements))))]
+  (let [elements (q/find-references-from-cursor db uri row col true)
+        same-file-references-only? (= 1 (count (keys (group-by :uri elements))))]
     (if same-file-references-only?
       {:ranges (->> elements
                     (map shared/->range))}

--- a/lib/src/clojure_lsp/feature/resolve_macro.clj
+++ b/lib/src/clojure_lsp/feature/resolve_macro.clj
@@ -32,8 +32,7 @@
 
 (defn find-full-macro-symbol-to-resolve [zloc uri db]
   (when-let [{macro-name-row :row macro-name-col :col} (find-function-name-position zloc)]
-    (let [filename (shared/uri->filename uri)
-          element (q/find-element-under-cursor db filename macro-name-row macro-name-col)]
+    (let [element (q/find-element-under-cursor db uri macro-name-row macro-name-col)]
       (when (:macro element)
         (let [excluded-vars (get excluded-macros (:to element))]
           (when (and (not= excluded-vars '*)

--- a/lib/src/clojure_lsp/feature/semantic_tokens.clj
+++ b/lib/src/clojure_lsp/feature/semantic_tokens.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.feature.semantic-tokens
   (:require
-   [clojure-lsp.shared :as shared]
    [clojure.string :as string])
   (:import
    [clojure.lang PersistentVector]))
@@ -216,7 +215,7 @@
        doall))
 
 (defn full-tokens [uri db]
-  (let [buckets (get-in db [:analysis (shared/uri->filename uri)])]
+  (let [buckets (get-in db [:analysis uri])]
     (->> buckets
          (mapcat val)
          elements->absolute-tokens
@@ -224,7 +223,7 @@
 
 (defn range-tokens
   [uri range db]
-  (let [buckets (get-in db [:analysis (shared/uri->filename uri)])]
+  (let [buckets (get-in db [:analysis uri])]
     (->> buckets
          (mapcat val)
          (filter #(element-inside-range? % range))

--- a/lib/src/clojure_lsp/feature/signature_help.clj
+++ b/lib/src/clojure_lsp/feature/signature_help.clj
@@ -81,9 +81,8 @@
                                   edit/find-function-usage-name-loc)]
     (let [db @db*
           arglist-nodes (function-loc->arglist-nodes function-loc)
-          filename (shared/uri->filename uri)
           function-meta (meta (z/node function-loc))
-          definition (q/find-definition-from-cursor db filename (:row function-meta) (:col function-meta))
+          definition (q/find-definition-from-cursor db uri (:row function-meta) (:col function-meta))
           signatures (definition->signature-informations definition)
           active-signature (get-active-signature-index definition arglist-nodes)]
       (when (seq signatures)

--- a/lib/src/clojure_lsp/feature/test_tree.clj
+++ b/lib/src/clojure_lsp/feature/test_tree.clj
@@ -34,9 +34,8 @@
      :children (->testings-children local-testings)}))
 
 (defn tree [uri db]
-  (let [filename (shared/uri->filename uri)
-        ns-element (q/find-namespace-definition-by-filename db filename)
-        local-buckets (get-in db [:analysis filename])
+  (let [ns-element (q/find-namespace-definition-by-uri db uri)
+        local-buckets (get-in db [:analysis uri])
         deftests (into []
                        (filter #(contains? '#{clojure.test/deftest cljs.test/deftest}
                                            (:defined-by %)))

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -180,7 +180,7 @@
     :definition
     (let [db @db*
           [row col] (shared/position->row-col position)]
-      (when-let [definition (q/find-definition-from-cursor db (shared/uri->filename (:uri text-document)) row col)]
+      (when-let [definition (q/find-definition-from-cursor db (:uri text-document) row col)]
         {:uri (f.java-interop/uri->translated-uri (:uri definition) db producer)
          :range (shared/->range definition)}))))
 
@@ -189,7 +189,7 @@
     :declaration
     (let [db @db*
           [row col] (shared/position->row-col position)]
-      (when-let [declaration (q/find-declaration-from-cursor db (shared/uri->filename (:uri text-document)) row col)]
+      (when-let [declaration (q/find-declaration-from-cursor db (:uri text-document) row col)]
         {:uri (f.java-interop/uri->translated-uri (:uri declaration) db producer)
          :range (shared/->range declaration)}))))
 

--- a/lib/test/clojure_lsp/dep_graph_test.clj
+++ b/lib/test/clojure_lsp/dep_graph_test.clj
@@ -38,10 +38,10 @@
                            :dependents-langs {:clj 2}}}
            (:dep-graph (h/db))))
     (h/assert-submap
-      {:internal? false, :langs #{:clj}, :namespaces #{'xxx} :filename (h/file-path "/some.jar:xxx.clj")}
+      '{:internal? false, :langs #{:clj}, :namespaces #{xxx}}
       (get-in (h/db) [:documents (h/file-uri "zipfile:///some.jar::xxx.clj")]))
     (h/assert-submap
-      {:internal? false, :langs #{:clj}, :namespaces #{'xxx.yyy} :filename (h/file-path "/some.jar:xxx/yyy.clj")}
+      '{:internal? false, :langs #{:clj}, :namespaces #{xxx.yyy}}
       (get-in (h/db) [:documents (h/file-uri "zipfile:///some.jar::xxx/yyy.clj")])))
   (testing "initial internal analysis"
     (h/reset-components!)
@@ -77,13 +77,13 @@
                            :dependents-langs {:clj 3}}}
            (:dep-graph (h/db))))
     (h/assert-submap
-      {:internal? true, :langs #{:clj}, :namespaces #{'aaa}, :filename (h/file-path "/aaa.clj")}
+      '{:internal? true, :langs #{:clj}, :namespaces #{aaa}}
       (get-in (h/db) [:documents (h/file-uri "file:///aaa.clj")]))
     (h/assert-submap
-      {:internal? true, :langs #{:clj}, :namespaces #{'bbb}, :filename (h/file-path "/bbb.clj")}
+      '{:internal? true, :langs #{:clj}, :namespaces #{bbb}}
       (get-in (h/db) [:documents (h/file-uri "file:///bbb.clj")]))
     (h/assert-submap
-      {:internal? true, :langs #{:clj}, :namespaces #{'ccc}, :filename (h/file-path "/ccc.clj")}
+      '{:internal? true, :langs #{:clj}, :namespaces #{ccc}}
       (get-in (h/db) [:documents (h/file-uri "file:///ccc.clj")])))
   (testing "extending initial external analysis with internal analysis"
     (h/reset-components!)
@@ -316,10 +316,10 @@
             jjj kkk lll}
          (dep-graph/ns-names-for-langs (h/db) #{:clj :cljs}))))
 
-(deftest ns-names-for-file
+(deftest ns-names-for-uri
   (h/load-code-and-locs "(ns aaa) (ns ccc)" (h/file-uri "file:///aaa.clj"))
   (h/load-code-and-locs "(ns bbb)" (h/file-uri "file:///bbb.clj"))
-  (is (= '[aaa ccc]
+  (is (= '#{aaa ccc}
          (dep-graph/ns-names-for-uri (h/db) (h/file-uri "file:///aaa.clj")))))
 
 (deftest ns-names

--- a/lib/test/clojure_lsp/feature/test_tree_test.clj
+++ b/lib/test/clojure_lsp/feature/test_tree_test.clj
@@ -18,7 +18,7 @@
                                   "      (+ 2 3)))"
                                   ")"))
     (h/assert-submap
-      {:uri (h/file-uri "file:///a.clj")
+      {:uri h/default-uri
        :tree
        {:name "foo.bar"
         :range {:start {:line 0 :character 0}

--- a/lib/test/clojure_lsp/features/code_lens_test.clj
+++ b/lib/test/clojure_lsp/features/code_lens_test.clj
@@ -1,9 +1,9 @@
 (ns clojure-lsp.features.code-lens-test
   (:require
    [clojure-lsp.feature.code-lens :as f.code-lens]
+   [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
-   [clojure.test :refer [deftest is testing]]
-   [clojure-lsp.shared :as shared]))
+   [clojure.test :refer [deftest is testing]]))
 
 (h/reset-components-before-test)
 

--- a/lib/test/clojure_lsp/features/code_lens_test.clj
+++ b/lib/test/clojure_lsp/features/code_lens_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure-lsp.feature.code-lens :as f.code-lens]
    [clojure-lsp.test-helper :as h]
-   [clojure.test :refer [deftest is testing]]))
+   [clojure.test :refer [deftest is testing]]
+   [clojure-lsp.shared :as shared]))
 
 (h/reset-components-before-test)
 
@@ -114,4 +115,44 @@
                (h/file-uri "file:///a.clj") 1 13
                {:start {:line 1 :character 5}
                 :end {:line 1 :character 12}}
-               (h/db)))))))
+               (h/db))))))
+  (testing "test references"
+    (swap! (h/db*) shared/deep-merge {:settings {:source-paths #{(h/file-path "/project/src")
+                                                                 (h/file-path "/project/test")}}})
+    (testing "in src file"
+      (let [src-uri (h/file-uri "file:///project/src/a.clj")
+            [[start-r start-c :as start] end]
+            (h/load-code-and-locs (h/code "(ns a)"
+                                          "(def |aa| 1)"
+                                          "aa")
+                                  src-uri)
+            def-range (h/->range start end)]
+        (h/load-code (h/code "(ns a-test"
+                             "  (:require [a]))"
+                             "a/aa")
+                     (h/file-uri "file:///project/test/a_test.clj"))
+        (is (= {:range def-range,
+                :command {:title "1 reference | 1 test",
+                          :command "code-lens-references",
+                          :arguments [src-uri 2 6]}}
+               (f.code-lens/resolve-code-lens
+                 src-uri start-r start-c
+                 def-range
+                 (h/db))))))
+    (testing "in test file"
+      (let [test-uri (h/file-uri "file:///project/test/a_test.clj")
+            [[start-r start-c :as start] end]
+            (h/load-code-and-locs
+              (h/code "(ns a-test)"
+                      "(def |test-helper| 1)"
+                      "test-helper")
+              test-uri)
+            def-range (h/->range start end)]
+        (is (= {:range def-range,
+                :command {:title "1 reference",
+                          :command "code-lens-references",
+                          :arguments [test-uri 2 6]}}
+               (f.code-lens/resolve-code-lens
+                 test-uri start-r start-c
+                 def-range
+                 (h/db))))))))

--- a/lib/test/clojure_lsp/features/completion_test.clj
+++ b/lib/test/clojure_lsp/features/completion_test.clj
@@ -129,7 +129,7 @@
          {:label "bb/bar",
           :kind :variable
           :data {"unresolved" [["documentation" {"name" "bar"
-                                                 "filename" (h/file-path "/bbb.clj")
+                                                 "uri" (h/file-uri "file:///bbb.clj")
                                                  "name-row" 2
                                                  "name-col" 6}]]},
           :additional-text-edits
@@ -152,7 +152,7 @@
          {:label "bb/bar",
           :kind :variable
           :data {"unresolved" [["documentation" {"name" "bar"
-                                                 "filename" (h/file-path "/bbb.clj")
+                                                 "uri" (h/file-uri "file:///bbb.clj")
                                                  "name-row" 2
                                                  "name-col" 6}]
                                ["alias" {"ns-to-add" "bbb"
@@ -228,7 +228,7 @@
                                                  :kind :variable
                                                  :data {:unresolved [["documentation"
                                                                       {:name "foo"
-                                                                       :filename (h/file-path "/a.clj")
+                                                                       :uri (h/file-uri "file:///a.clj")
                                                                        :name-row 1
                                                                        :name-col 13}]]}}
                                                 (h/db*))))
@@ -241,8 +241,8 @@
                      (f.completion/resolve-item {:label "foo"
                                                  :kind :function
                                                  :data {:unresolved [["documentation"
-                                                                      {:name "foo"
-                                                                       :filename (h/file-path "/a.clj")
+                                                                      {:uri "file:///clojure.core.clj"
+                                                                       :name "foo"
                                                                        :ns "a"}]]}}
                                                 (h/db*))))
   (testing "When element needs an alias"
@@ -276,7 +276,7 @@
                                                  :kind :function
                                                  :data {:unresolved [["documentation"
                                                                       {:name "foo"
-                                                                       :filename (h/file-path "/a.clj")
+                                                                       :uri (h/file-uri "file:///a.clj")
                                                                        :name-row 1
                                                                        :name-col 13}]
                                                                      ["alias"
@@ -323,8 +323,8 @@
     (h/assert-submaps
       [{:label "comment"
         :kind :function
-        :data {"unresolved" [["documentation" {"filename" "/clojure.core.clj"
-                                               "name" "comment"
+        :data {"unresolved" [["documentation" {"name" "comment"
+                                               "uri" "file:///clojure.core.clj"
                                                "ns" "clojure.core"}]]}
         :detail "clojure.core/comment"}]
       (f.completion/completion (h/file-uri "file:///a.clj") 2 8 (h/db))))

--- a/lib/test/clojure_lsp/features/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/features/diagnostics_test.clj
@@ -20,13 +20,13 @@
   (h/load-code-and-locs (h/code "(ns some-ns) (defn ^:export foobar (fn []))") (h/file-uri "file:///d.cljs"))
   (testing "when linter level is :info"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :info}}}})
     (h/assert-submaps
-      [{:filename (h/file-path "/a.clj")
+      [{:uri h/default-uri
         :level :info
         :type :clojure-lsp/unused-public-var
         :message "Unused public var 'some-ns/foo'"
@@ -37,13 +37,13 @@
       @findings))
   (testing "when linter level is :warning"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :warning}}}})
     (h/assert-submaps
-      [{:filename (h/file-path "/a.clj")
+      [{:uri h/default-uri
         :level :warning
         :type :clojure-lsp/unused-public-var
         :message "Unused public var 'some-ns/foo'"
@@ -54,13 +54,13 @@
       @findings))
   (testing "when linter level is :error"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :error}}}})
     (h/assert-submaps
-      [{:filename (h/file-path "/a.clj")
+      [{:uri h/default-uri
         :level :error
         :type :clojure-lsp/unused-public-var
         :message "Unused public var 'some-ns/foo'"
@@ -71,13 +71,13 @@
       @findings))
   (testing "when linter level is :off"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :off}}}})
     (h/assert-submaps
-      [{:filename (h/file-path "/a.clj")
+      [{:uri h/default-uri
         :level :off
         :type :clojure-lsp/unused-public-var
         :message "Unused public var 'some-ns/foo'"
@@ -88,13 +88,13 @@
       @findings))
   (testing "linter level by default is :info"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
-      [{:filename (h/file-path "/a.clj")
+      [{:uri h/default-uri
         :level :info
         :type :clojure-lsp/unused-public-var
         :message "Unused public var 'some-ns/foo'"
@@ -105,8 +105,8 @@
       @findings))
   (testing "excluding the whole ns"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns}}}}})
@@ -115,8 +115,8 @@
       @findings))
   (testing "excluding the simple var from ns"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'foo}}}}})
@@ -125,8 +125,8 @@
       @findings))
   (testing "excluding the specific var"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/a.clj")
+    (f.diagnostic/custom-lint-uris!
+      [h/default-uri]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:exclude #{'some-ns/foo}}}}})
@@ -135,8 +135,8 @@
       @findings))
   (testing "excluding specific syms"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/b.clj")
+    (f.diagnostic/custom-lint-uris!
+      [(h/file-uri "file:///b.clj")]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
@@ -145,13 +145,13 @@
       @findings))
   (testing "unused keyword definitions"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/c.cljs")
+    (f.diagnostic/custom-lint-uris!
+      [(h/file-uri "file:///c.cljs")]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
     (h/assert-submaps
-      [{:filename (h/file-path "/c.cljs")
+      [{:uri (h/file-uri "file:///c.cljs")
         :level :info
         :type :clojure-lsp/unused-public-var
         :message "Unused public keyword ':some/thing'"
@@ -159,7 +159,7 @@
         :col 17
         :end-row 2
         :end-col 28}
-       {:filename (h/file-path "/c.cljs")
+       {:uri (h/file-uri "file:///c.cljs")
         :level :info
         :type :clojure-lsp/unused-public-var
         :message "Unused public keyword ':otherthing'"
@@ -170,8 +170,8 @@
       @findings))
   (testing "var marked ^:export is excluded"
     (reset! findings [])
-    (f.diagnostic/custom-lint-file!
-      (h/file-path "/d.cljs")
+    (f.diagnostic/custom-lint-uris!
+      [(h/file-uri "file:///d.cljs")]
       (h/db)
       {:reg-finding! #(swap! findings conj %)
        :config {}})
@@ -349,7 +349,7 @@
         (h/load-code-and-locs code h/default-uri (assoc (h/components)
                                                         :diagnostics-chan mock-diagnostics-chan))
         (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
-          (is (= (h/file-uri "file:///a.clj") uri))
+          (is (= h/default-uri uri))
           (is (= ["user/foo is called with 2 args but expects 1"]
                  (map :message diagnostics))))))
     (testing "for schema defs"
@@ -365,7 +365,7 @@
         (h/load-code-and-locs code h/default-uri (assoc (h/components)
                                                         :diagnostics-chan mock-diagnostics-chan))
         (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
-          (is (= (h/file-uri "file:///a.clj") uri))
+          (is (= h/default-uri uri))
           (is (= ["user/foo is called with 0 args but expects 2"
                   "user/foo is called with 1 arg but expects 2"]
                  (map :message diagnostics)))))))

--- a/lib/test/clojure_lsp/features/linked_editing_range_test.clj
+++ b/lib/test/clojure_lsp/features/linked_editing_range_test.clj
@@ -25,9 +25,9 @@
       {:ranges [{:start {:line 2, :character 6}, :end {:line 2, :character 9}}
                 {:start {:line 4, :character 1}, :end {:line 4, :character 4}}
                 {:start {:line 6, :character 0}, :end {:line 6, :character 3}}]}
-      (f.linked-editing-range/ranges (h/file-uri "file:///a.clj") 5 2 (h/db))))
+      (f.linked-editing-range/ranges h/default-uri 5 2 (h/db))))
   (testing "when some reference is on another file"
     (h/assert-submap
       {:error {:code :invalid-params
                :message "There are references on other files for this symbol"}}
-      (f.linked-editing-range/ranges (h/file-uri "file:///a.clj") 6 2 (h/db)))))
+      (f.linked-editing-range/ranges h/default-uri 6 2 (h/db)))))

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -30,7 +30,7 @@
     (let [mock-diagnostics-chan (async/chan 1)]
       (h/load-code-and-locs "(ns a) (when)" h/default-uri (assoc (h/components)
                                                                  :diagnostics-chan mock-diagnostics-chan))
-      (is (some? (get-in (h/db) [:analysis (h/file-path "/a.clj")])))
+      (is (some? (get-in (h/db) [:analysis (h/file-uri "file:///a.clj")])))
       (let [{:keys [uri diagnostics]} (h/take-or-timeout mock-diagnostics-chan 500)]
         (is (= (h/file-uri "file:///a.clj") uri))
         (h/assert-submaps
@@ -51,7 +51,7 @@
                            :end {:line 999998, :character 999998}}
                    :new-text "(ns foo.bar)"}]}]
         (:document-changes (h/take-or-timeout mock-edits-chan 500)))
-      (is (some? (get-in (h/db) [:analysis (h/file-path "/project/src/foo/bar.clj")])))))
+      (is (some? (get-in (h/db) [:analysis (h/file-uri "file:///project/src/foo/bar.clj")])))))
   (testing "opening a new edn file not adding the ns"
     (h/reset-components!)
     (swap! (h/db*) merge {:settings {:auto-add-ns-to-new-files? true
@@ -62,7 +62,7 @@
       (h/load-code-and-locs "" (h/file-uri "file:///project/src/foo/baz.edn") (assoc (h/components)
                                                                                      :edits-chan mock-edits-chan))
       (h/assert-no-take mock-edits-chan 500)
-      (is (some? (get-in (h/db) [:analysis (h/file-path "/project/src/foo/baz.edn")]))))))
+      (is (some? (get-in (h/db) [:analysis (h/file-uri "file:///project/src/foo/baz.edn")]))))))
 
 (deftest document-symbol
   (let [code "(ns a) (def bar ::bar) (def ^:m baz 1) (defmulti mult identity) (defmethod mult \"foo\")"

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -651,10 +651,6 @@
       {:ns nil, :name "unregistered-kw", :uri (h/file-uri "file:///aaa.clj"), :bucket :keyword-usages}
       (q/find-definition-from-cursor db (h/file-uri "file:///aaa.clj") unreg-kw-r unreg-kw-c))))
 
-;; TODO: We need tests of finding java-class-definitions. The below issue has
-;; been fixed, but the tests still don't work because the analysis of the .java
-;; file doesn't include a java-class-definition. Why not?
-
 (deftest find-clojure-definition-of-imported-java-class-usage
   (h/load-code-and-locs (h/code "(ns my.fabulous-namespace)"
                                 "(defrecord SomeRecord [foo bar])"

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -12,7 +12,7 @@
     (h/reset-components!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
-    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "zipfile:///some.jar::some-file.clj"))
     (is (= 2 (count (q/internal-analysis (h/db))))))
   (testing "when dependency-scheme is jar"
     (swap! (h/db*) shared/deep-merge {:settings {:dependency-scheme "jar"}})
@@ -26,9 +26,10 @@
     (h/reset-components!)
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
-    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "zipfile:///some.jar::some-file.clj"))
     (is (= 1 (count (q/external-analysis (h/db))))))
   (testing "when dependency-scheme is jar"
+    (h/reset-components!)
     (swap! (h/db*) shared/deep-merge {:settings {:dependency-scheme "jar"}})
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
@@ -101,23 +102,23 @@
 (deftest find-last-order-by-project-analysis
   (testing "with pred that applies for both project and external analysis"
     (h/reset-components!)
-    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "zipfile:///some.jar::some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (let [element (#'q/find-last-order-by-project-analysis
                    (comp q/xf-analysis->namespace-definitions
                          (q/xf-same-name 'foo.bar))
                    (h/db))]
-      (is (= (h/file-path "/a.clj") (:filename element)))))
+      (is (= (h/file-uri "file:///a.clj") (:uri element)))))
   (testing "with pred that applies for both project and external analysis with multiple on project"
     (h/reset-components!)
-    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "jar:file:///some.jar!/some-file.clj"))
+    (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "zipfile:///some.jar::some-file.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///a.clj"))
     (h/load-code-and-locs "(ns foo.bar)" (h/file-uri "file:///b.clj"))
     (let [element (#'q/find-last-order-by-project-analysis
                    (comp q/xf-analysis->namespace-definitions
                          (q/xf-same-name 'foo.bar))
                    (h/db))]
-      (is (= (h/file-path "/b.clj") (:filename element))))))
+      (is (= (h/file-uri "file:///b.clj") (:uri element))))))
 
 (deftest find-element-under-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -131,16 +132,16 @@
         db (h/db)]
     (h/assert-submap
       '{:alias f-alias}
-      (q/find-element-under-cursor db (h/file-path "/a.clj") alias-r alias-c))
+      (q/find-element-under-cursor db (h/file-uri "file:///a.clj") alias-r alias-c))
     (h/assert-submap
       '{:name x}
-      (q/find-element-under-cursor db (h/file-path "/a.clj") x-r x-c))
+      (q/find-element-under-cursor db (h/file-uri "file:///a.clj") x-r x-c))
     (h/assert-submap
       '{:name filename}
-      (q/find-element-under-cursor db (h/file-path "/a.clj") param-r param-c))
+      (q/find-element-under-cursor db (h/file-uri "file:///a.clj") param-r param-c))
     (h/assert-submap
       '{:name unknown}
-      (q/find-element-under-cursor db (h/file-path "/a.clj") unknown-r unknown-c))))
+      (q/find-element-under-cursor db (h/file-uri "file:///a.clj") unknown-r unknown-c))))
 
 (deftest find-references-from-cursor
   (let [a-code (h/code "(ns a.b.c (:require [d.e.f :as |f-alias]))"
@@ -167,30 +168,30 @@
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.clj") x-r x-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.clj") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.clj") param-r param-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.clj") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor db (h/file-path "/a.clj") unknown-r unknown-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.clj") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.clj") alias-r alias-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.clj") alias-r alias-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-foo-kw-r :name-col a-foo-kw-c}
        {:name "foo-kw" :name-row b-foo-kw-r :name-col b-foo-kw-c}
        {:name "foo-kw" :name-row d-foo-kw-r :name-col d-foo-kw-c}
        {:name "foo-kw" :name-row c-foo-kw-r :name-col c-foo-kw-c}]
-      (q/find-references-from-cursor db (h/file-path "/c.clj") b-foo-kw-r b-foo-kw-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///c.clj") b-foo-kw-r b-foo-kw-c true))
     (h/assert-submaps
       [{:name "foo-kw" :name-row a-baz-kw-r :name-col a-baz-kw-c :ns :clj-kondo/unknown-namespace}]
-      (q/find-references-from-cursor db (h/file-path "/baz.clj") a-baz-kw-r a-baz-kw-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///baz.clj") a-baz-kw-r a-baz-kw-c true))
     (h/assert-submaps
       [{:name "baz-kw" :name-row b-baz-kw-r :name-col b-baz-kw-c :ns 'baz}]
-      (q/find-references-from-cursor db (h/file-path "/baz.clj") b-baz-kw-r b-baz-kw-c true))))
+      (q/find-references-from-cursor db (h/file-uri "file:///baz.clj") b-baz-kw-r b-baz-kw-c true))))
 
 (deftest find-references-from-cursor-cljc
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -207,18 +208,18 @@
     (h/assert-submaps
       [{:name 'x :name-row x-r :name-col x-c}
        {:name 'x :name-row x-use-r :name-col x-use-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.cljc") x-r x-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.cljc") x-r x-c true))
     (h/assert-submaps
       [{:name 'filename :name-row param-r :name-col param-c}
        {:name 'filename :name-row param-use-r :name-col param-use-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.cljc") param-r param-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.cljc") param-r param-c true))
     (h/assert-submaps
       ['{:name unknown}]
-      (q/find-references-from-cursor db (h/file-path "/a.cljc") unknown-r unknown-c true))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.cljc") unknown-r unknown-c true))
     (h/assert-submaps
       [{:alias 'f-alias :name-row alias-r :name-col alias-c}
        {:alias 'f-alias :name 'foo :name-row alias-use-r :name-col alias-use-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.cljc") alias-r alias-c true))))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.cljc") alias-r alias-c true))))
 
 (deftest find-references-from-namespace-definition
   (let [[[ns-def-r ns-def-c]] (h/load-code-and-locs (h/code "(ns |some.cool-ns) (def foo 1)"))
@@ -227,11 +228,11 @@
                                 (h/file-uri "file:///b.clj"))
         _ (h/load-code-and-locs (h/code "(ns |another.cool-ns) :some.cool-ns/bar")
                                 (h/file-uri "file:///c.clj"))
-        common-references [{:filename (h/file-path "/b.clj")
+        common-references [{:uri (h/file-uri "file:///b.clj")
                             :bucket :namespace-usages
                             :name 'some.cool-ns
                             :from 'other.cool-ns}
-                           {:filename (h/file-path "/c.clj")
+                           {:uri (h/file-uri "file:///c.clj")
                             :bucket :keyword-usages
                             :from 'another.cool-ns
                             :name "bar"
@@ -239,14 +240,14 @@
     (testing "from ns definition"
       (h/assert-submaps
         common-references
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") ns-def-r ns-def-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") ns-def-r ns-def-c false)))
     (testing "Including definition"
       (h/assert-submaps
-        (concat [{:filename (h/file-path "/a.clj")
+        (concat [{:uri (h/file-uri "file:///a.clj")
                   :name 'some.cool-ns
                   :bucket :namespace-definitions}]
                 common-references)
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") ns-def-r ns-def-c true)))))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") ns-def-r ns-def-c true)))))
 
 (deftest find-references-from-namespace-usage
   (let [_ (h/load-code-and-locs (h/code "(ns some.cool-ns) (def foo 1)"))
@@ -257,16 +258,16 @@
                                 (h/file-uri "file:///c.clj"))]
     (testing "from ns usage"
       (h/assert-submaps
-        [{:filename (h/file-path "/b.clj")
+        [{:uri (h/file-uri "file:///b.clj")
           :bucket :namespace-usages
           :name 'some.cool-ns
           :from 'other.cool-ns}
-         {:filename (h/file-path "/c.clj")
+         {:uri (h/file-uri "file:///c.clj")
           :bucket :keyword-usages
           :from 'another.cool-ns
           :name "bar"
           :ns 'some.cool-ns}]
-        (q/find-references-from-cursor (h/db) (h/file-path "/b.clj") usage-r usage-c false)))))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///b.clj") usage-r usage-c false)))))
 
 (deftest find-references-from-defrecord
   (let [code (str "(defrecord |MyRecord [])\n"
@@ -282,7 +283,7 @@
       [{:name 'MyRecord :bucket :var-usages :name-row raw-r :name-col raw-c}
        {:name '->MyRecord :bucket :var-usages :name-row to-r :name-col to-c}
        {:name 'map->MyRecord :bucket :var-usages :name-row map-to-r :name-col map-to-c}]
-      (q/find-references-from-cursor db (h/file-path "/a.clj") def-r def-c false))))
+      (q/find-references-from-cursor db (h/file-uri "file:///a.clj") def-r def-c false))))
 
 (deftest find-references-excluding-function-different-arity
   (let [a-code (h/code "(ns a)"
@@ -303,45 +304,45 @@
       (h/assert-submaps
         #{{:name-row 6
            :name 'bar
-           :filename (h/file-path "/a.clj")
+           :uri (h/file-uri "file:///a.clj")
            :name-col 2
            :bucket :var-usages}
           {:name-row 4
            :name 'bar
-           :filename (h/file-path "/b.clj")
+           :uri (h/file-uri "file:///b.clj")
            :from 'b
            :name-col 4
            :from-var 'bar}}
 
-        (q/find-references-from-cursor db (h/file-path "/a.clj") bar-def-r bar-def-c false)))
+        (q/find-references-from-cursor db (h/file-uri "file:///a.clj") bar-def-r bar-def-c false)))
     (testing "from usage"
       (h/assert-contains-submaps
         #{{:name-row 6
            :name 'bar
-           :filename (h/file-path "/a.clj")
+           :uri (h/file-uri "file:///a.clj")
            :name-col 2
            :bucket :var-usages}
           {:name-row 4
            :name 'bar
-           :filename (h/file-path "/b.clj")
+           :uri (h/file-uri "file:///b.clj")
            :from 'b
            :name-col 4
            :from-var 'bar}}
-        (q/find-references-from-cursor db (h/file-path "/a.clj") bar-usa-r bar-usa-c false)))
+        (q/find-references-from-cursor db (h/file-uri "file:///a.clj") bar-usa-r bar-usa-c false)))
     (testing "from other ns"
       (h/assert-contains-submaps
         #{{:name-row 6
            :name 'bar
-           :filename (h/file-path "/a.clj")
+           :uri (h/file-uri "file:///a.clj")
            :name-col 2
            :bucket :var-usages}
           {:name-row 4
            :name 'bar
-           :filename (h/file-path "/b.clj")
+           :uri (h/file-uri "file:///b.clj")
            :from 'b
            :name-col 4
            :from-var 'bar}}
-        (q/find-references-from-cursor db (h/file-path "/b.clj") bar-usa-b-r bar-usa-b-c false)))))
+        (q/find-references-from-cursor db (h/file-uri "file:///b.clj") bar-usa-b-r bar-usa-b-c false)))))
 
 (deftest find-references-from-protocol-impl
   (h/load-code-and-locs (h/code "(ns a)"
@@ -361,20 +362,20 @@
       [{:row 8 :col 1 :end-row 8 :end-col 27
         :name-row 8 :name-end-col 13 :name-col 2 :name-end-row 8
         :name 'something
-        :filename (h/file-path "/b.clj")
+        :uri (h/file-uri "file:///b.clj")
         :alias 'f
         :from 'b
         :bucket :var-usages
         :to 'a}
        {:name-col 2 :name-row 9 :name-end-row 9 :name-end-col 13
         :name 'something
-        :filename (h/file-path "/b.clj")
+        :uri (h/file-uri "file:///b.clj")
         :alias 'f
         :from 'b
         :row 9 :col 1 :end-row 9 :end-col 27
         :bucket :var-usages
         :to 'a}]
-      (q/find-references-from-cursor (h/db) (h/file-path "/b.clj") 7 9 false))))
+      (q/find-references-from-cursor (h/db) (h/file-uri "file:///b.clj") 7 9 false))))
 
 (deftest find-references-for-defmulti
   (let [[[defmulti-r defmulti-c]]
@@ -391,7 +392,7 @@
                     {:name-row 2 :name-col 12 :name-end-row 2 :name-end-col 22
                      :row 2 :col 12 :end-row 2 :end-col 22
                      :name 'my-multi
-                     :filename (h/file-path "/b.clj")
+                     :uri (h/file-uri "file:///b.clj")
                      :alias 'f
                      :from 'b
                      :bucket :var-usages
@@ -401,7 +402,7 @@
                     {:name-row 5 :name-col 2 :name-end-row 5 :name-end-col 12
                      :row 5 :col 1 :end-row 5 :end-col 31
                      :name 'my-multi
-                     :filename (h/file-path "/b.clj")
+                     :uri (h/file-uri "file:///b.clj")
                      :alias 'f
                      :from 'b
                      :arity 1
@@ -410,15 +411,15 @@
     (testing "from defmulti method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") defmulti-r defmulti-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") defmulti-r defmulti-c false)))
     (testing "from defmethod method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (h/db) (h/file-path "/b.clj") defmethod-r defmethod-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///b.clj") defmethod-r defmethod-c false)))
     (testing "from usage name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (h/db) (h/file-path "/b.clj") usage-r usage-c false)))))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///b.clj") usage-r usage-c false)))))
 
 (deftest find-references-for-defmulti-without-usages
   (let [[[defmulti-r defmulti-c]]
@@ -433,7 +434,7 @@
                     {:name-row 2 :name-col 12 :name-end-row 2 :name-end-col 22
                      :row 2 :col 12 :end-row 2 :end-col 22
                      :name 'my-multi
-                     :filename (h/file-path "/b.clj")
+                     :uri (h/file-uri "file:///b.clj")
                      :alias 'f
                      :from 'b
                      :bucket :var-usages
@@ -442,11 +443,11 @@
     (testing "from defmulti method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") defmulti-r defmulti-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") defmulti-r defmulti-c false)))
     (testing "from defmethod method name"
       (h/assert-submaps
         references
-        (q/find-references-from-cursor (h/db) (h/file-path "/b.clj") defmethod-r defmethod-c false)))))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///b.clj") defmethod-r defmethod-c false)))))
 
 (deftest find-references-from-declare
   (let [[[declare-r declare-c]
@@ -459,22 +460,22 @@
         usage-element {:name-row 4 :name-col 6 :name-end-row 4 :name-end-col 17
                        :row 4 :col 6 :end-row 4 :end-col 17
                        :name 'my-declared
-                       :filename (h/file-path "/a.clj")
+                       :uri (h/file-uri "file:///a.clj")
                        :from 'a
                        :bucket :var-usages
                        :to 'a}]
     (testing "from declare"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") declare-r declare-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") declare-r declare-c false)))
     (testing "from def"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") def-r def-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") def-r def-c false)))
     (testing "from usage name"
       (h/assert-submaps
         [usage-element]
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") usage-r usage-c false)))))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") usage-r usage-c false)))))
 
 (deftest find-references-from-declare-without-usages
   (let [[[declare-r declare-c]
@@ -485,11 +486,11 @@
     (testing "from declare"
       (h/assert-submaps
         '[]
-        (q/find-references-from-cursor (h/db) (h/file-path "/a.clj") declare-r declare-c false)))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///a.clj") declare-r declare-c false)))
     (testing "from def"
       (h/assert-submaps
         '[]
-        (q/find-references-from-cursor (h/db) (h/file-path "/b.clj") def-r def-c false)))))
+        (q/find-references-from-cursor (h/db) (h/file-uri "file:///b.clj") def-r def-c false)))))
 
 (deftest find-definition-from-cursor
   (let [code (str "(ns a.b.c (:require [d.e.f :as |f-alias]))\n"
@@ -506,28 +507,28 @@
         db (h/db)]
     (h/assert-submap
       {:name 'x :name-row x-r :name-col x-c}
-      (q/find-definition-from-cursor db (h/file-path "/a.clj") x-use-r x-use-c))
+      (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") x-use-r x-use-c))
     (h/assert-submap
       {:name 'filename :name-row param-r :name-col param-c}
-      (q/find-definition-from-cursor db (h/file-path "/a.clj") param-use-r param-use-c))
+      (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") param-use-r param-use-c))
     (is (= nil
-           (q/find-definition-from-cursor db (h/file-path "/a.clj") unknown-r unknown-c)))
+           (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") unknown-r unknown-c)))
     (h/assert-submap
-      {:name 'foo :filename (h/file-path "/b.clj") :ns 'd.e.f}
-      (q/find-definition-from-cursor db (h/file-path "/a.clj") alias-use-r alias-use-c))
+      {:name 'foo :uri (h/file-uri "file:///b.clj") :ns 'd.e.f}
+      (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") alias-use-r alias-use-c))
     (h/assert-submap
       {:name 'd.e.f :bucket :namespace-definitions}
-      (q/find-definition-from-cursor db (h/file-path "/a.clj") alias-r alias-c))))
+      (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") alias-r alias-c))))
 
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
-  (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "jar:file:///some.jar!/some-jar.clj")
+  (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "zipfile:///some.jar::some-jar.clj")
         _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "file:///a.clj"))
         [[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                       "|f/bar") (h/file-uri "file:///b.clj"))
         db (h/db)]
     (h/assert-submap
-      {:name 'bar :filename (h/file-path "/a.clj")}
-      (q/find-definition-from-cursor db (h/file-path "/b.clj") bar-r bar-c))))
+      {:name 'bar :uri (h/file-uri "file:///a.clj")}
+      (q/find-definition-from-cursor db (h/file-uri "file:///b.clj") bar-r bar-c))))
 
 (defn assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs []
   (testing "when on a clj file"
@@ -535,22 +536,22 @@
                                                         "|f/bar") (h/file-uri "file:///b.clj"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor db (h/file-path "/b.clj") bar-r bar-c))))
+        {:name 'bar :uri (h/file-uri "zipfile:///some.jar::some-jar.clj")}
+        (q/find-definition-from-cursor db (h/file-uri "file:///b.clj") bar-r bar-c))))
   (testing "when on a cljs file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.cljs"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
-        (q/find-definition-from-cursor db (h/file-path "/b.cljs") bar-r bar-c))))
+        {:name 'bar :uri (h/file-uri "zipfile:///some.jar::other-jar.cljs")}
+        (q/find-definition-from-cursor db (h/file-uri "file:///b.cljs") bar-r bar-c))))
   (testing "when on a cljc file"
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns baz (:require [foo :as f]))"
                                                         "|f/bar") (h/file-uri "file:///b.cljc"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r bar-c))))
+        {:name 'bar :uri (h/file-uri "zipfile:///some.jar::some-jar.clj")}
+        (q/find-definition-from-cursor db (h/file-uri "file:///b.cljc") bar-r bar-c))))
   (testing "when on a cljc file with multiple langs available"
     (let [[[bar-r-clj bar-c-clj]
            [bar-r-cljs bar-c-cljs]] (h/load-code-and-locs (h/code "(ns baz #?(:clj (:require [foo :as fc]) :cljs (:require [foo :as fs])))"
@@ -558,11 +559,11 @@
                                                                   "|fs/bar") (h/file-uri "file:///b.cljc"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some.jar:some-jar.clj")}
-        (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r-clj bar-c-clj))
+        {:name 'bar :uri (h/file-uri "zipfile:///some.jar::some-jar.clj")}
+        (q/find-definition-from-cursor db (h/file-uri "file:///b.cljc") bar-r-clj bar-c-clj))
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some.jar:other-jar.cljs")}
-        (q/find-definition-from-cursor db (h/file-path "/b.cljc") bar-r-cljs bar-c-cljs))))
+        {:name 'bar :uri (h/file-uri "zipfile:///some.jar::other-jar.cljs")}
+        (q/find-definition-from-cursor db (h/file-uri "file:///b.cljc") bar-r-cljs bar-c-cljs))))
   (testing "when a macro is require-macros on cljs, being the var-definition on a clj/cljc file."
     (h/reset-components!)
     (h/load-code-and-locs (h/code "(ns some.foo) (defmacro bar [& body] @body)") (h/file-uri "file:///some/foo.clj"))
@@ -570,17 +571,17 @@
     (let [[[bar-r bar-c]] (h/load-code-and-locs (h/code "(ns a (:require [some.foo :as f])) (f/|bar 1)") (h/file-uri "file:///a.cljs"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/some/foo.clj")}
-        (q/find-definition-from-cursor db (h/file-path "/a.cljs") bar-r bar-c)))))
+        {:name 'bar :uri (h/file-uri "file:///some/foo.clj")}
+        (q/find-definition-from-cursor db (h/file-uri "file:///a.cljs") bar-r bar-c)))))
 
 (deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs
-  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
-  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "zipfile:///some.jar::some-jar.clj"))
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "zipfile:///some.jar::other-jar.cljs"))
   (assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs))
 
 (deftest find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs-in-other-load-order
-  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/other-jar.cljs"))
-  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "jar:file:///some.jar!/some-jar.clj"))
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "zipfile:///some.jar::other-jar.cljs"))
+  (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "zipfile:///some.jar::some-jar.clj"))
   (assert-find-definition-from-cursor-when-it-has-same-namespace-from-clj-and-cljs))
 
 (deftest find-definition-from-cursor-when-declared
@@ -593,8 +594,8 @@
                                  "(defn |bar [] 1)") (h/file-uri "file:///a.clj"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/a.clj") :defined-by 'clojure.core/defn :row defn-r}
-        (q/find-definition-from-cursor db (h/file-path "/a.clj") usage-r usage-c))))
+        {:name 'bar :uri (h/file-uri "file:///a.clj") :defined-by 'clojure.core/defn :row defn-r}
+        (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") usage-r usage-c))))
   (testing "only declared"
     (let [[[decl-r _]
            [usage-r usage-c]] (h/load-code-and-locs
@@ -603,16 +604,16 @@
                                         "(|bar)") (h/file-uri "file:///a.clj"))
           db (h/db)]
       (h/assert-submap
-        {:name 'bar :filename (h/file-path "/a.clj") :defined-by 'clojure.core/declare :row decl-r}
-        (q/find-definition-from-cursor db (h/file-path "/a.clj") usage-r usage-c)))))
+        {:name 'bar :uri (h/file-uri "file:///a.clj") :defined-by 'clojure.core/declare :row decl-r}
+        (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") usage-r usage-c)))))
 
 (deftest find-definition-from-namespace-alias
   (h/load-code-and-locs (h/code "(ns foo.bar) (def a 1)") (h/file-uri "file:///a.clj"))
   (let [[[foob-r foob-c]] (h/load-code-and-locs (h/code "(ns foo.baz (:require [foo.bar :as |foob]))") (h/file-uri "file:///b.clj"))
         db (h/db)]
     (h/assert-submap
-      {:name-end-col 12 :name-end-row 1 :name-row 1 :name 'foo.bar :filename (h/file-path "/a.clj") :col 1 :name-col 5 :bucket :namespace-definitions :row 1}
-      (q/find-definition-from-cursor db (h/file-path "/b.clj") foob-r foob-c))))
+      {:name-end-col 12 :name-end-row 1 :name-row 1 :name 'foo.bar :uri (h/file-uri "file:///a.clj") :col 1 :name-col 5 :bucket :namespace-definitions :row 1}
+      (q/find-definition-from-cursor db (h/file-uri "file:///b.clj") foob-r foob-c))))
 
 (deftest find-definition-from-cursor-when-on-potemkin
   (h/load-code-and-locs (h/code "(ns foo.impl) (def bar)") (h/file-uri "file:///b.clj"))
@@ -623,8 +624,8 @@
                                   "(import-vars |impl/bar)") (h/file-uri "file:///a.clj"))
         db (h/db)]
     (h/assert-submap
-      {:name 'bar :filename (h/file-path "/b.clj") :defined-by 'clojure.core/def :row 1 :col 15}
-      (q/find-definition-from-cursor db (h/file-path "/a.clj") bar-r bar-c))))
+      {:name 'bar :uri (h/file-uri "file:///b.clj") :defined-by 'clojure.core/def :row 1 :col 15}
+      (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") bar-r bar-c))))
 
 (deftest find-definition-from-keyword-usage
   (h/load-code-and-locs (h/code "(ns bbb (:require [re-frame.core :as r]))"
@@ -641,14 +642,18 @@
                               (h/file-uri "file:///aaa.clj"))
         db (h/db)]
     (h/assert-submap
-      {:ns 'namespaced, :name "kw", :filename (h/file-path "/bbb.clj"), :bucket :keyword-definitions}
-      (q/find-definition-from-cursor db (h/file-path "/aaa.clj") ns-kw-r ns-kw-c))
+      {:ns 'namespaced, :name "kw", :uri (h/file-uri "file:///bbb.clj"), :bucket :keyword-definitions}
+      (q/find-definition-from-cursor db (h/file-uri "file:///aaa.clj") ns-kw-r ns-kw-c))
     (h/assert-submap
-      {:ns nil, :name "simple-kw", :filename (h/file-path "/bbb.clj"), :bucket :keyword-definitions}
-      (q/find-definition-from-cursor db (h/file-path "/aaa.clj") simple-kw-r simple-kw-c))
+      {:ns nil, :name "simple-kw", :uri (h/file-uri "file:///bbb.clj"), :bucket :keyword-definitions}
+      (q/find-definition-from-cursor db (h/file-uri "file:///aaa.clj") simple-kw-r simple-kw-c))
     (h/assert-submap
-      {:ns nil, :name "unregistered-kw", :filename (h/file-path "/aaa.clj"), :bucket :keyword-usages}
-      (q/find-definition-from-cursor db (h/file-path "/aaa.clj") unreg-kw-r unreg-kw-c))))
+      {:ns nil, :name "unregistered-kw", :uri (h/file-uri "file:///aaa.clj"), :bucket :keyword-usages}
+      (q/find-definition-from-cursor db (h/file-uri "file:///aaa.clj") unreg-kw-r unreg-kw-c))))
+
+;; TODO: We need tests of finding java-class-definitions. The below issue has
+;; been fixed, but the tests still don't work because the analysis of the .java
+;; file doesn't include a java-class-definition. Why not?
 
 (deftest find-clojure-definition-of-imported-java-class-usage
   (h/load-code-and-locs (h/code "(ns my.fabulous-namespace)"
@@ -671,14 +676,14 @@
           expected {:ns 'my.fabulous-namespace
                     :name 'SomeRecord
                     :defined-by 'clojure.core/defrecord
-                    :filename (h/file-path "/project/my/fabulous_namespace.clj")
+                    :uri (h/file-uri "file:///project/my/fabulous_namespace.clj")
                     :bucket :var-definitions}]
       (h/assert-submap
         expected
-        (q/find-definition-from-cursor (h/db) (h/file-path "/project/my/other_namespace.clj") from-ns-row from-ns-col))
+        (q/find-definition-from-cursor (h/db) (h/file-uri "file:///project/my/other_namespace.clj") from-ns-row from-ns-col))
       (h/assert-submap
         expected
-        (q/find-definition-from-cursor (h/db) (h/file-path "/project/my/other_namespace.clj") from-defrecord-row from-defrecord-col)))))
+        (q/find-definition-from-cursor (h/db) (h/file-uri "file:///project/my/other_namespace.clj") from-defrecord-row from-defrecord-col)))))
 
 (deftest find-declaration-from-cursor
   (h/load-code-and-locs (h/code "(ns foo.baz) (def other 123)"))
@@ -702,7 +707,7 @@
          :bucket
          :namespace-alias
          :to 'foo.bar}
-        (q/find-declaration-from-cursor db (h/file-path "/b.clj") something-r something-c)))
+        (q/find-declaration-from-cursor db (h/file-uri "file:///b.clj") something-r something-c)))
     (testing "from usage with refer"
       (h/assert-submap
         '{:from sample
@@ -710,14 +715,14 @@
           :name orange
           :bucket :var-usages
           :refer true}
-        (q/find-declaration-from-cursor db (h/file-path "/b.clj") orange-r orange-c)))
+        (q/find-declaration-from-cursor db (h/file-uri "file:///b.clj") orange-r orange-c)))
     (testing "from usage with refer all"
       (h/assert-submap
         {:from 'sample
          :bucket
          :namespace-usages
          :name 'foo.baz}
-        (q/find-declaration-from-cursor db (h/file-path "/b.clj") other-r other-c)))))
+        (q/find-declaration-from-cursor db (h/file-uri "file:///b.clj") other-r other-c)))))
 
 (deftest find-declaration-from-cursor-in-cljc
   (let [[[clj-ns-r clj-ns-c]
@@ -738,7 +743,7 @@
          :bucket :namespace-usages
          :row clj-ns-r
          :col clj-ns-c}
-        (q/find-declaration-from-cursor db (h/file-path "/b.cljc") clj-usage-r clj-usage-c)))
+        (q/find-declaration-from-cursor db (h/file-uri "file:///b.cljc") clj-usage-r clj-usage-c)))
     (testing "from cljs usage"
       (h/assert-submap
         {:name 'foo
@@ -746,7 +751,7 @@
          :bucket :namespace-usages
          :row cljs-ns-r
          :col cljs-ns-c}
-        (q/find-declaration-from-cursor db (h/file-path "/b.cljc") cljs-usage-r cljs-usage-c)))))
+        (q/find-declaration-from-cursor db (h/file-uri "file:///b.cljc") cljs-usage-r cljs-usage-c)))))
 
 (deftest find-implementations-from-cursor-protocols
   (h/load-code-and-locs (h/code "(ns a)"
@@ -787,7 +792,7 @@
          :from-var make-foo
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (h/db) (h/file-path "/a.clj") 2 16)))
+      (q/find-implementations-from-cursor (h/db) (h/file-uri "file:///a.clj") 2 16)))
   (testing "from protocol method definitions"
     (h/assert-submaps
       [{:impl-ns 'b
@@ -813,9 +818,9 @@
         :method-name 'something
         :defined-by 'clojure.core/reify
         :protocol-name 'Foo
-        :filename (h/file-path "/b.clj")
+        :uri (h/file-uri "file:///b.clj")
         :bucket :protocol-impls}]
-      (q/find-implementations-from-cursor (h/db) (h/file-path "/a.clj") 3 4)))
+      (q/find-implementations-from-cursor (h/db) (h/file-uri "file:///a.clj") 3 4)))
   (testing "from implementation usage"
     (h/assert-submaps
       [{:impl-ns 'b
@@ -841,9 +846,9 @@
         :method-name 'something
         :defined-by 'clojure.core/reify
         :protocol-name 'Foo
-        :filename (h/file-path "/b.clj")
+        :uri (h/file-uri "file:///b.clj")
         :bucket :protocol-impls}]
-      (q/find-implementations-from-cursor (h/db) (h/file-path "/b.clj") 9 2))))
+      (q/find-implementations-from-cursor (h/db) (h/file-uri "file:///b.clj") 9 2))))
 
 (deftest find-implementations-from-cursor-defmulti
   (h/load-code-and-locs (h/code "(ns a)"
@@ -875,7 +880,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (h/db) (h/file-path "/a.clj") 2 12)))
+      (q/find-implementations-from-cursor (h/db) (h/file-uri "file:///a.clj") 2 12)))
   (testing "from defmethod declaration"
     (h/assert-submaps
       '[{:name foo
@@ -894,7 +899,7 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (h/db) (h/file-path "/b.clj") 2 13)))
+      (q/find-implementations-from-cursor (h/db) (h/file-uri "file:///b.clj") 2 13)))
   (testing "from defmethod usage"
     (h/assert-submaps
       '[{:name foo
@@ -913,151 +918,151 @@
          :from b
          :bucket :var-usages
          :to a}]
-      (q/find-implementations-from-cursor (h/db) (h/file-path "/b.clj") 8 2))))
+      (q/find-implementations-from-cursor (h/db) (h/file-uri "file:///b.clj") 8 2))))
 
 (deftest find-unused-aliases
   (testing "clj"
     (testing "used require via alias"
       (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo")
       (is (= '#{}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.clj")))))
     (testing "used require via full-ns"
       (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo")
       (is (= '#{}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.clj")))))
     (testing "full-ns require"
       (h/load-code-and-locs "(ns a (:require [x] y)) foo")
       (is (= '#{}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.clj")))))
     (testing "single unused-alias"
       (h/load-code-and-locs "(ns a (:require [x :as f]))")
       (is (= '#{x}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.clj")))))
     (testing "used and unused aliases"
       (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o")
       (is (= '#{y bar}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.clj"))))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.clj"))))))
   (testing "cljc"
     (testing "used require via alias"
       (h/load-code-and-locs "(ns a (:require [x :as f])) f/foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "used require via full-ns"
       (h/load-code-and-locs "(ns a (:require [x :as f])) x/foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "full-ns require"
       (h/load-code-and-locs "(ns a (:require [x] y)) foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "single unused-alias"
       (h/load-code-and-locs "(ns a (:require [x :as f]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{x}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "used and unused aliases"
       (h/load-code-and-locs "(ns a (:require [x :as f] [foo] x [bar :as b] [y :refer [m]] [z :refer [o i]])) o" (h/file-uri "file:///a.cljc"))
       (is (= '#{y bar}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "used alias in a reader conditional"
       (h/load-code-and-locs "(ns a (:require [y :as o] [x :as f])) #?(:clj f/foo)" (h/file-uri "file:///a.cljc"))
       (is (= '#{y}
-             (q/find-unused-aliases (h/db) (h/file-path "/a.cljc")))))))
+             (q/find-unused-aliases (h/db) (h/file-uri "file:///a.cljc")))))))
 
 (deftest find-unused-refers
   (testing "clj"
     (testing "used require via refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo")
       (is (= '#{}
-             (q/find-unused-refers (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.clj")))))
     (testing "multiple used refers"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz")
       (is (= '#{}
-             (q/find-unused-refers (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.clj")))))
     (testing "single unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))")
       (is (= '#{x/foo}
-             (q/find-unused-refers (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.clj")))))
     (testing "multiple unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))")
       (is (= '#{x/foo x/bar}
-             (q/find-unused-refers (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.clj")))))
     (testing "multiple unused refer and used"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar")
       (is (= '#{x/foo x/baz}
-             (q/find-unused-refers (h/db) (h/file-path "/a.clj"))))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.clj"))))))
   (testing "cljc"
     (testing "used require via refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]])) foo" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-refers (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "multiple used refers"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) foo bar baz" (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-refers (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "single unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo]]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{x/foo}
-             (q/find-unused-refers (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "multiple unused refer"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar]]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{x/foo x/bar}
-             (q/find-unused-refers (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "multiple unused refer and used"
       (h/load-code-and-locs "(ns a (:require [x :refer [foo bar baz]])) bar" (h/file-uri "file:///a.cljc"))
       (is (= '#{x/foo x/baz}
-             (q/find-unused-refers (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "used refer in a reader conditional"
       (h/load-code-and-locs "(ns a (:require [y :refer [o]] [x :refer [f]])) #?(:clj f)" (h/file-uri "file:///a.cljc"))
       (is (= '#{y/o}
-             (q/find-unused-refers (h/db) (h/file-path "/a.cljc")))))))
+             (q/find-unused-refers (h/db) (h/file-uri "file:///a.cljc")))))))
 
 (deftest find-unused-imports
   (testing "clj"
     (testing "single used full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date)) Date.")
       (is (= '#{}
-             (q/find-unused-imports (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.clj")))))
     (testing "single unused full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date))")
       (is (= '#{java.util.Date}
-             (q/find-unused-imports (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.clj")))))
     (testing "multiple unused full imports"
       (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))")
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.clj")))))
     (testing "multiple unused package imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))")
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.clj")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.clj")))))
     (testing "multiple unused and used imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime.")
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.clj"))))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.clj"))))))
   (testing "cljc"
     (testing "single used full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date)) Date." (h/file-uri "file:///a.cljc"))
       (is (= '#{}
-             (q/find-unused-imports (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "single unused full import"
       (h/load-code-and-locs "(ns a (:import java.util.Date))" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date}
-             (q/find-unused-imports (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "multiple unused full imports"
       (h/load-code-and-locs "(ns a (:import java.util.Date java.util.Calendar java.time.LocalDateTime))" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "multiple unused package imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalDateTime]))" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "multiple unused and used imports"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) LocalTime." (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.cljc")))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.cljc")))))
     (testing "used import in a reader conditional"
       (h/load-code-and-locs "(ns a (:import [java.util Date Calendar] [java.time LocalTime LocalDateTime])) #?(:clj LocalTime.)" (h/file-uri "file:///a.cljc"))
       (is (= '#{java.util.Date java.util.Calendar java.time.LocalDateTime}
-             (q/find-unused-imports (h/db) (h/file-path "/a.cljc")))))))
+             (q/find-unused-imports (h/db) (h/file-uri "file:///a.cljc")))))))
 
 (deftest find-local-usages-under-cursor
   (testing "inside let"
@@ -1066,7 +1071,7 @@
           (h/load-code-and-locs "(ns a) (let [a 2 b 1] |(+ 2 b)| (- 2 a))")]
       (h/assert-submaps
         [{:name 'b}]
-        (q/find-local-usages-under-form (h/db) (h/file-path "/a.clj")
+        (q/find-local-usages-under-form (h/db) (h/file-uri "file:///a.clj")
                                         {:row sum-pos-r, :col sum-pos-c
                                          :end-row sum-end-pos-r, :end-col sum-end-pos-c}))))
   (testing "inside defn"
@@ -1075,6 +1080,6 @@
           (h/load-code-and-locs "(ns a) (defn ab [b] |(let [a 1] (b a))|) (defn other [c] c)")]
       (h/assert-submaps
         [{:name 'b}]
-        (q/find-local-usages-under-form (h/db) (h/file-path "/a.clj")
+        (q/find-local-usages-under-form (h/db) (h/file-uri "file:///a.clj")
                                         {:row let-pos-r, :col let-pos-c
                                          :end-row let-end-pos-r, :end-col let-end-pos-c})))))


### PR DESCRIPTION
This does URI/filename conversion at the boundary with clj-kondo. Analysis and findings are indexed by URI. That lets most of the rest of clojure-lsp use uris, which it receives from LSP clients, without needing to convert to filenames.

I'd suggest reviewing the PR with [difftastic](https://github.com/Wilfred/difftastic) or a similar structural diffing tool—there are many renames of `filename` to `uri`, that don't have any other significant changes, but which GitHub over-emphasizes.

Fixes #1207, or at least does the bulk of the work. There are still several places where we do conversion or need filenames for some reason or another. I'll annotate those spots in the PR. There are a few things we could consider to further reduce the amount of conversion that happens:
* We could calculate `project-root-path` during init and store it in the db. There are several places that need this directory name (as opposed to `project-root-uri`, which is already stored in the db).
* We could reason through the algorithms that detect which "source-path" a file is in to decide if they could be switched from using filenames to using URIs. As an example of such an algorithm, when creating a new test file we figure out a subdirectory for it, and then generate a namespace based on that directory/filename. I think this could be done using URIs, but I'm hesitant to include further refactorings in this PR.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
