### PR TITLE
Rename test files and crawler

### DIFF
--- a/cli/build.clj
+++ b/cli/build.clj
@@ -1,11 +1,9 @@
 (ns build
   (:require
    [babashka.fs :as fs]
-   [babashka.process :as p]
    [clojure.java.io :as io]
    [clojure.string :as string]
-   [clojure.tools.build.api :as b]
-   [clojure.xml :as xml]))
+   [clojure.tools.build.api :as b]))
 
 (def lib 'com.github.clojure-lsp/clojure-lsp)
 (def clojars-lib 'com.github.clojure-lsp/clojure-lsp-standalone)

--- a/docs/all-available-settings.edn
+++ b/docs/all-available-settings.edn
@@ -2,7 +2,7 @@
 ;; Check the settings documentation section for more details of each one.
 {:source-paths #{"src" "test"} ;; auto-resolved for deps.edn, project.clj or bb.edn projects
  :source-aliases #{:dev :test}
- :project-specs [] ;; Check the default at clojure-lsp.crawler/default-project-specs
+ :project-specs [] ;; Check the default at clojure-lsp.classpath/default-project-specs
  :source-paths-ignore-regex ["resources.*" "target.*"]
  :lint-project-files-after-startup? true
  :notify-references-on-file-change true

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -1,6 +1,5 @@
 (ns clojure-lsp.handlers
   (:require
-   [clojure-lsp.startup :as startup]
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.feature.call-hierarchy :as f.call-hierarchy]
    [clojure-lsp.feature.clojuredocs :as f.clojuredocs]
@@ -27,6 +26,7 @@
    [clojure-lsp.queries :as q]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
+   [clojure-lsp.startup :as startup]
    [clojure.core.async :as async]
    [clojure.pprint :as pprint]))
 

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -1,6 +1,6 @@
 (ns clojure-lsp.handlers
   (:require
-   [clojure-lsp.crawler :as crawler]
+   [clojure-lsp.startup :as startup]
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.feature.call-hierarchy :as f.call-hierarchy]
    [clojure-lsp.feature.clojuredocs :as f.clojuredocs]
@@ -92,7 +92,7 @@
     (swap! db* assoc :project-analysis-type :project-and-deps)
     (if project-root-uri
       (do
-        (crawler/initialize-project
+        (startup/initialize-project
           project-root-uri
           client-capabilities
           client-settings
@@ -109,7 +109,7 @@
             (let [settings (:settings db)]
               (when (stubs/check-stubs? settings)
                 (stubs/generate-and-analyze-stubs! settings db*))))
-          (logger/info crawler/startup-logger-tag "Analyzing test paths for project root" project-root-uri)
+          (logger/info startup/startup-logger-tag "Analyzing test paths for project root" project-root-uri)
           (producer/refresh-test-tree producer internal-uris)
           (when (settings/get db [:java] true)
             (async/go

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -1,7 +1,6 @@
 (ns clojure-lsp.internal-api
   (:require
    [cheshire.core :as json]
-   [clojure-lsp.startup :as startup]
    [clojure-lsp.db :as db]
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.diff :as diff]
@@ -14,6 +13,7 @@
    [clojure-lsp.queries :as q]
    [clojure-lsp.settings :as settings]
    [clojure-lsp.shared :as shared]
+   [clojure-lsp.startup :as startup]
    [clojure.core.async :as async :refer [<! go-loop]]
    [clojure.java.io :as io]
    [clojure.string :as string])

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -1,7 +1,7 @@
 (ns clojure-lsp.internal-api
   (:require
    [cheshire.core :as json]
-   [clojure-lsp.crawler :as crawler]
+   [clojure-lsp.startup :as startup]
    [clojure-lsp.db :as db]
    [clojure-lsp.dep-graph :as dep-graph]
    [clojure-lsp.diff :as diff]
@@ -172,7 +172,7 @@
   [{:keys [project-root settings log-path]}
    {:keys [db*] :as components}]
   (try
-    (crawler/initialize-project
+    (startup/initialize-project
       (project-root->uri project-root @db*)
       {:workspace {:workspace-edit {:document-changes true}}}
       (settings/clean-client-settings {})

--- a/lib/src/clojure_lsp/startup.clj
+++ b/lib/src/clojure_lsp/startup.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.crawler
+(ns clojure-lsp.startup
   (:require
    [clojure-lsp.classpath :as classpath]
    [clojure-lsp.clj-depend :as lsp.depend]

--- a/lib/test/clojure_lsp/feature/call_hierarchy_test.clj
+++ b/lib/test/clojure_lsp/feature/call_hierarchy_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.call-hierarchy-test
+(ns clojure-lsp.feature.call-hierarchy-test
   (:require
    [clojure-lsp.feature.call-hierarchy :as f.call-hierarchy]
    [clojure-lsp.test-helper :as h]

--- a/lib/test/clojure_lsp/feature/code_actions_test.clj
+++ b/lib/test/clojure_lsp/feature/code_actions_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.code-actions-test
+(ns clojure-lsp.feature.code-actions-test
   (:require
    [clojure-lsp.feature.code-actions :as f.code-actions]
    [clojure-lsp.parser :as parser]

--- a/lib/test/clojure_lsp/feature/code_lens_test.clj
+++ b/lib/test/clojure_lsp/feature/code_lens_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.code-lens-test
+(ns clojure-lsp.feature.code-lens-test
   (:require
    [clojure-lsp.feature.code-lens :as f.code-lens]
    [clojure-lsp.shared :as shared]

--- a/lib/test/clojure_lsp/feature/completion_test.clj
+++ b/lib/test/clojure_lsp/feature/completion_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.completion-test
+(ns clojure-lsp.feature.completion-test
   (:require
    [clojure-lsp.feature.completion :as f.completion]
    [clojure-lsp.test-helper :as h]

--- a/lib/test/clojure_lsp/feature/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/feature/diagnostics_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.diagnostics-test
+(ns clojure-lsp.feature.diagnostics-test
   (:require
    [clj-depend.api :as clj-depend]
    [clojure-lsp.feature.diagnostics :as f.diagnostic]

--- a/lib/test/clojure_lsp/feature/file_management_test.clj
+++ b/lib/test/clojure_lsp/feature/file_management_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.file-management-test
+(ns clojure-lsp.feature.file-management-test
   (:require
    [clojure-lsp.feature.file-management :as f.file-management]
    [clojure-lsp.shared :as shared]

--- a/lib/test/clojure_lsp/feature/format_test.clj
+++ b/lib/test/clojure_lsp/feature/format_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.format-test
+(ns clojure-lsp.feature.format-test
   (:require
    [clojure-lsp.feature.format :as f.format]
    [clojure-lsp.shared :as shared]

--- a/lib/test/clojure_lsp/feature/hover_test.clj
+++ b/lib/test/clojure_lsp/feature/hover_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.hover-test
+(ns clojure-lsp.feature.hover-test
   (:require
    [clojure-lsp.feature.hover :as f.hover]
    [clojure-lsp.shared :as shared]

--- a/lib/test/clojure_lsp/feature/linked_editing_range_test.clj
+++ b/lib/test/clojure_lsp/feature/linked_editing_range_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.linked-editing-range-test
+(ns clojure-lsp.feature.linked-editing-range-test
   (:require
    [clojure-lsp.feature.linked-editing-range :as f.linked-editing-range]
    [clojure-lsp.test-helper :as h]

--- a/lib/test/clojure_lsp/feature/rename_test.clj
+++ b/lib/test/clojure_lsp/feature/rename_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.rename-test
+(ns clojure-lsp.feature.rename-test
   (:require
    [clojure-lsp.feature.rename :as f.rename]
    [clojure-lsp.shared :as shared]

--- a/lib/test/clojure_lsp/feature/resolve_macro_test.clj
+++ b/lib/test/clojure_lsp/feature/resolve_macro_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.resolve-macro-test
+(ns clojure-lsp.feature.resolve-macro-test
   (:require
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.test-helper :as h]

--- a/lib/test/clojure_lsp/feature/semantic_tokens_test.clj
+++ b/lib/test/clojure_lsp/feature/semantic_tokens_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.semantic-tokens-test
+(ns clojure-lsp.feature.semantic-tokens-test
   (:require
    [clojure-lsp.feature.semantic-tokens :as semantic-tokens]
    [clojure-lsp.test-helper :as h]

--- a/lib/test/clojure_lsp/feature/signature_help_test.clj
+++ b/lib/test/clojure_lsp/feature/signature_help_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.signature-help-test
+(ns clojure-lsp.feature.signature-help-test
   (:require
    [clojure-lsp.feature.signature-help :as f.signature-help]
    [clojure-lsp.test-helper :as h]

--- a/lib/test/clojure_lsp/feature/workspace_symbols_test.clj
+++ b/lib/test/clojure_lsp/feature/workspace_symbols_test.clj
@@ -1,4 +1,4 @@
-(ns clojure-lsp.features.workspace-symbols-test
+(ns clojure-lsp.feature.workspace-symbols-test
   (:require
    [clojure-lsp.feature.workspace-symbols :as f.workspace-symbols]
    [clojure-lsp.test-helper :as h]


### PR DESCRIPTION
This is two different filenames.

First, this renames `lib/test/clojure_lsp/{features => feature}/*`. This allows easier navigation and test execution in editors that understand the relationship between implementation file names and their test file names.

Second, it renames crawler.clj. We talked about this at some point @ericdallo, but I can't find the discussion. I renamed it to `clojure-lsp.startup`, since that's what the functions in the namespace support, but let me know if you'd prefer another name.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- ~I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~
- ~I updated documentation if applicable (`docs` folder)~
