### PR TITLE
Process requests in parallel

### DIFF
--- a/.clj-kondo/funcool/promesa/config.edn
+++ b/.clj-kondo/funcool/promesa/config.edn
@@ -1,0 +1,8 @@
+{:lint-as {promesa.core/->          clojure.core/->
+           promesa.core/->>         clojure.core/->>
+           promesa.core/as->        clojure.core/as->
+           promesa.core/let         clojure.core/let
+           promesa.core/plet        clojure.core/let
+           promesa.core/loop        clojure.core/loop
+           promesa.core/recur       clojure.core/recur
+           promesa.core/with-redefs clojure.core/with-redefs}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Lint opened files after a clojure-lsp or clj-kondo config file is saved on disk, avoiding users to re-edit files. #1247
   - Allow find definition of java class usages where definition comes from clojure, like defrecords.
   - Fix: wait for rename to apply before allowing another rename, to ensure suggested name is correct. #1270
+  - Process requests in parallel, to prevent typing lag and other performance problems introduced during migration away from lsp4j. #1240
 
 - API/CLI
   - Fix missing diagnostics when `--project-root` is different than current directory. #1245

--- a/cli/bb.edn
+++ b/cli/bb.edn
@@ -1,8 +1,8 @@
 {:paths ["integration-test"]
  :min-bb-version "0.4.0"
  :deps {medley/medley {:mvn/version "1.4.0"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
-        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
+        ;; com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
+        com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                  :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
  :tasks {integration-test entrypoint/run-all}}

--- a/cli/bb.edn
+++ b/cli/bb.edn
@@ -1,8 +1,8 @@
 {:paths ["integration-test"]
  :min-bb-version "0.4.0"
  :deps {medley/medley {:mvn/version "1.4.0"}
-        ;; com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
-        com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.3.0"}
+        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                  :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
  :tasks {integration-test entrypoint/run-all}}

--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -3,7 +3,8 @@
         borkdude/dynaload {:mvn/version "0.3.5"}
         nrepl/bencode {:mvn/version "1.1.0"}
         com.taoensso/timbre {:mvn/version "5.2.1"}
-        clojure-lsp/lib {:local/root "../lib"}}
+        clojure-lsp/lib {:local/root "../lib"}
+        funcool/promesa {:mvn/version "8.0.450"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}
                                lambdaisland/kaocha {:mvn/version "1.70.1086"}}

--- a/cli/integration-test/integration/api/rename_test.clj
+++ b/cli/integration-test/integration/api/rename_test.clj
@@ -1,7 +1,6 @@
 (ns integration.api.rename-test
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [integration.helper :as h]
    [integration.lsp :as lsp]))

--- a/cli/integration-test/integration/client.clj
+++ b/cli/integration-test/integration/client.clj
@@ -118,12 +118,12 @@
       (async/>!! output notif)))
   (receive-response [this {:keys [id] :as resp}]
     (if-let [{:keys [request start-ns]} (get @sent-requests id)]
-      (let [sec (/ (double (- (. System (nanoTime)) start-ns)) 1000000000.0)]
-        (do (protocols.endpoint/log this :green (format "received response (%.3f sec):" sec) resp)
-            (swap! sent-requests dissoc id)
-            (deliver request (if (:error resp)
-                               resp
-                               (:result resp)))))
+      (let [ms (float (/ (- (System/nanoTime) start-ns) 1000000))]
+        (protocols.endpoint/log this :green (format "received response (%.0fms):" ms) resp)
+        (swap! sent-requests dissoc id)
+        (deliver request (if (:error resp)
+                           resp
+                           (:result resp))))
       (protocols.endpoint/log this :red "received response for unmatched request:" resp)))
   (receive-request [this _ {:keys [id method] :as req}]
     (protocols.endpoint/log this :magenta "received request:" req)

--- a/cli/integration-test/integration/formatting_test.clj
+++ b/cli/integration-test/integration/formatting_test.clj
@@ -1,6 +1,5 @@
 (ns integration.formatting-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer [deftest testing]]
    [integration.fixture :as fixture]
    [integration.helper :as h]

--- a/cli/integration-test/integration/helper.clj
+++ b/cli/integration-test/integration/helper.clj
@@ -53,12 +53,6 @@
   [string1 string2]
   (= (string/split-lines string1) (string/split-lines string2)))
 
