### PR TITLE
Fixes NPE when checking code actions of file that begins with comment

### DIFF
--- a/lib/src/clojure_lsp/feature/sort_clauses.clj
+++ b/lib/src/clojure_lsp/feature/sort_clauses.clj
@@ -6,13 +6,14 @@
    [rewrite-clj.zip :as z]))
 
 (defn ^:private clause-spec [zloc uri db]
-  (let [zloc (or (and (n/inner? (z/node zloc)) ;; sort from map/vector/list bracket
-                      (z/down zloc))
-                 zloc)
-        clause-spec (f.clauses/clause-spec zloc uri db)]
-    ;; don't sort in places that establish bindings, which are order dependent
-    (when-not (contains? #{:forms :binding} (:context clause-spec))
-      clause-spec)))
+  (when zloc
+    (let [zloc (or (and (n/inner? (z/node zloc)) ;; sort from map/vector/list bracket
+                        (z/down zloc))
+                   zloc)
+          clause-spec (f.clauses/clause-spec zloc uri db)]
+      ;; don't sort in places that establish bindings, which are order dependent
+      (when-not (contains? #{:forms :binding} (:context clause-spec))
+        clause-spec))))
 
 (defn can-sort? [zloc uri db]
   (clause-spec zloc uri db))

--- a/lib/test/clojure_lsp/feature/sort_clauses_test.clj
+++ b/lib/test/clojure_lsp/feature/sort_clauses_test.clj
@@ -20,6 +20,7 @@
 
 (deftest should-not-sort
   (testing "top-level forms"
+    (assert-cannot-sort "|")
     (assert-cannot-sort "|[]")
     (assert-cannot-sort "|1")
     (assert-cannot-sort "|{}"))

--- a/lib/test/clojure_lsp/features/code_actions_test.clj
+++ b/lib/test/clojure_lsp/features/code_actions_test.clj
@@ -12,6 +12,27 @@
 (defn zloc-of [uri]
   (parser/safe-zloc-of-file (h/db) uri))
 
+(deftest no-zloc-test
+  ;; We don't always have a zloc. This happens, for example, when Calva opens a
+  ;; file that begins with a comment.
+  (testing "doesn't throw when file hasn't been opened"
+    (is (seq (f.code-actions/all (zloc-of h/default-uri)
+                                 h/default-uri
+                                 0
+                                 0
+                                 []
+                                 {:workspace {:workspace-edit true}}
+                                 (h/db)))))
+  (testing "doesn't throw when file begins with a comment"
+    (h/load-code ";; a file")
+    (is (seq (f.code-actions/all (zloc-of h/default-uri)
+                                 h/default-uri
+                                 0
+                                 0
+                                 []
+                                 {:workspace {:workspace-edit true}}
+                                 (h/db))))))
+
 (deftest add-alias-suggestion-code-actions
   (h/load-code-and-locs "(ns clojure.set)" (h/file-uri "file:///clojure.core.clj"))
   (h/load-code-and-locs "(ns medley.core)" (h/file-uri "file:///medley.core.clj"))


### PR DESCRIPTION
This fixes an NPE that is thrown when a client requests code actions but a zloc can't be found.

One scenario where a zloc can't be found is when a source file begins with a comment or whitespace. (Calva automatically invokes code actions as you navigate, so this can easily be reproduced by adding a comment at the top of a file and clicking on it.)

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
