### PR TITLE
Support Cider's `:style/indent` syntax for indenting macros

### DIFF
--- a/.clj-kondo/funcool/promesa/config.edn
+++ b/.clj-kondo/funcool/promesa/config.edn
@@ -5,4 +5,5 @@
            promesa.core/plet        clojure.core/let
            promesa.core/loop        clojure.core/loop
            promesa.core/recur       clojure.core/recur
-           promesa.core/with-redefs clojure.core/with-redefs}}
+           promesa.core/with-redefs clojure.core/with-redefs
+           promesa.core/doseq       clojure.core/doseq}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Change `:source-paths-ignore-regex` default value to `["target.*"]`, removing resource folders. #1452
   - Bump cljfmt to 0.9.2
   - Bump lsp4clj to 1.7.0
+  - Support `:style/indent` metadata for indentation with cljfmt #1420
 
 - Editor
   - Fix add missing import code action when there are multiple options. #1422

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -243,6 +243,7 @@
    :java-class-usages true
    :context [:clojure.test
              :re-frame.core]
+   :var-definitions {:meta [:style/indent]}
    :symbols true})
 
 (defn ^:private config-for-paths [paths file-analyzed-fn db]


### PR DESCRIPTION
Cider's `:style/indent` metadata is a lightweight, cross-editor way to customize the indentation of macros.

cljfmt supports a configuration setting `:indents` with its own syntax for the same purpose.

This change captures the `:style/indent` metadata with clj-kondo's analysis, converts it to cljfmt's syntax, and merges it into the cljfmt config.

Fixes #1420.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
