### PR TITLE
Consider original text's line separator type when reporting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Improve MS-Windows support by fixing various path, URI and line ending issues coming out of repairing the unit tests suite on windows. #1211
   - End dep-graph-queries experiment; clojure-lsp now uses the dep-graph to optimize queries whenever possible
   - Bump clj-kondo to `2022.09.09-20220918.164105-17`. #1226 
+  - Fix issue with changes being reporting with spurious and incorrect line endings on MS-Windows text files. #1211
 
 - Editor
   - Fix to avoid error when checking code actions from an #_x uneval node. #1227

--- a/bb.edn
+++ b/bb.edn
@@ -29,6 +29,10 @@
          lint-format make/lint-format
          lint-diagnostics make/lint-diagnostics
          lint-fix make/lint-fix
+         lint {:doc "Run all linters in dry mode."
+               :task (doseq [linter '[lint-clean lint-format lint-diagnostics]]
+                       (println :running-task linter)
+                       (run linter))}
 
          release make/release
 

--- a/cli/integration-test/sample-test/src/sample_test/api/clean_ns/dos.clj
+++ b/cli/integration-test/sample-test/src/sample_test/api/clean_ns/dos.clj
@@ -1,0 +1,5 @@
+(ns sample-test.api.clean-ns.dos
+  (:require
+   [clojure.string :as string]))
+
+(string/capitalize "x")

--- a/cli/integration-test/sample-test/src/sample_test/api/clean_ns/unix.clj
+++ b/cli/integration-test/sample-test/src/sample_test/api/clean_ns/unix.clj
@@ -1,0 +1,5 @@
+(ns sample-test.api.clean-ns.unix
+  (:require
+   [clojure.string :as string]))
+
+(string/capitalize "x")

--- a/common-test/src/clojure_lsp/test_helper.clj
+++ b/common-test/src/clojure_lsp/test_helper.clj
@@ -5,6 +5,7 @@
    [clojure-lsp.logger :as logger]
    [clojure-lsp.parser :as parser]
    [clojure-lsp.producer :as producer]
+   [clojure-lsp.shared :as shared]
    [clojure.core.async :as async]
    [clojure.pprint :as pprint]
    [clojure.string :as string]
@@ -24,6 +25,14 @@
 (defn file-uri [uri]
   (cond-> uri windows?
           (string/replace #"^(file|zipfile|jar:file):///(?!\w:/)" "$1:///C:/")))
+
+(defn lf->sys
+  "Returns TEXT, converting `\n` line endings to those of the underlying
+  system's, if different."
+  [text]
+  (if-not (= shared/line-separator "\n")
+    (string/replace text #"\n" shared/line-separator)
+    text))
 
 (defn string=
   "Like `clojure.core/=` applied on STRING1 and STRING2, but treats

--- a/lib/src/clojure_lsp/diff.clj
+++ b/lib/src/clojure_lsp/diff.clj
@@ -7,11 +7,15 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- lines [s]
-  (string/split s #"\n"))
+(defn- lines
+  "Splits S on `\n` or `\r\n`."
+  [s]
+  (string/split-lines s))
 
-(defn- unlines [ss]
-  (string/join "\n" ss))
+(defn- unlines
+  "Joins SS strings coll using the system's line separator."
+  [ss]
+  (string/join shared/line-separator ss))
 
 (defn unified-diff
   ([old-uri new-uri original revised project-root-uri]

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -19,6 +19,10 @@
 
 (set! *warn-on-reflection* true)
 
+(def line-separator
+  "The system's line separator."
+  (System/lineSeparator))
+
 (def ^:private ansi-colors
   {:reset "[0m"
    :red   "[31m"

--- a/lib/test/clojure_lsp/features/file_management_test.clj
+++ b/lib/test/clojure_lsp/features/file_management_test.clj
@@ -10,14 +10,27 @@
 (h/reset-components-before-test)
 
 (deftest update-text
-  (is (= "(comment\n   )" (#'f.file-management/replace-text "(comment)" "\n   " 0 8 0 8)))
+  ;; line endings the same as those of the underlying system's.
+  (is (= (h/lf->sys "(comment\n   )") (#'f.file-management/replace-text "(comment)" "\n   " 0 8 0 8)))
+  (is (= (h/lf->sys "(comment\n   )") (#'f.file-management/replace-text "(comment)" "\r\n   " 0 8 0 8)))
+
+  ;; line endings should be those of the original text's.
   (is (= "some \nboring\n text" (#'f.file-management/replace-text "some \ncool\n text" "boring" 1 0 1 4)))
+  (is (= "some \r\nboring\r\n text" (#'f.file-management/replace-text "some \r\ncool\r\n text" "boring" 1 0 1 4)))
+
   (is (= "(+ 1 2)" (#'f.file-management/replace-text "(+ 1 1)" "2" 0 5 0 6)))
   (is (= "(+ 1)" (#'f.file-management/replace-text "(+ 1 1)" "" 0 4 0 6)))
+
   (is (= "\n\n (+ 1 2)\n" (#'f.file-management/replace-text "\n\n (let [a 1\n   b 2]\n   (+ 1 2))\n" "(+ 1 2)" 2 1 4 11)))
   (is (= "\r\n\r\n (+ 1 2)\r\n" (#'f.file-management/replace-text "\r\n\r\n (let [a 1\r\n   b 2]\r\n   (+ 1 2))\r\n" "(+ 1 2)" 2 1 4 11)))
+
   (is (= "\n\n (let [a 1\n   b 2]\n   (+ 1 2))\n" (#'f.file-management/replace-text "\n\n (+ 1 2)\n" "(let [a 1\n   b 2]\n   (+ 1 2))" 2 1 2 8)))
-  (is (= "(+ 1 1)\n\n" (#'f.file-management/replace-text "(+ 1 1)\n" "\n" 1 0 1 0))))
+  (is (= "\r\n\r\n (let [a 1\r\n   b 2]\r\n   (+ 1 2))\r\n" (#'f.file-management/replace-text "\r\n\r\n (+ 1 2)\r\n" "(let [a 1\r\n   b 2]\r\n   (+ 1 2))" 2 1 2 8)))
+
+  (is (= "(+ 1 1)\n\n" (#'f.file-management/replace-text "(+ 1 1)\n" "\n" 1 0 1 0)))
+  (is (= "(+ 1 1)\n\n" (#'f.file-management/replace-text "(+ 1 1)\n" "\r\n" 1 0 1 0)))
+  (is (= "(+ 1 1)\r\n\r\n" (#'f.file-management/replace-text "(+ 1 1)\r\n" "\n" 1 0 1 0)))
+  (is (= "(+ 1 1)\r\n\r\n" (#'f.file-management/replace-text "(+ 1 1)\r\n" "\r\n" 1 0 1 0))))
 
 (deftest did-close
   (swap! (h/db*) medley/deep-merge {:settings {:source-paths #{(h/file-path "/user/project/src/clj")}}

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -671,7 +671,7 @@
           expected {:ns 'my.fabulous-namespace
                     :name 'SomeRecord
                     :defined-by 'clojure.core/defrecord
-                    :filename "/project/my/fabulous_namespace.clj"
+                    :filename (h/file-path "/project/my/fabulous_namespace.clj")
                     :bucket :var-definitions}]
       (h/assert-submap
         expected


### PR DESCRIPTION
Hi,

could you please consider patch to fix linter issues with line endings when reporting changes back to the client. This is part of #1211.

`clojure-lsp` normalizes all line endings to those of *unix, i.e. `\n` (aka LF), either directly or some times indirectly via third party libraries (see https://github.com/clj-commons/rewrite-clj/issues/187). On MS-Windows the native line endings are `\r\n` (aka CRLF), and thus if we internally treat all line endings as `\n`, we might end up reporting text as changing, although the only thing that changed was the internal change of `\r\n` to `\n`, i.e. false positive changes. This is what happened when running the `bb lint-clean` linter on windows, although there was no namespace to clean, differences were reported.

The patch tries to determine the line ending type of the original text and forces that to the replacement text, thus maintaining the original line endings.

It also:
- fixes java interop test failure on win introduced with earlier unrelated commit.
- introduces a convenient `bb lint` task.


thanks

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)