-(defn ->system-newlines
-  "Converts TEXT new lines to those of the underlying system, and
-  returns it."
-  [text]
-  (-> (string/split-lines text) (string/join "\n")))
-
 (defn str-includes?
   "Like `clojure.string/includes?` applied to S and SUBSTR, but treats
   any line endings as equal."

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -158,10 +158,13 @@
 (defmethod lsp.server/receive-request "clojure/dependencyContents" [_ components params]
   (->> params
        (handler/dependency-contents components)
-       (conform-or-log ::coercer/uri)))
+       (conform-or-log ::coercer/uri)
+       delay))
 
 (defmethod lsp.server/receive-request "clojure/serverInfo/raw" [_ components _params]
-  (handler/server-info-raw components))
+  (->> components
+       handler/server-info-raw
+       delay))
 
 (defmethod lsp.server/receive-notification "clojure/serverInfo/log" [_ components _params]
   (future
@@ -172,7 +175,9 @@
         (throw e)))))
 
 (defmethod lsp.server/receive-request "clojure/cursorInfo/raw" [_ components params]
-  (handler/cursor-info-raw components params))
+  (->> params
+       (handler/cursor-info-raw components)
+       delay))
 
 (defmethod lsp.server/receive-notification "clojure/cursorInfo/log" [_ components params]
   (future
@@ -183,7 +188,9 @@
         (throw e)))))
 
 (defmethod lsp.server/receive-request "clojure/clojuredocs/raw" [_ components params]
-  (handler/clojuredocs-raw components params))
+  (->> params
+       (handler/clojuredocs-raw components)
+       delay))
 
 ;;;; Document sync features
 
@@ -209,43 +216,51 @@
 (defmethod lsp.server/receive-request "textDocument/references" [_ components params]
   (->> params
        (handler/references components)
-       (conform-or-log ::coercer/locations)))
+       (conform-or-log ::coercer/locations)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/completion" [_ components params]
   (->> params
        (handler/completion components)
-       (conform-or-log ::coercer/completion-items)))
+       (conform-or-log ::coercer/completion-items)
+       delay))
 
 (defmethod lsp.server/receive-request "completionItem/resolve" [_ components item]
   (->> item
        (conform-or-log ::coercer/input.completion-item)
        (handler/completion-resolve-item components)
-       (conform-or-log ::coercer/completion-item)))
+       (conform-or-log ::coercer/completion-item)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/prepareRename" [_ components params]
   (->> params
        (handler/prepare-rename components)
-       (conform-or-log ::coercer/prepare-rename-or-error)))
+       (conform-or-log ::coercer/prepare-rename-or-error)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/rename" [_ components params]
   (->> params
        (handler/rename components)
-       (conform-or-log ::coercer/workspace-edit-or-error)))
+       (conform-or-log ::coercer/workspace-edit-or-error)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/hover" [_ components params]
   (->> params
        (handler/hover components)
-       (conform-or-log ::coercer/hover)))
+       (conform-or-log ::coercer/hover)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/signatureHelp" [_ components params]
   (->> params
        (handler/signature-help components)
-       (conform-or-log ::coercer/signature-help)))
+       (conform-or-log ::coercer/signature-help)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/formatting" [_ components params]
   (->> params
        (handler/formatting components)
-       (conform-or-log ::coercer/edits)))
+       (conform-or-log ::coercer/edits)
+       delay))
 
 (def ^:private formatting (atom false))
 
