### PR TITLE
Handle non-string literal docs, follow recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
   - Allow go to definition of namespace even when the var is not known. Ex: `clojure.string/foo` will go to the definition of `clojure.string`. This is useful for cases where the var was not created yet but user wants to go to the ns to check the available functions or check the correct name of the function.
   - Avoid basing results on old analysis.
   - Add new setting `:completion :analysis-type` to choose between `:fast-but-stale`(default) or `:slow-but-accurate`, this should define whether completion should wait for changes that may still happening, this by default reverts the behavior introduced after #1425. #1487
-
-- Editor
   - Fix `textDocument/hover` issue when doc metadata isn't a string literal.
   - Follow references to other vars in doc metadata for use in `textDocument/hover`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   - Avoid basing results on old analysis.
   - Add new setting `:completion :analysis-type` to choose between `:fast-but-stale`(default) or `:slow-but-accurate`, this should define whether completion should wait for changes that may still happening, this by default reverts the behavior introduced after #1425. #1487
 
+- API/CLI
+  - Fix `textDocument/hover` issue when doc metadata isn't a string literal.
+  - Follow references to other vars in doc metadata for use in `textDocument/hover`.
+
 ## 2023.01.26-11.08.16
 
 - General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   - Avoid basing results on old analysis.
   - Add new setting `:completion :analysis-type` to choose between `:fast-but-stale`(default) or `:slow-but-accurate`, this should define whether completion should wait for changes that may still happening, this by default reverts the behavior introduced after #1425. #1487
 
-- API/CLI
+- Editor
   - Fix `textDocument/hover` issue when doc metadata isn't a string literal.
   - Follow references to other vars in doc metadata for use in `textDocument/hover`.
 

--- a/lib/src/clojure_lsp/feature/hover.clj
+++ b/lib/src/clojure_lsp/feature/hover.clj
@@ -95,12 +95,10 @@
                              (meta (second doc'')))))))
           referenced-var-docs
           (when referenced-var-meta
-            (->> (q/find-element-under-cursor
-                   db uri
-                   (:row referenced-var-meta)
-                   (:col referenced-var-meta))
-                 (q/find-definition db)
-                 :doc))]
+            (:doc (q/find-definition-from-cursor
+                    db uri
+                    (:row referenced-var-meta)
+                    (:col referenced-var-meta))))]
       ;; Recur only when the definition has docs
       (when referenced-var-docs
         (recur db markdown? uri referenced-var-docs (inc cnt))))))


### PR DESCRIPTION
Use the idiom `{:doc (:doc (meta #'some-var))}` to dive into the docs of a referenced var in the metadata of a defined var. Only recurse 3 times to avoid shenanigans.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)

Closes #1489