### PR TITLE
bump promesa to 9.0.462

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Process requests in parallel, to prevent typing lag and other performance problems introduced during migration away from lsp4j. #1240
   - Fix: Avoid wrong ns require after `Create ns and require` code-action/command.
   - Fix: Avoid errors when a file starts with a comment. #1252
+  - Bump promesa to `9.0.462` and use it for parallel request processing.
 
 - API/CLI
   - Fix missing diagnostics when `--project-root` is different than current directory. #1245

--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -4,7 +4,7 @@
         nrepl/bencode {:mvn/version "1.1.0"}
         com.taoensso/timbre {:mvn/version "5.2.1"}
         clojure-lsp/lib {:local/root "../lib"}
-        funcool/promesa {:mvn/version "8.0.450"}}
+        funcool/promesa {:mvn/version "9.0.462"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}
                                lambdaisland/kaocha {:mvn/version "1.70.1086"}}

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -18,13 +18,11 @@
    [lsp4clj.liveness-probe :as lsp.liveness-probe]
    [lsp4clj.lsp.requests :as lsp.requests]
    [lsp4clj.server :as lsp.server]
-   [taoensso.timbre :as timbre])
-  (:import
-   (java.util.concurrent CompletableFuture)
-   (java.util.function Supplier)))
+   [promesa.core :as p]
+   [taoensso.timbre :as timbre]))
 
 (defmacro eventually [& body]
-  `(CompletableFuture/supplyAsync (reify Supplier (get [this] ~@body))))
+  `(p/future ~@body))
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
This version includes a fix that allows its futures to be cancelled, which was requested in https://github.com/funcool/promesa/issues/111 and implemented in https://github.com/funcool/promesa/commit/b0df22496899daf8ec6b0cf146f3adce494e688c.

This fix lets us use its futures for parallel request processing.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
