### PR TITLE
Use `deps-bin` on MS-Windows, add dev testing and bb tasks documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,16 +104,7 @@ jobs:
           boot: '2.8.3'
           bb: '0.9.161'
 
-      - name: Install launch4j
-        if: startsWith (matrix.os, 'windows')
-        run: |
-          iwr -UserAgent "Wget" -URI "https://sourceforge.net/projects/launch4j/files/launch4j-3/3.14/launch4j-3.14-win32.exe/download" -OutFile "$env:TEMP/l4j-installer.exe"
-          Start-Process -Filepath "$env:TEMP/l4j-installer.exe" -ArgumentList "/S"
-        shell: pwsh
-
       - name: Generate embedded binary
-        env: # only relevant to the MS-Windows job.
-          LAUNCH4J_HOME: "C:\\Program Files (x86)\\Launch4j"
         run: bb prod-cli
 
       - name: Run integration tests

--- a/bb.edn
+++ b/bb.edn
@@ -26,7 +26,11 @@
          prod-cli make/prod-cli
          native-cli make/native-cli
 
-         test make/test
+         test-lib make/test-lib
+         test-cli make/test-cli
+         test {:doc "Run all unit tests."
+               :depends [test-lib test-cli]}
+
          pod-test make/pod-test
          integration-test make/integration-test
 

--- a/cli/build.clj
+++ b/cli/build.clj
@@ -52,65 +52,21 @@
              :main 'clojure-lsp.main
              :basis basis})))
 
