### PR TITLE
Update clj-nix, simplifies nix build

### DIFF
--- a/.github/workflows/update_deps-lock.yml
+++ b/.github/workflows/update_deps-lock.yml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - "**/deps.edn"
+      - "**/bb.edn"
 
 jobs:
   update-lock:
@@ -16,7 +17,7 @@ jobs:
       - uses: cachix/install-nix-action@v17
 
       - name: Update deps-lock
-        run: "nix run github:jlesquembre/clj-nix?ref=0.2.0#deps-lock"
+        run: "nix develop --command deps-lock-update"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.0.3

--- a/deps-lock.json
+++ b/deps-lock.json
@@ -203,16 +203,6 @@
       "hash": "sha256-63Enn5Ak0AUpOBdVZKScWG8P/QAnWaVNPmIPS891Leo="
     },
     {
-      "mvn-path": "cider/cider-nrepl/0.30.0/cider-nrepl-0.30.0.jar",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-1II+rLGpnsUAgOzkZ/h/qe/iD2hLXuesOgb9GdjM7wc="
-    },
-    {
-      "mvn-path": "cider/cider-nrepl/0.30.0/cider-nrepl-0.30.0.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-KeGadyR0AdZfzoVdaANenTD7sn+fxOS+Wg4S4P21XoI="
-    },
-    {
       "mvn-path": "clj-commons/pomegranate/1.2.1/pomegranate-1.2.1.jar",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-A36zRGyfeOzpT7y4FeJrmn7zEgKT9qKaQWl4yeAqsPM="
@@ -303,26 +293,6 @@
       "mvn-path": "com/amazonaws/jmespath-java/1.12.49/jmespath-java-1.12.49.pom",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-K3q8dApBM5bzLK6nQPIYevjHqnKDN+E7THIyf0bhD3o="
-    },
-    {
-      "mvn-path": "com/clojure-goes-fast/clj-async-profiler/1.0.3/clj-async-profiler-1.0.3.jar",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-QdFiP4ck2fUUwC5XXvUjZ8PSP+9RGsBIlPz6ndG1o/c="
-    },
-    {
-      "mvn-path": "com/clojure-goes-fast/clj-async-profiler/1.0.3/clj-async-profiler-1.0.3.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-dxa5i4dimtU9V+KGd1w8z/WX+ucUAIaS1H0TImbGxKk="
-    },
-    {
-      "mvn-path": "com/clojure-goes-fast/clj-memory-meter/0.2.2/clj-memory-meter-0.2.2.jar",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-zsfGWhYAzp/ZHY2102q5w//nTe2yjEPSnQzF7CvnKCw="
-    },
-    {
-      "mvn-path": "com/clojure-goes-fast/clj-memory-meter/0.2.2/clj-memory-meter-0.2.2.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-ssa8Kz4LB8FoZsw9XKaiF61nOkXlIShSIMeM4me0N+I="
     },
     {
       "mvn-path": "com/cognitect/aws/api/0.8.612/api-0.8.612.jar",
@@ -935,16 +905,6 @@
       "hash": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
     },
     {
-      "mvn-path": "criterium/criterium/0.4.6/criterium-0.4.6.jar",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-r14UbxCZd9XNA1vAzjlOySebIySQBp8ErsaO5Mi8FY4="
-    },
-    {
-      "mvn-path": "criterium/criterium/0.4.6/criterium-0.4.6.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-Lb9Ysv6gyT1w02RS6Rf+soFUNpnPGzs+IrGl6cpol0k="
-    },
-    {
       "mvn-path": "de/ubercode/clostache/clostache/1.4.0/clostache-1.4.0.jar",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-KdHna+zYBX5ZBbVahZYPxVeVfme/yjgOxxv59Ok/61M="
@@ -1273,16 +1233,6 @@
       "mvn-path": "nrepl/bencode/1.1.0/bencode-1.1.0.pom",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-o3pFBButfzw3yua864SedMbz58atvnYFR5VghPuua3I="
-    },
-    {
-      "mvn-path": "nrepl/nrepl/1.0.0/nrepl-1.0.0.jar",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-owuXNP8uY582Xw11U7SHcwbypUPPAh4pnRW/HqvWpbs="
-    },
-    {
-      "mvn-path": "nrepl/nrepl/1.0.0/nrepl-1.0.0.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-dHN5LZGfjodYUES5nySqLqFVNCBgRI2opHhGvkXz2nI="
     },
     {
       "mvn-path": "org/apache/activemq/artemis-commons/1.4.0/artemis-commons-1.4.0.jar",

--- a/deps.edn
+++ b/deps.edn
@@ -14,19 +14,4 @@
                                 "lib/test"
                                 "cli/test"]
                   :main-opts ["-m" "kaocha.runner"]}
