### PR TITLE
Add missing ns snippet paren

### DIFF
--- a/lib/src/clojure_lsp/feature/completion_snippet.clj
+++ b/lib/src/clojure_lsp/feature/completion_snippet.clj
@@ -126,7 +126,7 @@
    {:label "ns"
     :function-call function-call?
     :detail "Insert ns"
-    :insert-text "(ns ${1:name}\n  $0:references})"}
+    :insert-text "(ns ${1:name}\n  ${0:references})"}
    {:label "ns-doc"
     :function-call function-call?
     :detail "Insert ns with docstring"


### PR DESCRIPTION
This is a single symbol. Nobody will notice that it's fixed. I don't think there is any point to mention it in release log.