### PR TITLE
Adjust trace level of running server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Editor
   - Add refactorings to change param order of `defn`/`defmacro`, also changing call sites. #1131
   - Avoid shadowing existing locals when restructuring keys. #1229
+  - Let editors control whether the server's log includes traces of the messages they are exchanging. https://github.com/clojure-lsp/lsp4clj/issues/27
 
 ## 2022.10.05-16.39.51
 

--- a/bb.edn
+++ b/bb.edn
@@ -4,7 +4,7 @@
                                       :git/sha "ce060c12a25b552b864dc90f8fb344a2eb91ea9d"}
 
         medley/medley {:mvn/version "1.4.0"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.3.1"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.4.0"}
         ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                  :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}

--- a/cli/bb.edn
+++ b/cli/bb.edn
@@ -1,7 +1,7 @@
 {:paths ["integration-test"]
  :min-bb-version "0.4.0"
  :deps {medley/medley {:mvn/version "1.4.0"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.3.1"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.4.0"}
         ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                  :git/sha "8df0712896f596680da7a32ae44bb000b7e45e68"}}

--- a/cli/src/clojure_lsp/main.clj
+++ b/cli/src/clojure_lsp/main.clj
@@ -40,11 +40,16 @@
         "See https://clojure-lsp.io/settings/ for detailed documentation."]
        (string/join \newline)))
 
+(def ^:private trace-levels
+  #{"off" "messages" "verbose"})
+
 (defn ^:private cli-options []
   [["-h" "--help" "Print the available commands and its options"]
    [nil "--version" "Print clojure-lsp version"]
    [nil "--verbose" "Use stdout for clojure-lsp logs instead of default log settings"]
-   [nil "--trace" "Enable trace logs between client and server, for debugging."]
+   [nil "--trace LEVEL" "Enable trace logs between client and server, for debugging. Set to 'messages' for basic traces, or 'verbose' for more detailed traces."
+    :default "off"
+    :validate [trace-levels (str "Must be in " trace-levels)]]
    ["-s" "--settings SETTINGS" "Optional settings as edn to use for the specified command. For all available settings, check https://clojure-lsp.io/settings"
     :id :settings
     :validate [#(try (edn/read-string %) true (catch Exception _ false))

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -17,7 +17,7 @@
         org.benf/cfr {:mvn/version "0.152"}
 
         babashka/fs {:mvn/version "0.1.11"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.3.1"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.4.0"}
         ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
         }
  :paths ["src" "resources"]


### PR DESCRIPTION
This is the clojure-lsp side of https://github.com/clojure-lsp/lsp4clj/pull/28. A server can be started at the `messages` or `verbose` trace level. While it's running, its trace level can be changed by sending it a new level in the `initialize` request or a `$/setTrace` notification.

A good way to test this is in Calva. While watching the server's logs, change **Clojure > Trace: Server** to 'messages' or 'verbose', then go back to a .clj file. You should start seeing traces in the logs. You can turn the traces off by changing the setting back to 'off'. This works because Calva already sends `$/setTrace` when that setting is changed. Other editors may not send `$/setTrace` yet.

Somewhat unrelated:

The `--verbose` option in the CLI doesn't seem to do anything. Should it be removed?

While working on this I discovered the [$/logTrace](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#logTrace) notification, a notification servers can use to ask clients to "log the trace of the server’s execution". I'm not sure what to make of it. Should we be sending that notification instead of putting traces in the log file? If we do, where would they show up? Alongside the client's own traces? Or are we supposed to send both traces _and_ logs to the client via $/logTrace? If so, that might significantly simplify our logging infrastructure. On the other hand, we'd lose the persistent log files.

- [x] https://github.com/clojure-lsp/lsp4clj/issues/27
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
