### PR TITLE
Only apply multiple file check when renaming namespace

### DIFF
--- a/lib/src/clojure_lsp/feature/rename.clj
+++ b/lib/src/clojure_lsp/feature/rename.clj
@@ -240,6 +240,7 @@
                :message "Can't rename namespace, client does not support file renames."}}
 
       (and (= :namespace-definitions (:bucket definition))
+           (not= :namespace-alias (:bucket element))
            (not= 1 (count (q/find-all-project-namespace-definitions db (:name definition)))))
       {:error {:code :invalid-params
                :message "Can't rename namespace, namespace is defined in multiple files."}}

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -1196,6 +1196,6 @@
   (h/load-code-and-locs "(ns b)" (h/file-uri "file:///test/b.clj"))
 
   (h/assert-submaps
-    [{:uri "file:///src/a.cljc"}
-     {:uri "file:///test/a.clj"}]
+    [{:uri (h/file-uri "file:///src/a.cljc")}
+     {:uri (h/file-uri "file:///test/a.clj")}]
     (q/find-all-project-namespace-definitions (h/db) 'a)))


### PR DESCRIPTION
Filter out the cases from the check where the namespace's alias is being renamed.
Follow-up of #1628 to fix integration test failures.
Related to https://github.com/clojure-lsp/clojure-lsp/issues/1574

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