-(defn ^:private l4j-xml
-  "Return a launch4j configuration xml document to convert the JAR file
-  to an executable at OUTFILE using the java installation at JRE-PATH
-  and JRE-OPTS."
-  [jar outfile jre-path jvm-opts]
-  (-> (with-out-str (xml/emit-element
-                      {:tag :launch4jConfig :attrs nil
-                       :content [{:tag :dontWrapJar :attrs nil :content ["false"]}
-                                 {:tag :headerType :attrs nil  :content ["console"]}
-                                 {:tag :jar :attrs nil :content [jar]}
-                                 {:tag :outfile :attrs nil :content [outfile]}
-                                 {:tag :priority :attrs nil :content ["normal"]}
-                                 {:tag :stayAlive :attrs nil :content ["false"]}
-                                 {:tag :restartOnCrash :attrs nil :content ["false"]}
-                                 {:tag :jre :attrs nil :content
-                                  (into [{:tag :path :attrs nil :content [jre-path]}
-                                         {:tag :bundledJre64Bit :attrs nil :content ["true"]}
-                                         {:tag :bundledJreAsFallback :attrs nil :content ["false"]}
-                                         {:tag :jdkPreference :attrs nil :content ["preferJre"]}
-                                         {:tag :runtimeBits :attrs nil :content ["64/32"]}]
-                                        (for [opt jvm-opts]
-                                          {:tag :opt :attrs nil :content [opt]}))}]}))
-      (string/replace #"\r\n" "")))
-
 (defn ^:private bin
-  "Create a binary out of UBER-FILE jar with OPTS.
+  "Create an executable `clojure-lsp` script out of UBER-FILE jar with
+  the given OPTS.
 
   OPTS can be a map of
-  :jvm-opts A vector of options ot pass to the JVM.
-
-  launch4j is uses on MS-Windows for the conversion to binary file. It
-  requires its installation path to be either set in the LAUNCH4J_HOME
-  environment variable or included in the PATH env variable. It also
-  requires a java installation path to be set in the JAVA_HOME
-  environment variable."
+  :jvm-opts A vector of options ot pass to the JVM."
   [opts]
   (println "Generating bin...")
 
   (let [jvm-opts (concat (:jvm-opts opts []) ["-Xmx2g" "-server"])]
-    (if (fs/windows?)
-      (if-let [l4j (or (some-> (System/getenv "LAUNCH4J_HOME") (fs/path "launch4jc.exe")
-                               (#(when (fs/executable? %) %)))
-                       (fs/which "launch4jc.exe"))]
-        (let [jar (-> (fs/real-path uber-file) .toString)
-              outfile (-> "clojure-lsp.exe"  fs/absolutize fs/path .toString)
-              java-home (System/getenv "JAVA_HOME")]
-          (fs/with-temp-dir
-            [temp-dir {}]
-            (let [l4jxml (-> (fs/path temp-dir "l4j.xml") .toString)]
-              (spit l4jxml (l4j-xml jar outfile java-home jvm-opts))
-              (p/shell (str l4j " " l4jxml)))))
-
-        (throw (Exception. "Cannot locate launch4j.exe either in LAUNCH4J_HOME environment variable or in PATH.")))
-
-      ((requiring-resolve 'deps-bin.impl.bin/build-bin)
-       {:jar uber-file
-        :name "clojure-lsp"
-        :jvm-opts jvm-opts
-        :skip-realign true}))))
+    ((requiring-resolve 'deps-bin.impl.bin/build-bin)
+     {:jar uber-file
+      :name "clojure-lsp"
+      :jvm-opts jvm-opts
+      :skip-realign true})))
 
 (defn debug-jar [opts]
   (uber-aot (merge opts {:extra-aliases [:debug :test]

--- a/cli/integration-test/integration/api/clean_ns_test.clj
+++ b/cli/integration-test/integration/api/clean_ns_test.clj
@@ -17,7 +17,7 @@
     (with-open [rdr (lsp/cli! "clean-ns"
                               "--project-root" h/root-project-path
                               "--namespace" "sample-test.api.clean-ns.a")]
-      (is (= "Cleared 1 namespaces\n" (slurp rdr)))
+      (is (h/string= "Cleared 1 namespaces\n" (slurp rdr)))
       (is (h/string= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "passing multiple namespaces but only one is cleanable"
@@ -25,7 +25,7 @@
                               "--project-root" h/root-project-path
                               "--namespace" "sample-test.api.clean-ns.b"
                               "--namespace" "sample-test.api.clean-ns.a")]
-      (is (= "Cleared 1 namespaces\n" (slurp rdr)))
+      (is (h/string= "Cleared 1 namespaces\n" (slurp rdr)))
       (is (h/string= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "when running with dry"

--- a/cli/integration-test/integration/api/format_test.clj
+++ b/cli/integration-test/integration/api/format_test.clj
@@ -1,6 +1,5 @@
 (ns integration.api.format-test
   (:require
-   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [integration.helper :as h]
    [integration.lsp :as lsp]))
@@ -17,7 +16,7 @@
     (with-open [rdr (lsp/cli! "format"
                               "--project-root" h/root-project-path
                               "--namespace" "sample-test.api.format.a")]
-      (is (string/includes? (slurp rdr) "Formatted 1 namespaces\n"))
+      (is (h/str-includes? (slurp rdr) "Formatted 1 namespaces\n"))
       (is (= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "passing multiple namespaces but only one is formatable"
@@ -25,28 +24,28 @@
                               "--project-root" h/root-project-path
                               "--namespace" "sample-test.api.format.b"
                               "--namespace" "sample-test.api.format.a")]
-      (is (string/includes? (slurp rdr) "Formatted 1 namespaces\n"))
+      (is (h/str-includes? (slurp rdr) "Formatted 1 namespaces\n"))
       (is (= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "passing multiple filenames separated by double colon but only one is formatable"
     (with-open [rdr (lsp/cli! "format"
                               "--project-root" h/root-project-path
                               "--filenames" "src/sample_test/api/format/b.clj:src/sample_test/api/format/a.clj")]
-      (is (string/includes? (slurp rdr) "Formatted 1 namespaces\n"))
+      (is (h/str-includes? (slurp rdr) "Formatted 1 namespaces\n"))
       (is (= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "passing multiple filenames separated by comma but only one is formatable"
     (with-open [rdr (lsp/cli! "format"
                               "--project-root" h/root-project-path
                               "--filenames" "src/sample_test/api/format/b.clj,src/sample_test/api/format/a.clj")]
-      (is (string/includes? (slurp rdr) "Formatted 1 namespaces\n"))
+      (is (h/str-includes? (slurp rdr) "Formatted 1 namespaces\n"))
       (is (= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "passing filename folder"
     (with-open [rdr (lsp/cli! "format"
                               "--project-root" h/root-project-path
                               "--filenames" "src/sample_test/api/format")]
-      (is (string/includes? (slurp rdr) "Formatted 1 namespaces\n"))
+      (is (h/str-includes? (slurp rdr) "Formatted 1 namespaces\n"))
       (is (= a-expected-text (slurp a-subject-path))))
     (spit a-subject-path a-subject-text))
   (testing "when running with dry"
@@ -54,5 +53,5 @@
                               "--project-root" h/root-project-path
                               "--namespace" "sample-test.api.format.a"
                               "--dry")]
-      (is (string/includes? (slurp rdr) (h/file-path "src/sample_test/api/format/a.clj")))
+      (is (h/str-includes? (slurp rdr) (h/file-path "src/sample_test/api/format/a.clj")))
       (is (= a-subject-text (slurp a-subject-path))))))

--- a/cli/integration-test/integration/helper.clj
+++ b/cli/integration-test/integration/helper.clj
@@ -1,5 +1,6 @@
 (ns integration.helper
   (:require
+   [babashka.fs :as fs]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
    [clojure.string :as string]
@@ -13,8 +14,8 @@
   (-> (io/file *file*)
       .getParentFile
       .getParentFile
-      .toPath
-      (.resolve "sample-test")
+      (fs/path "sample-test")
+      fs/canonicalize
       str))
 
 (defn project-path->canon-path
@@ -45,7 +46,7 @@
               (->> (apply str)))))
 
 (defn file->uri [file]
-  (-> file .toPath .toUri .toString))
+  (-> file fs/canonicalize .toUri .toString))
 
 (defn string=
   "Like `clojure.core/=` applied on STRING1 and STRING2, but treats

--- a/docs/building.md
+++ b/docs/building.md
@@ -16,8 +16,6 @@ The build may take some minutes and the result will be a `./clojure-lsp` native 
 
 - Run `bb debug-cli`.
 
-On Windows, you first need to install [launch4j](http://launch4j.sourceforge.net/) and set the `LAUNCH4J_HOME` to the installation dir.
-
 ## Jar
 
 ### Editor/CLI

--- a/scripts/make.clj
+++ b/scripts/make.clj
@@ -6,11 +6,13 @@
    [babashka.process :as p]))
 
 (def lsp-bin (if (#'fs/windows?)
-               "clojure-lsp.exe"
+               "clojure-lsp.bat"
                "clojure-lsp"))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn clean []
+(defn clean
+  "Clean all artifacts produced by the various tasks."
+  []
   (let [files (into ["cli/target"
                      (fs/path "cli" lsp-bin)
                      "cli/clojure-lsp-standalone.jar"
@@ -39,7 +41,9 @@
   (fs/move "lib/target/clojure-lsp.jar" "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn cli-jar []
+(defn cli-jar
+  "Build `cli` jar."
+  []
   (-> (deps/clojure ["-T:build" "prod-jar"] {:dir "cli" :inherit true})
       (p/check))
   (fs/move "cli/target/clojure-lsp-standalone.jar" "." {:replace-existing true}))
@@ -58,28 +62,46 @@
   (fs/move "cli/target/clojure-lsp-standalone.jar" "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn debug-cli []
+(defn debug-cli
+  "Build the `clojure-lsp[.bat]` cli exec script (`cider-nrepl`/`clj-async-profile` support)."
+  []
   (-> (deps/clojure ["-T:build" "debug-cli"] {:dir "cli" :inherit true})
       p/check)
   (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn prod-cli []
+(defn prod-cli
+  "Build the `clojure-lsp[.bat]` cli exec script."
+  []
   (-> (deps/clojure ["-T:build" "prod-cli"] {:dir "cli" :inherit true})
       p/check)
   (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn native-cli []
+(defn native-cli
+  "Build the native `clojure-lsp[.exe]` cli executable with `graalvm`."
+  []
   (-> (deps/clojure ["-T:build" "native-cli"] {:dir "cli" :inherit true})
       (p/check))
   (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn test []
-  (doseq [dir ["lib" "cli"]]
-    (-> (deps/clojure ["-M:test"] {:dir dir :inherit true})
-        (p/check))))
+(defn test-lib
+  "Run all unit tests in lib/."
+  []
+  (println :running-unit-tests... "lib")
+  (-> (deps/clojure ["-M:test"] {:dir "lib" :inherit true})
+      (p/check))
+  (println))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn test-cli
+  "Run all unit tests in cli/."
+  []
+  (println :running-unit-tests... "cli")
+  (-> (deps/clojure ["-M:test"] {:dir "cli" :inherit true})
+      (p/check))
+  (println))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn pod-test []
@@ -87,7 +109,9 @@
       (p/check)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn integration-test []
+(defn integration-test
+  "Run the integration tests in 'test/integration-test/' using `./clojure-lsp[.bat|.exe]`."
+  []
   (let [bb (str \" (.get (.command (.info (java.lang.ProcessHandle/current)))) \")]
     (p/shell {:dir "cli"} (str bb " integration-test ../" lsp-bin))))
 


### PR DESCRIPTION
Hi @ericdallo,

as requested some time ago, could you please review patch to remove the `launch4j` widnows dependency for generating cli script wrappers in favor of https://github.com/ericdallo/deps-bin/pull/3. This is part of #1211.

I've also 
- added a dev testing doc section explaining the diffs of *nix vs windows, and updated the doc of the bb tasks mentioned in there. Please update/correct as you see fit.
- fixed test path issues from previous unrelated commit while enforcing `babashka.fs/canonicalize` uses in helper functions.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I updated documentation if applicable (`docs` folder)

Thanks,