### PR TITLE
Avoid blocked requests, and abort cancelled requests

### DIFF
--- a/.clj-kondo/funcool/promesa/config.edn
+++ b/.clj-kondo/funcool/promesa/config.edn
@@ -5,5 +5,4 @@
            promesa.core/plet        clojure.core/let
            promesa.core/loop        clojure.core/loop
            promesa.core/recur       clojure.core/recur
-           promesa.core/with-redefs clojure.core/with-redefs
-           promesa.core/doseq       clojure.core/doseq}}
+           promesa.core/with-redefs clojure.core/with-redefs}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Add refactorings to change param order of `defn`/`defmacro`, also changing call sites. #1131
   - Avoid shadowing existing locals when restructuring keys. #1229
   - Let editors control whether the server's log includes traces of the messages they are exchanging. https://github.com/clojure-lsp/lsp4clj/issues/27
+  - Bump promesa to `9.0.470`
+  - Bump lsp4clj to `1.5.0`
+  - For users with fewer cores, avoid unnecessary waits for file analysis.
+  - Reduce CPU usage by aborting requests that the client won't use.
 
 ## 2022.10.05-16.39.51
 

--- a/bb.edn
+++ b/bb.edn
@@ -4,8 +4,8 @@
                                       :git/sha "ce060c12a25b552b864dc90f8fb344a2eb91ea9d"}
 
         medley/medley {:mvn/version "1.4.0"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.4.0"}
-        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.5.0"
+                                        #_#_:local/root "../../lsp4clj"}
         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                  :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
  :min-bb-version "0.8.156"

--- a/cli/bb.edn
+++ b/cli/bb.edn
@@ -1,8 +1,8 @@
 {:paths ["integration-test"]
  :min-bb-version "0.4.0"
  :deps {medley/medley {:mvn/version "1.4.0"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.4.0"}
-        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.5.0"
+                                        #_#_:local/root "../../lsp4clj"}
         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                  :git/sha "8df0712896f596680da7a32ae44bb000b7e45e68"}}
  :tasks {integration-test entrypoint/run-all}}

--- a/cli/deps.edn
+++ b/cli/deps.edn
@@ -4,7 +4,7 @@
         nrepl/bencode {:mvn/version "1.1.0"}
         com.taoensso/timbre {:mvn/version "5.2.1"}
         clojure-lsp/lib {:local/root "../lib"}
-        funcool/promesa {:mvn/version "9.0.462"}}
+        funcool/promesa {:mvn/version "9.0.470"}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}
                                lambdaisland/kaocha {:mvn/version "1.70.1086"}}

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -17,9 +17,9 @@
         org.benf/cfr {:mvn/version "0.152"}
 
         babashka/fs {:mvn/version "0.1.11"}