-           :debug {:extra-paths ["cli/dev"]}
-
-           ;; the below is a copy of bb.edn's deps that must be kept
-           ;; in sync, and is used as temp workaround to inform
-           ;; clj-nix's deps-lock fn about bb deps for building
-           ;; clojure-lsp in flake.nix using babashka.
-           ;;
-           ;; see https://github.com/clojure-lsp/clojure-lsp/issues/1373
-           :nix-flake {:extra-deps {borkdude/gh-release-artifact {:git/url "https://github.com/borkdude/gh-release-artifact"
-                                                                  :git/sha "4a9a74f0e50e897c45df8cc70684360eb30fce80"}
-
-                                    medley/medley {:mvn/version "1.4.0"}
-                                    com.github.clojure-lsp/lsp4clj {:mvn/version "1.8.0"
-                                                                    #_#_:local/root "../../lsp4clj"}
-                                    org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
-                                                             :git/sha "951b49b8c173244e66443b8188e3ff928a0a71e7"}}}}}
+           :debug {:extra-paths ["cli/dev"]}}}

--- a/flake.lock
+++ b/flake.lock
@@ -3,115 +3,130 @@
     "clj-nix": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils_2",
+        "nix-fetcher-data": "nix-fetcher-data",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1659540102,
-        "narHash": "sha256-ci4967IWz8dNoePzidI4RDXh9fFnHOQw4y6sNyn9xy8=",
+        "lastModified": 1688751607,
+        "narHash": "sha256-MmQczk1ooZXgeTVFAbgtYrFxnpOyNhtwHvCgBu8Rs38=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "6d162a46506d94280de247134fa62f9baef0908e",
+        "rev": "9bd2e23cc2e44982e003ff35fa3f3e235151bfcd",
         "type": "github"
       },
       "original": {
         "owner": "jlesquembre",
-        "ref": "0.3.0",
         "repo": "clj-nix",
         "type": "github"
-      }
-    },
-    "cljtools": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-Pks1TCZC5+0Vjc9Zni1oK4ypS9JcmEt8Ijhl6qYfWac=",
-        "type": "file",
-        "url": "https://download.clojure.org/install/clojure-tools-1.11.1.1257.zip"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://download.clojure.org/install/clojure-tools-1.11.1.1257.zip"
       }
     },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "clj-nix",
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687944744,
+        "narHash": "sha256-4ZtRVG/5yWHPZpkit1Ak5Mo1DDnkx1AG1HpNu/P+n5U=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "3864857b2754ab0e16c7c7c626f0e5a1d4e42f38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-part": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1685546676,
+        "narHash": "sha256-XDbjJyAg6odX5Vj0Q22iI/gQuFvEkv9kamsSbQ+npaI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "6ef2707776c6379bc727faf3f83c0dd60b06e0c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1685546676,
+        "narHash": "sha256-XDbjJyAg6odX5Vj0Q22iI/gQuFvEkv9kamsSbQ+npaI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "6ef2707776c6379bc727faf3f83c0dd60b06e0c6",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-fetcher-data": {
+      "inputs": {
+        "flake-part": "flake-part",
+        "flake-parts": "flake-parts",
         "nixpkgs": [
           "clj-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1644227066,
-        "narHash": "sha256-FHcFZtpZEWnUh62xlyY3jfXAXHzJNEDLDzLsJxn+ve0=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "7033f64dd9ef8d9d8644c5030c73913351d2b660",
+        "lastModified": 1685572850,
+        "narHash": "sha256-lYKEqFG9F84xu51H1rM1u+Ip88cINL0+W26sT+vFEZc=",
+        "owner": "jlesquembre",
+        "repo": "nix-fetcher-data",
+        "rev": "f14967db6c92c79b77419f52c22a698518c91120",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "jlesquembre",
+        "repo": "nix-fetcher-data",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681648924,
-        "narHash": "sha256-pzi3HISK8+7mpEtv08Yr80wswyHKsz+RP1CROG1Qf6s=",
+        "lastModified": 1688590700,
+        "narHash": "sha256-ZF055rIUP89cVwiLpG5xkJzx00gEuuGFF60Bs/LM3wc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f294325aed382b66c7a188482101b0f336d1d7db",
+        "rev": "f292b4964cb71f9dfbbd30dc9f511d6165cd109b",
         "type": "github"
       },
       "original": {
@@ -121,15 +136,65 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "clj-nix": "clj-nix",
-        "cljtools": "cljtools",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
I updated `clj-nix` to:
- Add support for Babashka as build tool
- Be more granular about dependencies included in the lock files

The `:nix-flake` alias is no longer necessary. 

Just to build `clojure-lsp`, we don't need the dependencies in the `:debug` alias. I *think* all the other deps.edn files and aliases are needed. If not, you can exclude more dependencies from the lock file with the `--deps-exclude` and/or `--alias-exclude` (you can run `nix run github:jlesquembre/clj-nix#deps-lock -- --help` to see all the options)

I also added a nix shell, which I think is more convenient to run the `deps-lock` command locally and in CI.
