### PR TITLE
Fix Calva's escaped URIs rename issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - General
+  - Fix rename issue with VS-Code/Calva on MS-Windows. #1388
   - Only publish progress on initialize if client provided a `workDoneProgress`. #1363
   - Bump clj-kondo to `2022.11.03-20221116.204630-13`.
   - Avoid wrong clj-kondo configs in case clojure-lsp process is spawned from a different directory than project-root.

--- a/cli/integration-test/integration/helper.clj
+++ b/cli/integration-test/integration/helper.clj
@@ -58,9 +58,16 @@
     (catch IllegalArgumentException _
       uri)))
 
-(defn escape-uri [uri]
+(defn escape-uri
+  "Escapes enough URI characters for testing purposes and returns it.
+
+  On MS-Windows, it will also escape the drive colon, mimicking
+  VS-Code/Calva's behavior."
+  [uri]
   ;; Do a better escape considering more chars
-  (string/replace uri "::" "%3A%3A"))
+  (cond-> (string/replace uri "::" "%3A%3A")
+    windows?
+    (string/replace  #"/([a-zA-Z]):/" "/$1%3A/")))
 
 (defn file->uri [file]
   (let [uri (-> file fs/canonicalize .toUri .toString)]

--- a/cli/integration-test/integration/rename_test.clj
+++ b/cli/integration-test/integration/rename_test.clj
@@ -80,7 +80,8 @@
           :newText "your-key"}
          {:range {:start {:line 13 :character 7} :end {:line 13 :character 13}}
           :newText "your-key"}]}}
-      (lsp/request! (fixture/rename-request "rename/a.cljc" ":your-key" 12 15)))))
+      (with-redefs [h/*escape-uris?* true]
+        (lsp/request! (fixture/rename-request "rename/a.cljc" ":your-key" 12 15))))))
 
 (deftest rename-namespaced-keywords
   (lsp/start-process!)

--- a/cli/src/clojure_lsp/server.clj
+++ b/cli/src/clojure_lsp/server.clj
@@ -259,6 +259,7 @@
 
 (defmethod lsp.server/receive-request "textDocument/rename" [_ components params]
   (->> params
+       (normalize-doc-uri)
        (handler/rename components)
        (conform-or-log ::coercer/workspace-edit-or-error)
        eventually))


### PR DESCRIPTION
Hi,

can you pelase consider patch for restoring renaming functionality on VS Code/Calva on MS-Widnows. It fixes #1388

The bug was inroduced with #1327, which added special handling for escaped URIs coming from Calva (which unexpectedly even encodes the colon in a drive schema). It introduced a lot of   `(normalize-doc-uri)` inside the request handlers, but it is not obvious whether the rename handler was missed by mistake. Question: what qualifies for handled by `(normalize-doc-uri)` in the server? It is not obvious to me.

This patch introduces the missing form for the rename handler. A  test has also been extended to test the rename function. The escape uri fn has been updated to introduced calva's escaping behavior.

thanks

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
