### PR TITLE
Fix lint

### DIFF
--- a/cli/build.clj
+++ b/cli/build.clj
@@ -99,7 +99,7 @@
               outfile (-> "clojure-lsp.exe"  fs/absolutize fs/path .toString)
               java-home (System/getenv "JAVA_HOME")]
           (fs/with-temp-dir
-            [temp-dir]
+            [temp-dir {}]
             (let [l4jxml (-> (fs/path temp-dir "l4j.xml") .toString)]
               (spit l4jxml (l4j-xml jar outfile java-home jvm-opts))
               (p/shell (str l4j " " l4jxml)))))

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper :as h]
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [medley.core :as medley]))
 

--- a/scripts/make.clj
+++ b/scripts/make.clj
@@ -1,4 +1,5 @@
 (ns make
+  (:refer-clojure :exclude [test])
   (:require [babashka.fs :as fs]
             [babashka.deps :as deps]
             [babashka.process :as p]))
@@ -7,6 +8,7 @@
                "clojure-lsp.exe"
                "clojure-lsp"))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn clean []
   (let [files (into ["cli/target"
                      (fs/path "cli" lsp-bin)
@@ -19,97 +21,117 @@
     (doseq [f files]
       (fs/delete-tree f))))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lib-pom []
   (-> (deps/clojure ["-T:build" "pom"] {:dir "lib" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn cli-pom []
   (-> (deps/clojure ["-T:build" "pom"] {:dir "cli" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lib-jar []
   (-> (deps/clojure ["-T:build" "jar"] {:dir "lib" :inherit true})
       (p/check))
   (fs/move "lib/target/clojure-lsp.jar" "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn cli-jar []
   (-> (deps/clojure ["-T:build" "prod-jar"] {:dir "cli" :inherit true})
       (p/check))
   (fs/move "cli/target/clojure-lsp-standalone.jar" "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn cli-debug-jar []
   (-> (deps/clojure ["-T:build" "debug-jar"] {:dir "cli" :inherit true})
       (p/check))
   (fs/move "cli/target/clojure-lsp-standalone.jar" "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn cli-jar-for-native []
   (-> (deps/clojure ["-T:build" "prod-jar-for-native"]
                     {:dir "cli"})
       (p/check))
   (fs/move "cli/target/clojure-lsp-standalone.jar" "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn debug-cli []
   (-> (deps/clojure ["-T:build" "debug-cli"] {:dir "cli" :inherit true})
       p/check)
   (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn prod-cli []
   (-> (deps/clojure ["-T:build" "prod-cli"] {:dir "cli" :inherit true})
       p/check)
   (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn native-cli []
   (-> (deps/clojure ["-T:build" "native-cli"] {:dir "cli" :inherit true})
       (p/check))
   (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn test []
   (doseq [dir ["lib" "cli"]]
     (-> (deps/clojure ["-M:test"] {:dir dir :inherit true})
         (p/check))))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn pod-test []
   (-> (deps/clojure ["-M:pod-test"] {:dir "cli" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn integration-test []
   (let [bb (str \" (.get (.command (.info (java.lang.ProcessHandle/current)))) \")]
     (p/shell {:dir "cli"} (str bb " integration-test ../" lsp-bin))))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lint-clean []
   (-> (deps/clojure ["-M:run" "clean-ns" "--dry" "--ns-exclude-regex" "sample-test.*" "--project-root" "../"]
                     {:dir "cli" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lint-format []
   (-> (deps/clojure ["-M:run" "format" "--dry" "--ns-exclude-regex" "sample-test.*" "--project-root" "../"]
                     {:dir "cli" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lint-diagnostics []
   (-> (deps/clojure ["-M:run" "diagnostics" "--dry" "--ns-exclude-regex" "sample-test.*" "--project-root" "../"]
                     {:dir "cli" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lint-fix []
   (doseq [linter ["clean-ns" "format"]]
     (-> (deps/clojure ["-M:run" linter "--ns-exclude-regex" "sample-test.*" "--project-root" "../"]
                       {:dir "cli" :inherit true})
         (p/check))))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn release []
   (p/shell "./release"))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn deploy-clojars []
   (-> (deps/clojure ["-T:build" "deploy-clojars"]
                     {:dir "lib" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn deploy-clojars-standalone []
   (-> (deps/clojure ["-T:build" "deploy-clojars"]
                     {:dir "cli" :inherit true})
       (p/check)))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn local-webpage []
   (let [files ["CHANGELOG.md" "README.md"]]
     (doseq [f files]


### PR DESCRIPTION
Fixes lint that was introduced with some of the latest fixes for Windows.

@ericdallo it seems that CI doesn't lint all the files. Should it?

@ikappaki was your editor showing you lint on these files as you were working on them? If not, that's probably a bug in how clojure-lsp or clj-kondo works on Windows.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
