### PR TITLE
Bump graalvm to 22.2.0 for the MS-Windows release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
   windows:
     name: Build native Windows binary
     needs: [build-lib-jar, build-cli-jar]
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -358,12 +358,17 @@ jobs:
       - name: Install GraalVM
         uses: DeLaGuardo/setup-graalvm@master
         with:
-          graalvm: 21.3.0
+          graalvm: 22.2.0
           java: java11
 
       - name: Install native-image component
         run: |
           gu.cmd install native-image
+
+      # see https://github.com/oracle/graal/issues/4340
+      - name: GraalVM 22.2.0 workaround to support UPX compression
+        run: |
+          7z d "$env:JAVA_HOME\lib\svm\builder\svm.jar" com/oracle/svm/core/windows/WindowsImageHeapProviderFeature.class
 
       - name: Build Windows native image
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fix issue with changes being reporting with spurious and incorrect line endings on MS-Windows text files. #1211
   - Index internal data by URI instead of filename, to minimize conversion between these formats when running queries. #1207
   - Add support to enable trace logs on server via `--trace` flag. (For latest Emacs's lsp-mode this can be enabled easyly via `lsp-clojure-trace-enable` variable)
+  - Bump graalvm version for MS-Windows to 22.2.0, in sync with the other archs. #1211
 
 - Editor
   - Fix to avoid error when checking code actions from an #_x uneval node. #1227


### PR DESCRIPTION
Hi,

could you please review patch to upgrade Graalvm for the MS-Windows executable to 22.2.0, in sync with the other archs. This is part of #1211

This Graalvm version does not work with well with the UPX compression program, as per https://github.com/oracle/graal/issues/4340

A workaround suggested in that thread is to remove a class file from GraalVMs `svm.jar` file, which appears to work -- all integration tests pass.

Thanks

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

