### PR TITLE
Inlining the sole let binding removes the let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Editor
   - Show better icons for multimethods, var-arg fns, protocols, records, interfaces and types on `workspace/symbol` and `textDocument/documentSymbol`.
+  - Inlining the last binding of a let removes the let. #210
 
 ## 2022.11.03-00.14.57
 

--- a/lib/src/clojure_lsp/feature/code_actions.clj
+++ b/lib/src/clojure_lsp/feature/code_actions.clj
@@ -4,6 +4,7 @@
    [clojure-lsp.feature.destructure-keys :as f.destructure-keys]
    [clojure-lsp.feature.drag :as f.drag]
    [clojure-lsp.feature.drag-param :as f.drag-param]
+   [clojure-lsp.feature.inline-symbol :as f.inline-symbol]
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.feature.restructure-keys :as f.restructure-keys]
    [clojure-lsp.feature.sort-clauses :as f.sort-clauses]
@@ -355,7 +356,7 @@
         can-destructure-keys?* (future (f.destructure-keys/can-destructure-keys? zloc uri db))
         can-restructure-keys?* (future (f.restructure-keys/can-restructure-keys? zloc uri db))
         can-extract-to-def?* (future (r.transform/can-extract-to-def? zloc))
-        inline-symbol?* (future (r.transform/inline-symbol? uri row col db))
+        inline-symbol?* (future (f.inline-symbol/inline-symbol? uri row col db))
         can-add-let? (or (z/skip-whitespace z/right zloc)
                          (when-not (edit/top? zloc) (z/skip-whitespace z/up zloc)))]
     (cond-> []

--- a/lib/src/clojure_lsp/feature/inline_symbol.clj
+++ b/lib/src/clojure_lsp/feature/inline_symbol.clj
@@ -1,0 +1,152 @@
+(ns clojure-lsp.feature.inline-symbol
+  (:require
+   [clojure-lsp.parser :as parser]
+   [clojure-lsp.queries :as q]
+   [clojure-lsp.refactor.edit :as edit]
+   [rewrite-clj.node :as n]
+   [rewrite-clj.zip :as z]))
+
+(defn ^:private end-of [loc]
+  (let [{:keys [end-row end-col]} (meta (z/node loc))]
+    [end-row end-col]))
+
+(defn ^:private start-of [loc]
+  (let [{:keys [row col]} (meta (z/node loc))]
+    [row col]))
+
+(defn ^:private inline-data [uri row col db]
+  (let [{:keys [uri bucket name-row name-col] :as definition} (q/find-definition-from-cursor db uri row col)]
+    (when (or (identical? :locals bucket)
+              (identical? :var-definitions bucket))
+      (when-let [zloc (some-> (parser/safe-zloc-of-file db uri)
+                              (parser/to-pos name-row name-col))]
+        (when-let [op (some-> zloc edit/find-op z/sexpr #{'let 'def})]
+          {:def-elem definition
+           :def-zloc zloc
+           :def-uri uri
+           :def-op op})))))
+
+(defn ^:private merge-edits [start edits]
+  (apply merge-with into start edits))
+
+(defn ^:private ref-replacements [references val-loc]
+  (map (fn [{:keys [uri] :as element}]
+         {uri [{:loc val-loc :range element}]})
+       references))
+
+(defn ^:private delete-between [[start-row start-col] [end-row end-col]]
+  {:loc nil
+   :range {:row     start-row
+           :col     start-col
+           :end-row end-row
+           :end-col end-col}})
+
+(defn ^:private inline-def
+  "Inlines a var defined by `def`, replacing the var with its value in any file
+  it's used in."
+  [uri var-loc references]
+  ;; inlining `foo`, defined in a `def`
+  (let [def-loc (z/up var-loc)
+        start (if-let [prev-loc (z/left def-loc)]
+                ;; (def bar 2)| (def foo 1)
+                (end-of prev-loc)
+                ;; no sibling to left
+                ;; |(def foo 1)
+                (start-of def-loc))
+        ;; (def foo 1)|
+        end (end-of def-loc)]
+    (-> {uri [(delete-between start end)]}
+        (merge-edits (ref-replacements references (z/rightmost var-loc))))))
+
+(defn ^:private inline-one-let-binding
+  "Inlines one of several bindings in a let."
+  [uri local-loc val-loc references]
+  (let [start (if-let [prev-loc (z/left local-loc)]
+                ;; (let [bar 2| foo 1])
+                (end-of prev-loc)
+                ;; no sibling to left
+                ;; (let [|foo 1 bar 2])
+                (start-of local-loc))
+        ;; (let [foo 1| bar 2])
+        end (end-of val-loc)]
+    (-> {uri [(delete-between start end)]}
+        (merge-edits (ref-replacements references val-loc)))))
+
+(defn ^:private replace-refs [let-loc val-loc references]
+  (reduce (fn [let-loc reference]
+            (z/subedit-node
+              let-loc
+              #(z/replace
+                 (edit/find-at-pos % (:row reference) (:col reference))
+                 (z/node val-loc))))
+          let-loc
+          references))
+
+(def ^:private establishes-implicit-do?
+  '#{binding
+     comment
+     defn
+     defn-
+     delay
+     do
+     doseq
+     dosync
+     dotimes
+     fn
+     future
+     io!
+     let
+     letfn
+     locking
+     loop
+     sync
+     try
+     when
+     when-first
+     when-let
+     when-not
+     when-some
+     while
+     with-bindings
+     with-in-str
+     with-local-vars
+     with-open
+     with-out-str})
+
+(defn ^:private inline-sole-let-binding
+  "Inlines the last binding of a let. Splices the body into the surrounding
+  context, wrapping it in a `do` if necessary."
+  [uri local-loc val-loc references]
+  (let [let-form-loc (z/up (z/up local-loc))
+        edit-range (meta (z/node let-form-loc))
+        implicit-do? (let [leftmost (z/leftmost let-form-loc)]
+                       (and (not= leftmost let-form-loc)
+                            (z/sexpr-able? leftmost)
+                            (establishes-implicit-do? (z/sexpr leftmost))))
+        let-form-loc (replace-refs let-form-loc val-loc references)
+        ;; remove `let []`
+        let-body (z/subedit-> let-form-loc z/down z/remove z/down z/remove)
+        one-child? (-> let-body z/down z/rightmost?)]
+    {uri [{:loc (if (or one-child? implicit-do?)
+                  (z/of-node* (n/forms-node (n/children (z/node let-body))))
+                  (z/insert-child let-body 'do))
+           :range edit-range}]}))
+
+(defn ^:private inline-let-binding [uri local-loc references]
+  ;; inlining `foo`, defined in a `let`
+  (let [val-loc (z/right local-loc)]
+    (if (and (z/leftmost? local-loc)
+             (z/rightmost? val-loc))
+      (inline-sole-let-binding uri local-loc val-loc references)
+      (inline-one-let-binding uri local-loc val-loc references))))
+
+(defn inline-symbol? [uri row col db]
+  (boolean (inline-data uri row col db)))
+
+(defn inline-symbol [uri row col db]
+  (when-let [{:keys [def-zloc def-uri def-op def-elem]} (inline-data uri row col db)]
+    (let [references (q/find-references db def-elem false)]
+      {:changes-by-uri
+       (if (= def-op 'def)
+         (inline-def         def-uri def-zloc references)
+         (inline-let-binding def-uri def-zloc references))})))

--- a/lib/src/clojure_lsp/feature/refactor.clj
+++ b/lib/src/clojure_lsp/feature/refactor.clj
@@ -5,6 +5,7 @@
    [clojure-lsp.feature.destructure-keys :as f.destructure-keys]
    [clojure-lsp.feature.drag :as f.drag]
    [clojure-lsp.feature.drag-param :as f.drag-param]
+   [clojure-lsp.feature.inline-symbol :as f.inline-symbol]
    [clojure-lsp.feature.move-form :as f.move-form]
    [clojure-lsp.feature.resolve-macro :as f.resolve-macro]
    [clojure-lsp.feature.restructure-keys :as f.restructure-keys]
@@ -90,7 +91,7 @@
   (f.thread-get/get-in-none loc))
 
 (defmethod refactor :inline-symbol [{:keys [uri row col db]}]
-  (r.transform/inline-symbol uri row col db))
+  (f.inline-symbol/inline-symbol uri row col db))
 
 (defmethod refactor :introduce-let [{:keys [loc args]}]
   (apply r.transform/introduce-let loc args))

--- a/lib/test/clojure_lsp/feature/inline_symbol_test.clj
+++ b/lib/test/clojure_lsp/feature/inline_symbol_test.clj
@@ -1,0 +1,90 @@
+(ns clojure-lsp.feature.inline-symbol-test
+  (:require
+   [clojure-lsp.feature.inline-symbol :as f.inline-symbol]
+   [clojure-lsp.test-helper :as h]
+   [clojure.test :refer [deftest is testing]]))
+
+(h/reset-components-before-test)
+
+(defn inline-symbol [source-file source-text & others]
+  (let [[[source-r source-c]] (h/load-code-and-locs source-text source-file)]
+    (doseq [[other-file other-text] (partition 2 others)]
+      (h/load-code other-text other-file))
+    (let [db (h/db)
+          results (f.inline-symbol/inline-symbol source-file source-r source-c db)]
+      (reduce-kv (fn [result uri changes]
+                   (assoc result uri
+                          (h/changes->code changes uri db)))
+                 {}
+                 (:changes-by-uri results)))))
+
+(deftest inline-first-def-in-file
+  ;; TODO remove the extra line?
+  (is (= {(h/file-uri "file:///a.clj") (h/code ""
+                                               "(def another 5)"
+                                               "(* 2 60)")}
+         (inline-symbol (h/file-uri "file:///a.clj")
+                        (h/code "(def |something (* 2 60))"
+                                "(def another 5)"
+                                "something")))))
+
+(deftest inline-last-def-in-file
+  (is (= {(h/file-uri "file:///a.clj") (h/code "(def another 5)"
+                                               "(* 2 60)")}
+         (inline-symbol (h/file-uri "file:///a.clj")
+                        (h/code "(def another 5)"
+                                "(def |something (* 2 60))"
+                                "something")))))
+
+(deftest inline-def-with-usage-in-another-file
+  (is (= {(h/file-uri "file:///a.clj") "(ns a)"
+          (h/file-uri "file:///b.clj") "(ns b (:require a)) (inc (* 2 60))"}
+         (inline-symbol (h/file-uri "file:///a.clj")
+                        "(ns a) (def |something (* 2 60))"
+                        (h/file-uri "file:///b.clj")
+                        "(ns b (:require a)) (inc a/something)"))))
+
+(deftest inline-def-with-docstring
+  (is (= {(h/file-uri "file:///a.clj") (h/code ""
+                                               "1")}
+         (inline-symbol (h/file-uri "file:///a.clj")
+                        (h/code "(def |something \"a thing\" 1)"
+                                "something")))))
+
+(deftest inline-in-invalid-location
+  (is (= {}
+         (inline-symbol (h/file-uri "file:///a.clj") "|;; comment"))))
+
+(deftest inline-one-binding-let
+  (testing "no wrapper"
+    ;; one child
+    (is (= {(h/file-uri "file:///a.clj") "(inc 1)"}
+           (inline-symbol (h/file-uri "file:///a.clj") "(let [|something 1] (inc something))")))
+    ;; two children
+    ;; TODO: improve spacing?
+    (is (= {(h/file-uri "file:///a.clj") (h/code "(do (dec 1)"
+                                                 "  (inc 1))")}
+           (inline-symbol (h/file-uri "file:///a.clj") (h/code "(let [|something 1]"
+                                                               "  (dec something)"
+                                                               "  (inc something))")))))
+  (testing "wrapper without implicit do"
+    ;; one child
+    (is (= {(h/file-uri "file:///a.clj") "(boolean (inc 1))"}
+           (inline-symbol (h/file-uri "file:///a.clj") "(boolean (let [|something 1] (inc something)))")))
+    ;; two children
+    (is (= {(h/file-uri "file:///a.clj") "(boolean (do (dec 1) (inc 1)))"}
+           (inline-symbol (h/file-uri "file:///a.clj") "(boolean (let [|something 1] (dec something) (inc something)))"))))
+  (testing "wrapper with implicit do"
+    ;; one child
+    (is (= {(h/file-uri "file:///a.clj") "(try (inc 1))"}
+           (inline-symbol (h/file-uri "file:///a.clj") "(try (let [|something 1] (inc something)))")))
+    ;; two children
+    (is (= {(h/file-uri "file:///a.clj") "(try (dec 1) (inc 1))"}
+           (inline-symbol (h/file-uri "file:///a.clj") "(try (let [|something 1] (dec something) (inc something)))")))))
+
+(deftest inline-two-binding-let
+  ;; TODO: remove the extra space?
+  (is (= {(h/file-uri "file:///a.clj") "(let [ other 2] 1 other 1)"}
+         (inline-symbol (h/file-uri "file:///a.clj") "(let [|something 1 other 2] something other something)")))
+  (is (= {(h/file-uri "file:///a.clj") "(let [something 1] something 2 something)"}
+         (inline-symbol (h/file-uri "file:///a.clj") "(let [something 1 |other 2] something other something)"))))


### PR DESCRIPTION
This fixes https://github.com/clojure-lsp/clojure-lsp/issues/210.

```clojure
(let [|a 1] (inc a))
;; before
(let [] (inc 1))
;; after
(inc 1)
```

If the body of the let contains several forms, they will be wrapped in a `do`.

```clojure
(let [|a 1] (dec a) (inc a))
;; before
(let [] (dec 1) (inc 1))
;; after
(do (dec 1) (inc 1))
```

However, if the let is wrapped in a form that introduces an implicit `do`, the explicit `do` will be omitted.

```clojure
(try (let [|a 1] (dec a) (inc a)))
;; before
(try (let [] (dec 1) (inc 1)))
;; after
(try (dec 1) (inc 1))
```

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
