### PR TITLE
Handle clojure-lsp executable according to its usage

### DIFF
--- a/scripts/make.clj
+++ b/scripts/make.clj
@@ -5,19 +5,41 @@
    [babashka.fs :as fs]
    [babashka.process :as p]))
 
-(def lsp-bin (if (#'fs/windows?)
-               "clojure-lsp.bat"
-               "clojure-lsp"))
+(def windows? (#'fs/windows?))
+
+(defn lsp-bin-filename
+  "Returns the `clojure-lsp` executable filename for this system based
+  on the intented USAGE.
+
+  On MS-Windows, the extensions of the script and native executable
+  are different (`clojure-lsp.bat` vs `clojure-lsp.exe`) and serve
+  different needs. We should be able to differentiate
+  betweent the two.
+
+  USAGE can be one of
+
+  :native The filename of the native executable.
+
+  :script The filename of the executable script wrapper."
+  [usage]
+  (let [lsp-bin "clojure-lsp"]
+    (case usage
+      :native (cond-> lsp-bin windows? (str ".exe"))
+      :script (cond-> lsp-bin windows? (str ".bat")))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn clean
   "Clean all artifacts produced by the various tasks."
   []
-  (let [files (into ["cli/target"
-                     (fs/path "cli" lsp-bin)
+  (let [lsp-bin-native (lsp-bin-filename :native)
+        lsp-bin-script  (lsp-bin-filename :script)
+        files (into ["cli/target"
+                     (fs/path "cli" lsp-bin-native)
+                     (fs/path "cli" lsp-bin-script)
                      "cli/clojure-lsp-standalone.jar"
                      "lib/clojure-lsp.jar"
-                     lsp-bin
+                     lsp-bin-native
+                     lsp-bin-script
                      "docs/README.md"
                      "docs/CHANGELOG.md"]
                     (fs/match "." "regex:clojure-lsp.*\\.jar"))]
@@ -63,11 +85,11 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn debug-cli
-  "Build the `clojure-lsp[.bat]` cli exec script (`cider-nrepl`/`clj-async-profile` support)."
+  "Build the `clojure-lsp[.bat]` cli exec script (suppots `cider-nrepl`/`clj-async-profile`)."
   []
   (-> (deps/clojure ["-T:build" "debug-cli"] {:dir "cli" :inherit true})
       p/check)
-  (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
+  (fs/move (fs/path "cli" (lsp-bin-filename :script)) "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn prod-cli
@@ -75,7 +97,7 @@
   []
   (-> (deps/clojure ["-T:build" "prod-cli"] {:dir "cli" :inherit true})
       p/check)
-  (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
+  (fs/move (fs/path "cli" (lsp-bin-filename :script)) "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn native-cli
@@ -83,7 +105,7 @@
   []
   (-> (deps/clojure ["-T:build" "native-cli"] {:dir "cli" :inherit true})
       (p/check))
-  (fs/move (fs/path "cli" lsp-bin) "." {:replace-existing true}))
+  (fs/move (fs/path "cli" (lsp-bin-filename :native)) "." {:replace-existing true}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn test-lib
@@ -110,10 +132,25 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn integration-test
-  "Run the integration tests in 'test/integration-test/' using `./clojure-lsp[.bat|.exe]`."
+  "Run the integration tests in 'test/integration-test/' using `./clojure-lsp[.bat|.exe]`.
+
+  There should only be one clojure-lsp executable found, throws error
+  otherwise."
   []
-  (let [bb (str \" (.get (.command (.info (java.lang.ProcessHandle/current)))) \")]
-    (p/shell {:dir "cli"} (str bb " integration-test ../" lsp-bin))))
+
+  (let [bin-native (str  (lsp-bin-filename :native))
+        bin-script (str  (lsp-bin-filename :script))
+        lsp-bins [bin-native bin-script]
+        lsp-bins-found (reduce (fn [col bin] (if (and (not (col bin)) (fs/exists? bin))
+                                               (conj col bin)
+                                               col))
+                               #{}  #{bin-native bin-script})
+        bb (str \" (.get (.command (.info (java.lang.ProcessHandle/current)))) \")]
+    (case (count lsp-bins-found)
+      0 (throw (ex-info "No clojure-lsp executables found." {:searched-for lsp-bins}))
+      1 (p/shell {:dir "cli"} bb "integration-test" (str (fs/path ".." (first lsp-bins-found))))
+      (throw (ex-info "More than one clojure-lsp executables found. Can only work with one."
+                      {:bin-found lsp-bins-found})))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn lint-clean []


### PR DESCRIPTION
Fixes #1275 PR issue with running integration test in `release.yml` with native executable on MS-Windows

There can be now two executables with different extensions created for windows (`.bat` and `.exe`) and the logic should be able to differentiate between the two based on their usage.

btw the following is called as if `babashka.fs/windows?` was private (it is not) to get around a false clojure-lsp warning:

```clojure
(def windows? (#'fs/windows?))
```

There must be a bug somewhere in the diagnostics linter? as if the kondo config from `babashka.fs` has not been copied over ...
``` bat
d:/src/clojure-lsp $ bb lint-diagnostics
[100%] Project analyzed            
Finding diagnostics...
scripts\make.clj:8:14: error: [private-call] #'babashka.fs/windows? is private
----- Error --------------------------------------------------------------------
```


