### PR TITLE
Wait for analysis of correct version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Fix cache issue: wrong external dependencies analysis when running clojure-lsp in editor after running on CLI, affecting navigation. #1473
   - Bump lsp4clj fixing progress notifications during initialization for Calva.
   - Allow go to definition of namespace even when the var is not known. Ex: `clojure.string/foo` will go to the definition of `clojure.string`. This is useful for cases where the var was not created yet but user wants to go to the ns to check the available functions or check the correct name of the function.
+  - Avoid basing results on old analysis.
 
 ## 2023.01.26-11.08.16
 

--- a/lib/src/clojure_lsp/db.clj
+++ b/lib/src/clojure_lsp/db.clj
@@ -11,7 +11,6 @@
 (def ^:private db-logger-tag "[DB]")
 
 (def initial-db {:documents {}
-                 :processing-changes #{}
                  :dep-graph {}})
 (defonce db* (atom initial-db))
 


### PR DESCRIPTION
We've been keeping track of a set of the files queued for analysis or currently being analyzed, a set called `:processing-changes`.

However, when managing `:processing-changes` we weren't accounting for the fact that we can have multiple analysis jobs running at the same time. In fact, this is fairly common. The user types a little, we start an analysis job, they type a little more, and then (even before the first job is finished) we start a second job.

When the first job finishes, we remove the file from `:processing-changes`. Then, even though the second job is still running, our records say that the file isn't being analyzed.

We have some companion code called `wait-for-changes`, which tries to wait for the analysis of a file to be finished before providing any information about that file.

Consider the implications for a function like `document-symbol`, which uses `wait-for-changes`.

Typically, the client requests `document-symbol` moments after `did-change`. Suppose two edits happen in quick succession. The second `document-symbol` request will start waiting before the first analysis run is finished. When the first analysis finishes, the file is removed from `:processing-changes`. Then both `document-symbol` requests will be processed.

```
DID-CHANGE
debounce -> analyze -------------> analyzed
  DOCUMENT-SYMBOL                |
  wait-for-changes --------------> run -> symbols
        DID-CHANGE               |
	 debounce -> analyze -------------> analyzed
           DOCUMENT-SYMBOL       |
           wait-for-changes -----> run -> symbols
```

But we wanted the second `document-symbol` request to wait for analysis of the second `did-change`.

With this commit, we now keep track of the latest version of the code for which we have analysis. Things that wait for changes note the version at the time they start waiting, and continue waiting until that version has been analyzed.

```
DID-CHANGE
debounce -> analyze -------------> analyzed
  DOCUMENT-SYMBOL                |
  wait-for-changes --------------> run -> symbols
        DID-CHANGE
	 debounce -> analyze -------------> analyzed
           DOCUMENT-SYMBOL               |
           wait-for-changes -------------> run -> symbols
```

I've described this commit in terms of correctness, but I originally approached it from the perspective of performance. After doing some research I realized that this commit actually makes performance worse, or to be more precise, it no longer returns results as quickly in certain cases, though those results are now based on the correct analysis.

There is, however, one edge case where the new code makes performance better (this is the case I was thinking about originally).

`wait-for-changes` is implemented as a loop with backoff. If it sees that analysis is running, it sleeps for a few milliseconds before checking again. None of that has changed. But with the original implementation, there was a chance that while it was sleeping one analysis job would finish (the one it was waiting for) and another one would start. Then, when it woke up again, it would notice that analysis was _still_ running, and so it would go back to sleep.

Because of this, sometimes `wait-for-changes` would wait unnecessarily for two or more analysis cycles. With the new code, `wait-for-changes` waits for only one cycle, because even if analysis is still running, it can see that the analysis it was originally waiting for has finished.

From a user perspective (on my machine, testing in clojure-lsp and clojure.core) there doesn't seem to be a noticeable change in performance, either negative or positive. But, we should keep an eye out for complaints about performance after merging this. We may decide to roll it back, favoring speed over consistency.

- ~I created an issue to discuss the problem I am trying to solve or an open issue already exists.~
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- ~I updated documentation if applicable (`docs` folder)~
