### PR TITLE
Skip cancelled futures

### DIFF
--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -18,8 +18,13 @@
    [lsp4clj.liveness-probe :as lsp.liveness-probe]
    [lsp4clj.lsp.requests :as lsp.requests]
    [lsp4clj.server :as lsp.server]
-   [promesa.core :as p]
-   [taoensso.timbre :as timbre]))
+   [taoensso.timbre :as timbre])
+  (:import
+   (java.util.concurrent CompletableFuture)
+   (java.util.function Supplier)))
+
+(defmacro eventually [& body]
+  `(CompletableFuture/supplyAsync (reify Supplier (get [this] ~@body))))
 
 (set! *warn-on-reflection* true)
 
@@ -160,12 +165,12 @@
   (->> params
        (handler/dependency-contents components)
        (conform-or-log ::coercer/uri)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "clojure/serverInfo/raw" [_ components _params]
   (->> components
        handler/server-info-raw
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-notification "clojure/serverInfo/log" [_ components _params]
   (future
@@ -178,10 +183,10 @@
 (defmethod lsp.server/receive-request "clojure/cursorInfo/raw" [_ components params]
   (->> params
        (handler/cursor-info-raw components)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-notification "clojure/cursorInfo/log" [_ components params]
-  (p/future
+  (eventually
     (try
       (handler/cursor-info-log components params)
       (catch Throwable e
@@ -191,7 +196,7 @@
 (defmethod lsp.server/receive-request "clojure/clojuredocs/raw" [_ components params]
   (->> params
        (handler/clojuredocs-raw components)
-       p/future))
+       eventually))
 
 ;;;; Document sync features
 
@@ -218,50 +223,50 @@
   (->> params
        (handler/references components)
        (conform-or-log ::coercer/locations)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/completion" [_ components params]
   (->> params
        (handler/completion components)
        (conform-or-log ::coercer/completion-items)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "completionItem/resolve" [_ components item]
   (->> item
        (conform-or-log ::coercer/input.completion-item)
        (handler/completion-resolve-item components)
        (conform-or-log ::coercer/completion-item)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/prepareRename" [_ components params]
   (->> params
        (handler/prepare-rename components)
        (conform-or-log ::coercer/prepare-rename-or-error)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/rename" [_ components params]
   (->> params
        (handler/rename components)
        (conform-or-log ::coercer/workspace-edit-or-error)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/hover" [_ components params]
   (->> params
        (handler/hover components)
        (conform-or-log ::coercer/hover)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/signatureHelp" [_ components params]
   (->> params
        (handler/signature-help components)
        (conform-or-log ::coercer/signature-help)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/formatting" [_ components params]
   (->> params
        (handler/formatting components)
        (conform-or-log ::coercer/edits)
-       p/future))
+       eventually))
 
 (def ^:private formatting (atom false))
 
@@ -280,85 +285,85 @@
   (->> params
        (handler/code-actions components)
        (conform-or-log ::coercer/code-actions)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/codeLens" [_ components params]
   (->> params
        (handler/code-lens components)
        (conform-or-log ::coercer/code-lenses)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "codeLens/resolve" [_ components params]
   (->> params
        (handler/code-lens-resolve components)
        (conform-or-log ::coercer/code-lens)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/definition" [_ components params]
   (->> params
        (handler/definition components)
        (conform-or-log ::coercer/location)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/declaration" [_ components params]
   (->> params
        (handler/declaration components)
        (conform-or-log ::coercer/location)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/implementation" [_ components params]
   (->> params
        (handler/implementation components)
        (conform-or-log ::coercer/locations)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/documentSymbol" [_ components params]
   (->> params
        (handler/document-symbol components)
        (conform-or-log ::coercer/document-symbols)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/documentHighlight" [_ components params]
   (->> params
        (handler/document-highlight components)
        (conform-or-log ::coercer/document-highlights)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/full" [_ components params]
   (->> params
        (handler/semantic-tokens-full components)
        (conform-or-log ::coercer/semantic-tokens)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/semanticTokens/range" [_ components params]
   (->> params
        (handler/semantic-tokens-range components)
        (conform-or-log ::coercer/semantic-tokens)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/prepareCallHierarchy" [_ components params]
   (->> params
        (handler/prepare-call-hierarchy components)
        (conform-or-log ::coercer/call-hierarchy-items)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "callHierarchy/incomingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-incoming components)
        (conform-or-log ::coercer/call-hierarchy-incoming-calls)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "callHierarchy/outgoingCalls" [_ components params]
   (->> params
        (handler/call-hierarchy-outgoing components)
        (conform-or-log ::coercer/call-hierarchy-outgoing-calls)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "textDocument/linkedEditingRange" [_ components params]
   (->> params
        (handler/linked-editing-ranges components)
        (conform-or-log ::coercer/linked-editing-ranges-or-error)
-       p/future))
+       eventually))
 
 ;;;; Workspace features
 
@@ -385,13 +390,13 @@
   (->> params
        (handler/workspace-symbols components)
        (conform-or-log ::coercer/workspace-symbols)
-       p/future))
+       eventually))
 
 (defmethod lsp.server/receive-request "workspace/willRenameFiles" [_ components params]
   (->> params
        (handler/will-rename-files components)
        (conform-or-log ::coercer/workspace-edit)
-       p/future))
+       eventually))
 
 (defn capabilities [settings]
   (conform-or-log


### PR DESCRIPTION
The body of a promise created by `p/future` is always run, even if the promise is cancelled (by lsp4clj) with `p/cancel!`. For this reason, clojure-lsp was doing more work on cancelled futures than it really needed to.

This switches back to `CompletableFuture/supplyAsync` + `Supplier`, which can actually be cancelled. This is how the code worked before the migration away from lsp4j.

To be more concrete, the following will always return `[1, 2, ... max-n]`.

```clojure
(defn check [make-future]
  (let [results (atom [])
        common-parallelism (java.util.concurrent.ForkJoinPool/getCommonPoolParallelism)
        max-n (* 2 common-parallelism)
        process-result (fn [n]
                         (Thread/sleep (* 100 n))
                         (swap! results conj n))
        futs (doall
               (map (fn [n]
                      (make-future #(process-result n)))
                    (range 1 (inc max-n))))]
    ;; give executor time to start first `common-parallelism` tasks
    (Thread/sleep 20)
    ;; cancel all futures, before some have started, and before any are finished
    (run! p/cancel! futs)
    ;; wait until all futures _would_ have finished, if they had been run
    (Thread/sleep (* 200 max-n))
    ;; check which futures actually ran
    @results))

(check (fn [f] (p/future (f))))
```

This is in contrast to the following, which returns a vector containing fewer results, usually `[1, 2, ... common-parallelism]`, but never more than `common-parallelism` of the `n`s.

```clojure
(check (fn [f]
         (java.util.concurrent.CompletableFuture/supplyAsync
           (reify java.util.function.Supplier
             (get [_] (f))))))
```

That is, if a `supplyAsync` future is cancelled before the executor starts it, then the body of `Supplier/get` is never run, whereas the body of a `p/future` is always run, even if it is cancelled.

This is an amendment to #1259 and may improve lingering problems from #1240. 

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