@@ -263,72 +278,86 @@
 (defmethod lsp.server/receive-request "textDocument/codeAction" [_ components params]
   (->> params
        (handler/code-actions components)
-       (conform-or-log ::coercer/code-actions)))
+       (conform-or-log ::coercer/code-actions)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/codeLens" [_ components params]
   (->> params
        (handler/code-lens components)
-       (conform-or-log ::coercer/code-lenses)))
+       (conform-or-log ::coercer/code-lenses)
+       delay))
 
 (defmethod lsp.server/receive-request "codeLens/resolve" [_ components params]
   (->> params
        (handler/code-lens-resolve components)
-       (conform-or-log ::coercer/code-lens)))
+       (conform-or-log ::coercer/code-lens)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/definition" [_ components params]
   (->> params
        (handler/definition components)
-       (conform-or-log ::coercer/location)))
+       (conform-or-log ::coercer/location)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/declaration" [_ components params]
   (->> params
        (handler/declaration components)
-       (conform-or-log ::coercer/location)))
+       (conform-or-log ::coercer/location)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/implementation" [_ components params]
   (->> params
        (handler/implementation components)
-       (conform-or-log ::coercer/locations)))
+       (conform-or-log ::coercer/locations)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/documentSymbol" [_ components params]
   (->> params
        (handler/document-symbol components)
-       (conform-or-log ::coercer/document-symbols)))
+       (conform-or-log ::coercer/document-symbols)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/documentHighlight" [_ components params]
   (->> params
        (handler/document-highlight components)
-       (conform-or-log ::coercer/document-highlights)))
+       (conform-or-log ::coercer/document-highlights)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/full" [_ components params]
   (->> params
        (handler/semantic-tokens-full components)
-       (conform-or-log ::coercer/semantic-tokens)))
+       (conform-or-log ::coercer/semantic-tokens)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/range" [_ components params]
   (->> params
        (handler/semantic-tokens-range components)
-       (conform-or-log ::coercer/semantic-tokens)))
+       (conform-or-log ::coercer/semantic-tokens)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/prepareCallHierarchy" [_ components params]
   (->> params
        (handler/prepare-call-hierarchy components)
-       (conform-or-log ::coercer/call-hierarchy-items)))
+       (conform-or-log ::coercer/call-hierarchy-items)
+       delay))
 
 (defmethod lsp.server/receive-request "callHierarchy/incomingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-incoming components)
-       (conform-or-log ::coercer/call-hierarchy-incoming-calls)))
+       (conform-or-log ::coercer/call-hierarchy-incoming-calls)
+       delay))
 
 (defmethod lsp.server/receive-request "callHierarchy/outgoingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-outgoing components)
-       (conform-or-log ::coercer/call-hierarchy-outgoing-calls)))
+       (conform-or-log ::coercer/call-hierarchy-outgoing-calls)
+       delay))
 
 (defmethod lsp.server/receive-request "textDocument/linkedEditingRange" [_ components params]
   (->> params
        (handler/linked-editing-ranges components)
-       (conform-or-log ::coercer/linked-editing-ranges-or-error)))
+       (conform-or-log ::coercer/linked-editing-ranges-or-error)
+       delay))
 
 ;;;; Workspace features
 
