### PR TITLE
Simplify finding of class defined by defrecord

### DIFF
--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -292,14 +292,14 @@
                      (filter #(safe-equal? full-class-name (:class %)))))
              (sort-by (complement #(string/ends-with? (:uri %) ".java")))
              first)
+        ;; maybe class was defined by defrecord
         (let [split (string/split full-class-name #"\.")
               ns (symbol (string/replace (string/join "." (drop-last split)) "_" "-"))
               name (symbol (last split))]
-          (find-first
-            (comp
-              xf-analysis->var-definitions
-              (xf-same-fqn ns name))
-            (:analysis db))))))
+          (find-definition db (assoc java-class-usage
+                                     :bucket :var-usages
+                                     :to ns
+                                     :name name))))))
 
 (defmethod find-definition :default
   [_db element]


### PR DESCRIPTION
This re-uses the code to find a var-definition defined by defrecord, when the usage was part of an `:import`.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
