### PR TITLE
Parse and nav to initial comment or whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - Fix: wait for rename to apply before allowing another rename, to ensure suggested name is correct. #1270
   - Process requests in parallel, to prevent typing lag and other performance problems introduced during migration away from lsp4j. #1240
   - Fix: Avoid wrong ns require after `Create ns and require` code-action/command.
+  - Fix: Avoid errors when a file starts with a comment. #1252
 
 - API/CLI
   - Fix missing diagnostics when `--project-root` is different than current directory. #1245

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -3,6 +3,7 @@
    [clojure-lsp.common-symbols :as common-sym]
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.feature.clean-ns :as f.clean-ns]
+   [clojure-lsp.parser :as parser]
    [clojure-lsp.queries :as q]
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.settings :as settings]
@@ -44,7 +45,7 @@
                   ;; re-read zloc to get a unchanged zloc with :forms
                   (some-> loc
                           z/root-string
-                          z/of-string
+                          parser/z-of-string*
                           (f.clean-ns/clean-ns-edits uri db)
                           first
                           (assoc :range range))

--- a/lib/src/clojure_lsp/feature/clean_ns.clj
+++ b/lib/src/clojure_lsp/feature/clean_ns.clj
@@ -1,5 +1,6 @@
 (ns clojure-lsp.feature.clean-ns
   (:require
+   [clojure-lsp.parser :as parser]
    [clojure-lsp.queries :as q]
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.settings :as settings]
@@ -425,8 +426,7 @@
 (defn clean-ns-edits
   [zloc uri db]
   (let [settings (settings/all db)
-        ;; TODO: use parser?
-        safe-loc (or zloc (z/of-string (get-in db [:documents uri :text])))
+        safe-loc (or zloc (parser/zloc-of-file db uri))
         ns-loc (edit/find-namespace safe-loc)]
     (when ns-loc
       (let [ns-inner-blocks-indentation (resolve-ns-inner-blocks-identation db)

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -3,6 +3,7 @@
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.feature.add-missing-libspec :as f.add-missing-libspec]
    [clojure-lsp.feature.file-management :as f.file-management]
+   [clojure-lsp.parser :as parser]
    [clojure-lsp.queries :as q]
    [clojure-lsp.refactor.edit :as edit]
    [clojure-lsp.shared :as shared]
@@ -117,7 +118,8 @@
                 dest-refs (filter (comp #(= % dest-uri) :uri) refs)
                 per-file-usages (group-by :uri refs)
                 insertion-loc (some-> (f.file-management/force-get-document-text dest-uri components)
-                                      z/of-string
+                                      parser/z-of-string*
+                                      z/down
                                       z/rightmost)
                 insertion-pos (meta (z/node insertion-loc))
                 dest-inner-usages (->> inner-usages
@@ -139,7 +141,7 @@
                                               (let [usage (first usages)
                                                     usage-uri (:uri usage)
                                                     file-loc (some-> (f.file-management/force-get-document-text file-uri components)
-                                                                     z/of-string)
+                                                                     parser/z-of-string*)
                                                     db @db*
                                                     local-buckets (get-in db [:analysis usage-uri])
                                                     source-refer (first (filter #(and (:refer %)

--- a/lib/test/clojure_lsp/parser_test.clj
+++ b/lib/test/clojure_lsp/parser_test.clj
@@ -30,7 +30,7 @@
 (deftest to-pos-test
   (testing "complete code"
     (let [zloc (parser/safe-zloc-of-string "  foo  ")]
-      (is (= nil (z/string (parser/to-pos zloc 1 1))))
+      (is (= "  " (z/string (parser/to-pos zloc 1 1))))
       (is (= 'foo (z/sexpr (parser/to-pos zloc 1 3))))
       (is (= 'foo (z/sexpr (parser/to-pos zloc 1 5))))
       (is (= "  " (z/string (parser/to-pos zloc 1 6))))))


### PR DESCRIPTION
Addresses #1252.

Note that this standardizes which node we parse to (always the `:forms` node) but doesn't eliminate any defensive checks for nil zlocs. We still have to be careful about nils because an empty file doesn't contain any nodes besides the root `:forms` node, which means any zipper navigation will return nil.

If and when https://github.com/clj-commons/rewrite-clj/issues/189 is fixed, we can switch to the rewrite-clj implementation.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
