### PR TITLE
Collect `:style/indent` metadata from external deps

### DIFF
--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -236,7 +236,8 @@
    :protocol-impls true
    :java-class-definitions true
    :var-usages false
-   :var-definitions {:shallow true}})
+   :var-definitions {:shallow true
+                     :meta    [:style/indent]}})
 
 (def ^:private config-for-full-analysis
   {:arglists true


### PR DESCRIPTION
This follows on from #1471 and #1420, which passes the `:style/indent` metadata from Kondo's analysis to cljfmt. That PR only used `:style/indent` tags from the local codebase, ignoring those in dependencies.

This change collects `:style/indent` metadata from all external deps as well, so all indentation rules are respected by cljfmt.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
