### PR TITLE
Add source-paths to clj-depend config when it is nil or empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - General
+  - Improve clj-depend merge config to overwrite `source-paths` only if it is nil or empty.  #1264
   - Fix stubs generation issue on MS-Windows, coming out of enabling all integrations tests on windows. #1211
   - Improve MS-Windows support by fixing various path, URI and line ending issues coming out of repairing the unit tests suite on windows. #1211
   - End dep-graph-queries experiment; clojure-lsp now uses the dep-graph to optimize queries whenever possible

--- a/lib/test/clojure_lsp/clj_depend_test.clj
+++ b/lib/test/clojure_lsp/clj_depend_test.clj
@@ -1,0 +1,16 @@
+(ns clojure-lsp.clj-depend-test
+  (:require [clojure-lsp.clj-depend :as clj-depend]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest config-with-source-paths-filled-test
+  (testing "Should add source-paths to config when it is nil"
+    (is (= {:source-paths #{"src" "test"}}
+           (clj-depend/config-with-source-paths {} #{"src" "test"}))))
+
+  (testing "Should add source-paths to config when it is empty"
+    (is (= {:source-paths #{"src" "test"}}
+           (clj-depend/config-with-source-paths {:source-paths #{}} #{"src" "test"}))))
+
+  (testing "Should not override source-paths when it is not nil or empty"
+    (is (= {:source-paths #{"src"}}
+           (clj-depend/config-with-source-paths {:source-paths #{"src"}} #{"src" "test"})))))

--- a/lib/test/clojure_lsp/clj_depend_test.clj
+++ b/lib/test/clojure_lsp/clj_depend_test.clj
@@ -1,6 +1,7 @@
 (ns clojure-lsp.clj-depend-test
-  (:require [clojure-lsp.clj-depend :as clj-depend]
-            [clojure.test :refer [deftest testing is]]))
+  (:require
+   [clojure-lsp.clj-depend :as clj-depend]
+   [clojure.test :refer [deftest is testing]]))
 
 (deftest config-with-source-paths-filled-test
   (testing "Should add source-paths to config when it is nil"


### PR DESCRIPTION
Fixes https://github.com/clojure-lsp/clojure-lsp/issues/1264

- [X] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
