### PR TITLE
Fix key to mark code actions preferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Bump lsp4clj to `1.5.0`
   - For users with fewer cores, avoid unnecessary waits for file analysis.
   - Reduce CPU usage by aborting requests that the client won't use.
+  - Fix to mark some code actions as preferred, so editors can emphasize them. https://github.com/clojure-lsp/lsp4clj/issues/32
 
 ## 2022.10.05-16.39.51
 

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -76,26 +76,26 @@
 (defn ^:private require-suggestion-actions
   [uri alias-suggestions]
   (map (fn [{:keys [ns alias refer position count]}]
-         {:title     (format "Add require '[%s%s%s]'%s"
-                             ns
-                             (if alias (str " :as " alias) "")
-                             (if refer (str " :refer [" refer "]") "")
-                             (if count (str " × " count) ""))
-          :kind      :quick-fix
-          :preferred true
-          :command   {:title     "Add require suggestion"
-                      :command   "add-require-suggestion"
-                      :arguments [uri (:line position) (:character position) ns alias refer]}})
+         {:title        (format "Add require '[%s%s%s]'%s"
+                                ns
+                                (if alias (str " :as " alias) "")
+                                (if refer (str " :refer [" refer "]") "")
+                                (if count (str " × " count) ""))
+          :kind         :quick-fix
+          :is-preferred true
+          :command      {:title     "Add require suggestion"
+                         :command   "add-require-suggestion"
+                         :arguments [uri (:line position) (:character position) ns alias refer]}})
        alias-suggestions))
 
 (defn ^:private missing-import-actions [uri missing-imports]
   (map (fn [{:keys [missing-import position]}]
-         {:title     (str "Add import '" missing-import "'")
-          :kind      :quick-fix
-          :preferred true
-          :command   {:title     "Add missing import"
-                      :command   "add-missing-import"
-                      :arguments [uri (:line position) (:character position)]}})
+         {:title        (str "Add import '" missing-import "'")
+          :kind         :quick-fix
+          :is-preferred true
+          :command      {:title     "Add missing import"
+                         :command   "add-missing-import"
+                         :arguments [uri (:line position) (:character position)]}})
        missing-imports))
 
 (defn ^:private change-colls-actions [uri line character other-colls]


### PR DESCRIPTION
This fixes the `Add require` code actions to use the `"isPreferred"` key correctly, so that they are sorted first. Before the migration away from lsp4j we were setting this key correctly, which made editors show the these code actions first. See https://github.com/clojure-lsp/lsp4clj/issues/32 for more context about lsp4j.

Unfortunately, this doesn't fix Emacs lsp-mode. IIRC, it used to sort the `Add require`s first, but even with this change it doesn't.

- [x] Addresses https://github.com/clojure-lsp/lsp4clj/issues/32
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
