### PR TITLE
Ignore GitHub Action dependency updates, cache dependencies to check

### DIFF
--- a/.github/workflows/bump_deps.yml
+++ b/.github/workflows/bump_deps.yml
@@ -22,10 +22,20 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Check deps
-      uses: nnichols/clojure-dependency-update-action@679163d5c8b407342c79a9176d2d559bd1a83e83
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      env:
+          cache-name: clojure-deps
       with:
-        skips: "pom"
+          path: ~/.m2
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/deps-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}
+
+    - name: Check deps
+      uses: nnichols/clojure-dependency-update-action@v4
+      with:
+        skips: "pom github-action"
         directories: "cli lib"
         git-username: clojure-lsp-bot
         github-token: ${{ secrets.CLOJURE_LSP_BOT_TOKEN }}


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)

Resolving an issue [against the dependency update job.](https://github.com/nnichols/clojure-dependency-update-action/issues/15)

Antq recently got the ability to check for updates to imported actions in your Workflow files, but doesn't yet have the ability to generate the file changes needed to modify the .yml files. The jobs were repeatedly trying to create PRs for those dependencies, so I added the `github-actions` type to the list of dependency types to skip. This accounted for a mass of repeated updates against existing branches.

I also added some caching for the deps your app declares so it doesn't have to deep fetch them every run. You may want to use that cache in other jobs (especially since you're testing against a matrix), and cache other folders (e.g. the gitlibs dir)