### PR TITLE
Fix truncation of namespaced keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - General
+  - Fix truncation of namespaced keywords #1640
   - Add rewrite-clj node to cursor-info.
   - Fixing semantic-tokens, collons not managed by lsp anymore. #1550
   - Fix `:paths-ignore-regex` setting to consider settings reload.

--- a/lib/src/clojure_lsp/classpath.clj
+++ b/lib/src/clojure_lsp/classpath.clj
@@ -158,9 +158,20 @@
            (string/join ",")
            (conj ["with-profile"])))
 
+(defn ^:private kw->str
+  "Given a keyword, returns a string with the ':' omitted, nil if `kw` is not a keyword."
+  [kw]
+  (cond
+    (qualified-keyword? kw)
+    (str (namespace kw) "/" (name kw))
+    (keyword? kw)
+    (name kw)
+    :else
+    nil))
+
 (defn ^:private deps-source-aliases [source-aliases]
   (some->> source-aliases
-           (map name)
+           (map kw->str)
            seq
            (string/join ":")
            (str "-A:")

--- a/lib/test/clojure_lsp/classpath_test.clj
+++ b/lib/test/clojure_lsp/classpath_test.clj
@@ -38,6 +38,19 @@
              {:project-path "bb.edn"
               :classpath-cmd ["bb" "print-deps" "--format" "classpath"]}]
             (classpath/default-project-specs #{:something}))))
+    (testing "single source-alias (namespaced)"
+      (is (h/assert-contains-submaps
+            [{:project-path "project.clj"
+              :classpath-cmd ["lein" "with-profile" "+something" "classpath"]}
+             {:project-path "deps.edn"
+              :classpath-cmd ["clojure" "-A:ns/something" "-Spath"]}
+             {:project-path "build.boot"
+              :classpath-cmd ["boot" "show" "--fake-classpath"]}
+             {:project-path "shadow-cljs.edn"
+              :classpath-cmd ["npx" "shadow-cljs" "classpath"]}
+             {:project-path "bb.edn"
+              :classpath-cmd ["bb" "print-deps" "--format" "classpath"]}]
+            (classpath/default-project-specs #{:ns/something}))))
     (testing "multiple source-aliases"
       (is (h/assert-contains-submaps
             [{:project-path "project.clj"
@@ -50,7 +63,20 @@
               :classpath-cmd ["npx" "shadow-cljs" "classpath"]}
              {:project-path "bb.edn"
               :classpath-cmd ["bb" "print-deps" "--format" "classpath"]}]
-            (classpath/default-project-specs #{:something :otherthing}))))))
+            (classpath/default-project-specs #{:something :otherthing}))))
+    (testing "multiple source-aliases (namespaced)"
+      (is (h/assert-contains-submaps
+            [{:project-path "project.clj"
+              :classpath-cmd ["lein" "with-profile" "+something,+otherthing" "classpath"]}
+             {:project-path "deps.edn"
+              :classpath-cmd ["clojure" "-A:ns/something:ns/otherthing" "-Spath"]}
+             {:project-path "build.boot"
+              :classpath-cmd ["boot" "show" "--fake-classpath"]}
+             {:project-path "shadow-cljs.edn"
+              :classpath-cmd ["npx" "shadow-cljs" "classpath"]}
+             {:project-path "bb.edn"
+              :classpath-cmd ["bb" "print-deps" "--format" "classpath"]}]
+            (classpath/default-project-specs #{:ns/something :ns/otherthing}))))))
 
 (defn make-components
   "Create a PROJECT-FILENAME file at DIR and return a clojure-lsp


### PR DESCRIPTION
- [X] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [X] I updated documentation if applicable (`docs` folder)

Here is a fix to https://github.com/clojure-lsp/clojure-lsp/issues/1637

A few questions remains:
1. I am not sure I provided enough tests, should this be tested at any other level?
2. I tried to stay as faithful to the original implementation as possible. I assumed the orignal use of `name` was to loose the leading `:` so I added an alternative path if the keyword is namespaced but still using the same keyword functions in case there is something else I am not aware of.
3. I never used `lein` before, is there a similar treatment to do? Or the `+` aliases of `lein` follow their own convention?
4. I didn't edit the changelog yet as I am not sure what is the process, I don't think I've seen it in the link you provided. Assuming the commit short message is good enough, should I paste it under `Unreleased` -> `General`? 