@@ -354,12 +383,14 @@
 (defmethod lsp.server/receive-request "workspace/symbol" [_ components params]
   (->> params
        (handler/workspace-symbols components)
-       (conform-or-log ::coercer/workspace-symbols)))
+       (conform-or-log ::coercer/workspace-symbols)
+       delay))
 
 (defmethod lsp.server/receive-request "workspace/willRenameFiles" [_ components params]
   (->> params
        (handler/will-rename-files components)
-       (conform-or-log ::coercer/workspace-edit)))
+       (conform-or-log ::coercer/workspace-edit)
+       delay))
 
 (defn capabilities [settings]
   (conform-or-log

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -545,7 +545,7 @@
           log-ch (async/chan (async/sliding-buffer 20))
           server (lsp.io-server/stdio-server {:log-ch log-ch
                                               ;; uncomment for server-side traces
-                                              :trace-ch log-ch})
+                                              #_#_:trace-ch log-ch})
           producer (ClojureLspProducer. server db*)
           components {:db* db*
                       :logger timbre-logger

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -18,6 +18,7 @@
    [lsp4clj.liveness-probe :as lsp.liveness-probe]
    [lsp4clj.lsp.requests :as lsp.requests]
    [lsp4clj.server :as lsp.server]
+   [promesa.core :as p]
    [taoensso.timbre :as timbre]))
 
 (set! *warn-on-reflection* true)
@@ -159,12 +160,12 @@
   (->> params
        (handler/dependency-contents components)
        (conform-or-log ::coercer/uri)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "clojure/serverInfo/raw" [_ components _params]
   (->> components
        handler/server-info-raw
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-notification "clojure/serverInfo/log" [_ components _params]
   (future
@@ -177,10 +178,10 @@
 (defmethod lsp.server/receive-request "clojure/cursorInfo/raw" [_ components params]
   (->> params
        (handler/cursor-info-raw components)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-notification "clojure/cursorInfo/log" [_ components params]
-  (future
+  (p/future
     (try
       (handler/cursor-info-log components params)
       (catch Throwable e
@@ -190,7 +191,7 @@
 (defmethod lsp.server/receive-request "clojure/clojuredocs/raw" [_ components params]
   (->> params
        (handler/clojuredocs-raw components)
-       future))
+       p/future))
 
 ;;;; Document sync features
 
@@ -217,50 +218,50 @@
   (->> params
        (handler/references components)
        (conform-or-log ::coercer/locations)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/completion" [_ components params]
   (->> params
        (handler/completion components)
        (conform-or-log ::coercer/completion-items)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "completionItem/resolve" [_ components item]
   (->> item
        (conform-or-log ::coercer/input.completion-item)
        (handler/completion-resolve-item components)
        (conform-or-log ::coercer/completion-item)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/prepareRename" [_ components params]
   (->> params
        (handler/prepare-rename components)
        (conform-or-log ::coercer/prepare-rename-or-error)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/rename" [_ components params]
   (->> params
        (handler/rename components)
        (conform-or-log ::coercer/workspace-edit-or-error)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/hover" [_ components params]
   (->> params
        (handler/hover components)
        (conform-or-log ::coercer/hover)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/signatureHelp" [_ components params]
   (->> params
        (handler/signature-help components)
        (conform-or-log ::coercer/signature-help)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/formatting" [_ components params]
   (->> params
        (handler/formatting components)
        (conform-or-log ::coercer/edits)
-       future))
+       p/future))
 
 (def ^:private formatting (atom false))
 
@@ -279,85 +280,85 @@
   (->> params
        (handler/code-actions components)
        (conform-or-log ::coercer/code-actions)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/codeLens" [_ components params]
   (->> params
        (handler/code-lens components)
        (conform-or-log ::coercer/code-lenses)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "codeLens/resolve" [_ components params]
   (->> params
        (handler/code-lens-resolve components)
        (conform-or-log ::coercer/code-lens)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/definition" [_ components params]
   (->> params
        (handler/definition components)
        (conform-or-log ::coercer/location)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/declaration" [_ components params]
   (->> params
        (handler/declaration components)
        (conform-or-log ::coercer/location)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/implementation" [_ components params]
   (->> params
        (handler/implementation components)
        (conform-or-log ::coercer/locations)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/documentSymbol" [_ components params]
   (->> params
        (handler/document-symbol components)
        (conform-or-log ::coercer/document-symbols)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/documentHighlight" [_ components params]
   (->> params
        (handler/document-highlight components)
        (conform-or-log ::coercer/document-highlights)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/full" [_ components params]
   (->> params
        (handler/semantic-tokens-full components)
        (conform-or-log ::coercer/semantic-tokens)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/range" [_ components params]
   (->> params
        (handler/semantic-tokens-range components)
        (conform-or-log ::coercer/semantic-tokens)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/prepareCallHierarchy" [_ components params]
   (->> params
        (handler/prepare-call-hierarchy components)
        (conform-or-log ::coercer/call-hierarchy-items)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "callHierarchy/incomingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-incoming components)
        (conform-or-log ::coercer/call-hierarchy-incoming-calls)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "callHierarchy/outgoingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-outgoing components)
        (conform-or-log ::coercer/call-hierarchy-outgoing-calls)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "textDocument/linkedEditingRange" [_ components params]
   (->> params
        (handler/linked-editing-ranges components)
        (conform-or-log ::coercer/linked-editing-ranges-or-error)
-       future))
+       p/future))
 
 ;;;; Workspace features
 
@@ -384,13 +385,13 @@
   (->> params
        (handler/workspace-symbols components)
        (conform-or-log ::coercer/workspace-symbols)
-       future))
+       p/future))
 
 (defmethod lsp.server/receive-request "workspace/willRenameFiles" [_ components params]
   (->> params
        (handler/will-rename-files components)
        (conform-or-log ::coercer/workspace-edit)
-       future))
+       p/future))
 
 (defn capabilities [settings]
   (conform-or-log

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -544,7 +544,7 @@
           log-ch (async/chan (async/sliding-buffer 20))
           server (lsp.io-server/stdio-server {:log-ch log-ch
                                               ;; uncomment for server-side traces
-                                              #_#_:trace-ch log-ch})
+                                              :trace-ch log-ch})
           producer (ClojureLspProducer. server db*)
           components {:db* db*
                       :logger timbre-logger

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -159,12 +159,12 @@
   (->> params
        (handler/dependency-contents components)
        (conform-or-log ::coercer/uri)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "clojure/serverInfo/raw" [_ components _params]
   (->> components
        handler/server-info-raw
-       delay))
+       future))
 
 (defmethod lsp.server/receive-notification "clojure/serverInfo/log" [_ components _params]
   (future
@@ -177,7 +177,7 @@
 (defmethod lsp.server/receive-request "clojure/cursorInfo/raw" [_ components params]
   (->> params
        (handler/cursor-info-raw components)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-notification "clojure/cursorInfo/log" [_ components params]
   (future
@@ -190,7 +190,7 @@
 (defmethod lsp.server/receive-request "clojure/clojuredocs/raw" [_ components params]
   (->> params
        (handler/clojuredocs-raw components)
-       delay))
+       future))
 
 ;;;; Document sync features
 
@@ -217,50 +217,50 @@
   (->> params
        (handler/references components)
        (conform-or-log ::coercer/locations)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/completion" [_ components params]
   (->> params
        (handler/completion components)
        (conform-or-log ::coercer/completion-items)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "completionItem/resolve" [_ components item]
   (->> item
        (conform-or-log ::coercer/input.completion-item)
        (handler/completion-resolve-item components)
        (conform-or-log ::coercer/completion-item)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/prepareRename" [_ components params]
   (->> params
        (handler/prepare-rename components)
        (conform-or-log ::coercer/prepare-rename-or-error)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/rename" [_ components params]
   (->> params
        (handler/rename components)
        (conform-or-log ::coercer/workspace-edit-or-error)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/hover" [_ components params]
   (->> params
        (handler/hover components)
        (conform-or-log ::coercer/hover)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/signatureHelp" [_ components params]
   (->> params
        (handler/signature-help components)
        (conform-or-log ::coercer/signature-help)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/formatting" [_ components params]
   (->> params
        (handler/formatting components)
        (conform-or-log ::coercer/edits)
-       delay))
+       future))
 
 (def ^:private formatting (atom false))
 
@@ -279,85 +279,85 @@
   (->> params
        (handler/code-actions components)
        (conform-or-log ::coercer/code-actions)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/codeLens" [_ components params]
   (->> params
        (handler/code-lens components)
        (conform-or-log ::coercer/code-lenses)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "codeLens/resolve" [_ components params]
   (->> params
        (handler/code-lens-resolve components)
        (conform-or-log ::coercer/code-lens)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/definition" [_ components params]
   (->> params
        (handler/definition components)
        (conform-or-log ::coercer/location)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/declaration" [_ components params]
   (->> params
        (handler/declaration components)
        (conform-or-log ::coercer/location)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/implementation" [_ components params]
   (->> params
        (handler/implementation components)
        (conform-or-log ::coercer/locations)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/documentSymbol" [_ components params]
   (->> params
        (handler/document-symbol components)
        (conform-or-log ::coercer/document-symbols)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/documentHighlight" [_ components params]
   (->> params
        (handler/document-highlight components)
        (conform-or-log ::coercer/document-highlights)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/full" [_ components params]
   (->> params
        (handler/semantic-tokens-full components)
        (conform-or-log ::coercer/semantic-tokens)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/range" [_ components params]
   (->> params
        (handler/semantic-tokens-range components)
        (conform-or-log ::coercer/semantic-tokens)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/prepareCallHierarchy" [_ components params]
   (->> params
        (handler/prepare-call-hierarchy components)
        (conform-or-log ::coercer/call-hierarchy-items)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "callHierarchy/incomingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-incoming components)
        (conform-or-log ::coercer/call-hierarchy-incoming-calls)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "callHierarchy/outgoingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-outgoing components)
        (conform-or-log ::coercer/call-hierarchy-outgoing-calls)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "textDocument/linkedEditingRange" [_ components params]
   (->> params
        (handler/linked-editing-ranges components)
        (conform-or-log ::coercer/linked-editing-ranges-or-error)
-       delay))
+       future))
 
 ;;;; Workspace features
 
@@ -384,13 +384,13 @@
   (->> params
        (handler/workspace-symbols components)
        (conform-or-log ::coercer/workspace-symbols)
-       delay))
+       future))
 
 (defmethod lsp.server/receive-request "workspace/willRenameFiles" [_ components params]
   (->> params
        (handler/will-rename-files components)
        (conform-or-log ::coercer/workspace-edit)
-       delay))
+       future))
 
 (defn capabilities [settings]
   (conform-or-log

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -17,8 +17,8 @@
         org.benf/cfr {:mvn/version "0.152"}
 
         babashka/fs {:mvn/version "0.1.11"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
-        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
+        ;; com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
+        com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         }
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -17,8 +17,8 @@
         org.benf/cfr {:mvn/version "0.152"}
 
         babashka/fs {:mvn/version "0.1.11"}
-        ;; com.github.clojure-lsp/lsp4clj {:mvn/version "1.2.1"}
-        com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.3.0"}
+        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         }
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -73,7 +73,9 @@
                result#)))))))
 
 (defmacro process-after-changes [task-id uri db* & body]
-  `(process-after-all-changes ~task-id [~uri] ~db* ~@body))
+  (with-meta
+    `(process-after-all-changes ~task-id [~uri] ~db* ~@body)
+    (meta &form)))
 
 (defn ^:private element->location [db producer element]
   {:uri (f.java-interop/uri->translated-uri (:uri element) db producer)


### PR DESCRIPTION
Uses https://github.com/clojure-lsp/lsp4clj/pull/25 to process request in parallel, fixing typing lag and other performance problems documented in #1240.

This PR is currently incomplete. At the moment the lsp4clj dependency points to a local repo. It needs https://github.com/clojure-lsp/lsp4clj/pull/25 to be merged and released, and then needs to use that version in the deps. I'm submitting it now though @ericdallo, so that https://github.com/clojure-lsp/lsp4clj/pull/25 can be tested more easily.

Fixes #1240.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