-        com.github.clojure-lsp/lsp4clj {:mvn/version "1.4.0"}
-        ;; com.github.clojure-lsp/lsp4clj {:local/root "../../lsp4clj"}
-        }
+        com.github.clojure-lsp/lsp4clj {:mvn/version "1.5.0"
+                                        #_#_:local/root "../../lsp4clj"
+                                        :exclusions [funcool/promesa]}}
  :paths ["src" "resources"]
  :aliases {:test {:extra-deps {clojure-lsp/common-test {:local/root "../common-test"}
                                lambdaisland/kaocha {:mvn/version "1.70.1086"}

--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -47,15 +47,21 @@
        (take 20))
   #_{})
 
-(defn wait-for-all-changes [uris db*]
+(defn ^:private wait-for-changes [{:keys [db* :lsp4clj.server/req-cancelled?]} uris]
   (let [delay-start (System/nanoTime)]
     (loop [immediate? true
            backoff backoff-start
            uris uris]
       (let [now (System/nanoTime)]
-        (if (> (quot (- now delay-start) 1000000) 60000) ; one minute timeout
+        (cond
+          (some-> req-cancelled? deref)
+          {:delay/outcome :cancelled
+           :delay/start delay-start
+           :delay/end now}
+          (> (quot (- now delay-start) 1000000) 60000) ; one minute timeout
           {:delay/outcome :timed-out
            :delay/timeout-uris uris}
+          :else
           (if-let [processing-uris (seq (filter (:processing-changes @db*) uris))]
             (do
               (Thread/sleep backoff)
@@ -67,30 +73,47 @@
                :delay/start delay-start
                :delay/end now})))))))
 
-(defn wait-for-changes [uri db*]
-  (wait-for-all-changes [uri] db*))
-
 (defmacro logging-delayed-task [delay-data task-id & body]
-  (let [process-msg (str task-id " %s")
-        wait-and-process-msg (str process-msg " - waited %s")
-        timeout-msg (format "Timeout in %s waiting for changes to %%s" task-id)
+  (let [cancelled-msg (str task-id " cancelled - waited %s")
+        timed-out-msg (format "Timeout in %s waiting for changes to %%s" task-id)
+        immediate-msg (str task-id " %s")
+        waited-msg (str immediate-msg " - waited %s")
         msg-sym (gensym "log-message")]
     `(let [delay-data# ~delay-data
            delay-outcome# (:delay/outcome delay-data#)]
-       (if (= :timed-out delay-outcome#)
-         (let [~msg-sym (format ~timeout-msg (first (:delay/timeout-uris delay-data#)))]
+       (case delay-outcome#
+         :cancelled
+         (let [~msg-sym (format ~cancelled-msg (shared/format-time-delta-ms (:delay/start delay-data#) (:delay/end delay-data#)))]
+           ~(with-meta `(logger/debug ~msg-sym) (meta &form)))
+         :timed-out
+         (let [~msg-sym (format ~timed-out-msg (first (:delay/timeout-uris delay-data#)))]
            ~(with-meta `(logger/warn ~msg-sym) (meta &form)))
          (let [result# (do ~@body)
                ~msg-sym (case delay-outcome#
                           :immediate
-                          (format ~process-msg
+                          (format ~immediate-msg
                                   (shared/start-time->end-time-ms (:delay/start delay-data#)))
                           :waited
-                          (format ~wait-and-process-msg
+                          (format ~waited-msg
                                   (shared/start-time->end-time-ms (:delay/end delay-data#))
                                   (shared/format-time-delta-ms (:delay/start delay-data#) (:delay/end delay-data#))))]
            ~(with-meta `(logger/info ~msg-sym) (meta &form))
            result#)))))
+
+(defmacro process-after-all-changes
+  [components uris task & body]
+  (with-meta
+    `(logging-delayed-task
+       (wait-for-changes ~components ~uris)
+       ~task
+       ~@body)
+    (meta &form)))
+
+(defmacro process-after-changes
+  [components uri task & body]
+  (with-meta
+    `(process-after-all-changes ~components [~uri] ~task ~@body)
+    (meta &form)))
 
 (defn ^:private element->location [db producer element]
   {:uri (f.java-interop/uri->translated-uri (:uri element) db producer)
@@ -182,9 +205,9 @@
     :resolve-completion-item
     (f.completion/resolve-item item db*)))
 
-(defn prepare-rename [{:keys [db*]} {:keys [text-document position]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+(defn prepare-rename [{:keys [db*] :as components} {:keys [text-document position]}]
+  (process-after-changes
+    components (:uri text-document)
     :prepare-rename
     (let [[row col] (shared/position->row-col position)]
       (f.rename/prepare-rename (:uri text-document) row col @db*))))
@@ -219,16 +242,16 @@
       (mapv #(element->location db producer %)
             (q/find-implementations-from-cursor db (:uri text-document) row col)))))
 
-(defn document-symbol [{:keys [db*]} {:keys [text-document]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+(defn document-symbol [{:keys [db*] :as components} {:keys [text-document]}]
+  (process-after-changes
+    components (:uri text-document)
     :document-symbol
     (let [db @db*]
       (f.document-symbol/document-symbols db (:uri text-document)))))
 
-(defn document-highlight [{:keys [db*]} {:keys [text-document position]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+(defn document-highlight [{:keys [db*] :as components} {:keys [text-document position]}]
+  (process-after-changes
+    components (:uri text-document)
     :document-highlight
     (let [db @db*
           [row col] (shared/position->row-col position)
@@ -364,9 +387,9 @@
     :formatting
     (f.format/formatting (:uri text-document) components)))
 
-(defn range-formatting [{:keys [db*]} {:keys [text-document range]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+(defn range-formatting [{:keys [db*] :as components} {:keys [text-document range]}]
+  (process-after-changes
+    components (:uri text-document)
     :range-formatting
     (let [db @db*
           [row col] (shared/position->row-col (:start range))
@@ -383,9 +406,9 @@
     (f.java-interop/read-content! uri @db* producer)))
 
 (defn code-actions
-  [{:keys [db*]} {:keys [range context text-document]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+  [{:keys [db*] :as components} {:keys [range context text-document]}]
+  (process-after-changes
+    components (:uri text-document)
     :code-actions
     (let [db @db*
           diagnostics (-> context :diagnostics)
@@ -395,9 +418,9 @@
       (f.code-actions/all root-zloc (:uri text-document) row col diagnostics client-capabilities db))))
 
 (defn code-lens
-  [{:keys [db*]} {:keys [text-document]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+  [{:keys [db*] :as components} {:keys [text-document]}]
+  (process-after-changes
+    components (:uri text-document)
     :code-lens
     (f.code-lens/reference-code-lens (:uri text-document) @db*)))
 
@@ -408,17 +431,17 @@
     (f.code-lens/resolve-code-lens uri row col range @db*)))
 
 (defn semantic-tokens-full
-  [{:keys [db*]} {:keys [text-document]}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+  [{:keys [db*] :as components} {:keys [text-document]}]
+  (process-after-changes
+    components (:uri text-document)
     :semantic-tokens-full
     (let [data (f.semantic-tokens/full-tokens (:uri text-document) @db*)]
       {:data data})))
 
 (defn semantic-tokens-range
-  [{:keys [db*]} {:keys [text-document] {:keys [start end]} :range}]
-  (logging-delayed-task
-    (wait-for-changes (:uri text-document) db*)
+  [{:keys [db*] :as components} {:keys [text-document] {:keys [start end]} :range}]
+  (process-after-changes
+    components (:uri text-document)
     :semantic-tokens-range
     (let [db @db*
           [row col] (shared/position->row-col start)
@@ -459,8 +482,8 @@
           [row col] (shared/position->row-col position)]
       (f.linked-editing-range/ranges (:uri text-document) row col db))))
 
-(defn will-rename-files [{:keys [db*]} {:keys [files]}]
-  (logging-delayed-task
-    (wait-for-all-changes (map :old-uri files) db*)
+(defn will-rename-files [{:keys [db*] :as components} {:keys [files]}]
+  (process-after-all-changes
+    components (map :old-uri files)
     :will-rename-files
     (f.file-management/will-rename-files files @db*)))


### PR DESCRIPTION
This makes two changes related to more efficiently handling process-after-changes requests.

First, as we noted while debugging borkdude's clojure-lsp setup, on machines with fewer cores the process-after-changes requests can fill up the thread pool, blocking requests that would find room in the pool on machines with more cores. This is despite the fact that the process-after-changes requests aren't doing anything except sleeping. This PR makes clojure-lsp use two pools, one for the process-after-changes requests, and one for the other requests. That way they don't interfere with each other. If we notice any problems with memory usage from having additional threads, this is easy to turn off... we can simply revert to using the same pool.

Second, this PR changes the process-after-changes requests to abort if they get a signal from lsp4clj that the client has aborted them. This keeps the process-after-changes pool working on requests that the client actually cares about. It also reduces CPU usage by avoiding unnecessary work.

Note that these changes aren't about mitigating performance problems introduced by the migration away from lsp4j. Both of them (or variations on them) would have benefited clojure-lsp even before the migration. 

Finally this PR removes a global lock from `range-formatting`. See the associated commit message for details.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. Part of this is the clojure-lsp side of https://github.com/clojure-lsp/lsp4clj/pull/30
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
