### PR TITLE
Ignore --trace on CLI

### DIFF
--- a/cli/src/clojure_lsp/main.clj
+++ b/cli/src/clojure_lsp/main.clj
@@ -47,8 +47,8 @@
   [["-h" "--help" "Print the available commands and its options"]
    [nil "--version" "Print clojure-lsp version"]
    [nil "--verbose" "Use stdout for clojure-lsp logs instead of default log settings"]
-   [nil "--trace LEVEL" "Enable trace logs between client and server, for debugging. Set to 'messages' for basic traces, or 'verbose' for more detailed traces."
-    :default "off"
+   [nil "--trace" "Deprecated: use --trace-level instead. Enable verbose trace logs between client and server, for debugging."]
+   [nil "--trace-level LEVEL" "Enable trace logs between client and server, for debugging. Set to 'messages' for basic traces, or 'verbose' for more detailed traces. Defaults to 'off' for no traces."
     :validate [trace-levels (str "Must be in " trace-levels)]]
    ["-s" "--settings SETTINGS" "Optional settings as edn to use for the specified command. For all available settings, check https://clojure-lsp.io/settings"
     :id :settings
@@ -143,7 +143,11 @@
 (defn ^:private handle-action!
   [action options]
   (if (= "listen" action)
-    (let [finished @(server/run-server! (:trace options))]
+    (let [trace-level (or (:trace-level options)
+                          (and (:trace options)
+                               "verbose")
+                          "off")
+          finished @(server/run-server! trace-level)]
       {:result-code (if (= :done finished) 0 1)})
     (try
       (case action

--- a/cli/src/clojure_lsp/main.clj
+++ b/cli/src/clojure_lsp/main.clj
@@ -47,8 +47,9 @@
   [["-h" "--help" "Print the available commands and its options"]
    [nil "--version" "Print clojure-lsp version"]
    [nil "--verbose" "Use stdout for clojure-lsp logs instead of default log settings"]
-   [nil "--trace" "Deprecated: use --trace-level instead. Enable verbose trace logs between client and server, for debugging."]
+   [nil "--trace" "Deprecated: use --trace-level instead."]
    [nil "--trace-level LEVEL" "Enable trace logs between client and server, for debugging. Set to 'messages' for basic traces, or 'verbose' for more detailed traces. Defaults to 'off' for no traces."
+    :default "off"
     :validate [trace-levels (str "Must be in " trace-levels)]]
    ["-s" "--settings SETTINGS" "Optional settings as edn to use for the specified command. For all available settings, check https://clojure-lsp.io/settings"
     :id :settings
@@ -143,11 +144,7 @@
 (defn ^:private handle-action!
   [action options]
   (if (= "listen" action)
-    (let [trace-level (or (:trace-level options)
-                          (and (:trace options)
-                               "verbose")
-                          "off")
-          finished @(server/run-server! trace-level)]
+    (let [finished @(server/run-server! (:trace-level options))]
       {:result-code (if (= :done finished) 0 1)})
     (try
       (case action


### PR DESCRIPTION
This is a slight modification of #1310. It marks the old opt `--trace` as deprecated in favor of a new opt `--trace-level`. This will avoid errors for anyone using the old opt.
