### PR TITLE
Fix MS-Windows unit test by constructing file:// URI using the  standard api

### DIFF
--- a/cli/build.clj
+++ b/cli/build.clj
@@ -63,7 +63,6 @@
                                  {:tag :headerType :attrs nil  :content ["console"]}
                                  {:tag :jar :attrs nil :content [jar]}
                                  {:tag :outfile :attrs nil :content [outfile]}
-                                 {:tag :chdir :attrs nil :content ["."]}
                                  {:tag :priority :attrs nil :content ["normal"]}
                                  {:tag :stayAlive :attrs nil :content ["false"]}
                                  {:tag :restartOnCrash :attrs nil :content ["false"]}

--- a/lib/test/clojure_lsp/feature/java_interop_test.clj
+++ b/lib/test/clojure_lsp/feature/java_interop_test.clj
@@ -21,11 +21,11 @@
   (testing "class files"
     (with-redefs [f.java-interop/decompile-file (fn [_jar entry _db]
                                                   (.getName entry))]
-      (let [test-jar-path (.getCanonicalPath (io/file (h/file-path "test/fixtures/java_interop/single-class.jar")))]
+      (let [test-jar-file-url (io/as-url (io/file "test/fixtures/java_interop/single-class.jar"))]
         (testing "jar scheme"
-          (is (= "Bar.class" (f.java-interop/uri->translated-uri (str "jar:file://" test-jar-path "!/Bar.class") (h/db) (h/producer)))))
+          (is (= "Bar.class" (f.java-interop/uri->translated-uri (str "jar:" test-jar-file-url "!/Bar.class") (h/db) (h/producer)))))
         (testing "zipfile scheme"
-          (is (= "Bar.class" (f.java-interop/uri->translated-uri (str "zipfile://" test-jar-path "::Bar.class") (h/db) (h/producer)))))))))
+          (is (= "Bar.class" (f.java-interop/uri->translated-uri (str "zip" test-jar-file-url "::Bar.class") (h/db) (h/producer)))))))))
 
 (defn ->decision [& args]
   (-> (apply #'f.java-interop/jdk-analysis-decision args)


### PR DESCRIPTION
Hi @ericdallo,

this is a fix for the #1239 windows unit test failure. Basically, the `file:` uri is difficult to get across systems. The problem is that on unix the path always begins with `/` while on windows it begins with a drive letter, and thus we are getting the number of slashes wrong in the end (see [How many slashes?](https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?) for a discussion).

The rule of thumb that I have just came up with is:
1. When constructing a `file:` uri from real paths, use `(io/as-url (io/file <real-path>))`
2. When constructing a `file:` uri from imaginary test paths, use the `h/file-uri` function.

There is also another change that  fixes an issue with the clojure-lsp binary wrapper on windows, that its CWD at startup was always set to the directory of the binary's location. This prevented the intergration-test's from displaying the log file when failing.

