### PR TITLE
Improves :kind on symbols, for better iconography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - Bump clj-kondo to `2022.11.03-20221105.203751-5`.
 
 - Editor
-  - Show better icons for multimethods, var-arg fns, protocols, records, interfaces and types.
+  - Show better icons for multimethods, var-arg fns, protocols, records, interfaces and types on `workspace/symbol` and `textDocument/documentSymbol`.
 
 ## 2022.11.03-00.14.57
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   - Only publish progress on initialize if client provided a `workDoneProgress`. #1363
   - Bump clj-kondo to `2022.11.03-20221105.203751-5`.
 
+- Editor
+  - Show better icons for multimethods, var-arg fns, protocols, records, interfaces and types.
+
 ## 2022.11.03-00.14.57
 
 - General

--- a/lib/test/clojure_lsp/feature/call_hierarchy_test.clj
+++ b/lib/test/clojure_lsp/feature/call_hierarchy_test.clj
@@ -144,7 +144,7 @@
     (h/assert-submaps
       [{:from-ranges []
         :to {:name "println [& args]"
-             :kind :variable
+             :kind :function
              :tags []
              :detail "clojure.core"
              :uri (h/file-uri "zipfile:///.m2/clojure.jar::clojure/core.clj")

--- a/lib/test/clojure_lsp/handlers_test.clj
+++ b/lib/test/clojure_lsp/handlers_test.clj
@@ -82,13 +82,13 @@
                               :tags []}
                                ;; defmulti
                              {:name "mult",
-                              :kind :variable,
+                              :kind :interface,
                               :range {:start {:line 0, :character 39}, :end {:line 0, :character 63}},
                               :selection-range {:start {:line 0, :character 49}, :end {:line 0, :character 53}}
                               :tags []}
                                ;; defmethod
                              {:name "mult \"foo\"",
-                              :kind :variable,
+                              :kind :function,
                               :range {:start {:line 0, :character 75}, :end {:line 0, :character 79}},
                               :selection-range {:start {:line 0, :character 75}, :end {:line 0, :character 79}}
                               :tags []}]}}]


### PR DESCRIPTION
When returning symbols from `workspace/symbol` and `textDocument/documentSymbol`, the LSP spec let's you say what "kind" of symbol each is. The clients use the "kind" to pick an icon to display next to each symbol.

Confusingly, for all of the following symbols, clojure-lsp assigned the "kind" as "variable". Therefore these symbols' icons were indistinguishable from symbols defined by `def`.

This patch changes the "kind" as follows.

```clojure
(defn fn-defn-varargs [a & args] a)                 ;; variable -> function (function with var args)
(defmulti interface-defmulti identity)              ;; variable -> interface
(defmethod interface-defmulti :fn-defmethod [x] x)  ;; variable -> function
(defprotocol InterfaceDefprotocol)                  ;; variable -> interface
(definterface InterfaceDefinterface)                ;; variable -> interface
(defrecord ClassDefrecord [])                       ;; variable -> class
(deftype ClassDeftype [])                           ;; variable -> class
```

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
