### PR TITLE
Use the URI constructor instead of toURI to correctly parse a URL with spaces

### DIFF
--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -206,7 +206,8 @@
   [^String uri]
   (if (string/starts-with? uri "jar:")
     (let [conn (jar-uri-string->jar-url-connection uri)
-          jar-file (uri-obj->filepath ^URI (.toURI ^URL (.getJarFileURL conn)))]
+          url ^URL (.getJarFileURL conn)
+          jar-file (uri-obj->filepath ^URI (new URI (.getProtocol url) (.getHost url) (.getPath url) (.getQuery url) nil))]
       (str jar-file ":" (.getEntryName conn)))
 
     (if-let [[_ uri-jar-path nested-file] (and (string/starts-with? uri "file:")

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -40,6 +40,8 @@
   (testing "Windows URIs"
     (is (= (when h/windows? "C:\\c.clj")
            (when h/windows? (shared/uri->filename "file:/c:/c.clj"))))
+    (is (= (when h/windows? "C:\\Users\\FirstName LastName\\c.clj")
+           (when h/windows? (shared/uri->filename "file:/c:/Users/FirstName%20LastName/c.clj"))))
     (is (= (when h/windows? "C:\\c.clj")
            (when h/windows? (shared/uri->filename "file:///c:/c.clj"))))))
 


### PR DESCRIPTION
Related: https://github.com/BetterThanTomorrow/calva/issues/2276

When using Calva, I was getting lots of errors coming from the language server. This was happening because it was trying to access a jar file which had a path that had a space in it and it seems that `.toURI` doesn't correctly parse this space. By instead using one of the URI constructors directly, the space is parsed correctly!

This is **literally** my very first piece of real clojure code I've ever written so if the way I've solved this isn't idiomatic or isn't catching some other edge cases please let me know!
