### PR TITLE
Fix `:dependency-scheme` setting for .java files from jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 - General
   - Bump clj-kondo to `2023.09.07`. 
   - Fix move-to-let/expand-let bug for multi-arity functions #1283
-
-- General
   - Fix `:dependency-scheme` setting for .java files from jars #1653
 
 ## 2023.08.06-00.28.06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- General
+  - Fix `:dependency-scheme` setting for .java files from jars #1653
+
 ## 2023.08.06-00.28.06
 
 - General

--- a/cli/integration-test/integration/helper.clj
+++ b/cli/integration-test/integration/helper.clj
@@ -147,3 +147,6 @@
 
 (defn code [& strings]
   (string/join \newline strings))
+
+(def maven-repository-uri
+  (file->uri (io/file (System/getProperty "user.home") ".m2" "repository")))

--- a/cli/integration-test/integration/java_interop_test.clj
+++ b/cli/integration-test/integration/java_interop_test.clj
@@ -21,7 +21,39 @@
       {:uri (h/source-path->uri "java_interop/SampleClass.java")
        :range {:start {:line 0 :character 0}
                :end {:line 0 :character 0}}}
-      (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 7 5)))))
+      (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 8 5)))))
+
+(deftest find-definition-of-java-class-when-source-in-a-jar-for-zipfile-scheme
+  (lsp/start-process!)
+  (lsp/request! (fixture/initialize-request
+                  {:initializationOptions (-> fixture/default-init-options
+                                              (assoc :dependency-scheme "zipfile"))}))
+  (lsp/notify! (fixture/initialized-notification))
+  (lsp/notify! (fixture/did-open-source-path-notification "java_interop/a.clj"))
+
+  (testing "We find java source class"
+    (h/assert-submap
+      {:uri (str "zip" h/maven-repository-uri
+                 "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0-sources.jar::difflib/DiffUtils.java")
+       :range {:start {:line 0 :character 0}
+               :end {:line 0 :character 0}}}
+      (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 10 12)))))
+
+(deftest find-definition-of-java-class-when-source-in-a-jar-for-jar-scheme
+  (lsp/start-process!)
+  (lsp/request! (fixture/initialize-request
+                  {:initializationOptions (-> fixture/default-init-options
+                                              (assoc :dependency-scheme "jar"))}))
+  (lsp/notify! (fixture/initialized-notification))
+  (lsp/notify! (fixture/did-open-source-path-notification "java_interop/a.clj"))
+
+  (testing "We find java source class"
+    (h/assert-submap
+      {:uri (str "jar:" h/maven-repository-uri
+                 "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0-sources.jar!/difflib/DiffUtils.java")
+       :range {:start {:line 0 :character 0}
+               :end {:line 0 :character 0}}}
+      (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 10 12)))))
 
 (deftest find-definition-of-java-class-when-source-does-not-exists-for-jar-scheme
   (h/delete-project-file "../../.lsp/.cache")
@@ -34,7 +66,7 @@
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-source-path-notification "java_interop/a.clj"))
 
-  (let [result (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 8 5))]
+  (let [result (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 9 5))]
     (testing "We find java compiled class first"
       (h/assert-submap
         {:uri (-> "integration-test/sample-test/.lsp/.cache/java/decompiled/clojure/lang/PersistentVector.java"
@@ -63,7 +95,7 @@
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-source-path-notification "java_interop/a.clj"))
 
-  (let [result (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 8 5))]
+  (let [result (lsp/request! (fixture/definition-request (h/source-path->uri "java_interop/a.clj") 9 5))]
     (testing "We find java compiled class first"
       (h/assert-submap
         {:uri (-> "integration-test/sample-test/.lsp/.cache/java/decompiled/clojure/lang/PersistentVector.java"

--- a/cli/integration-test/sample-test/deps.edn
+++ b/cli/integration-test/sample-test/deps.edn
@@ -1,3 +1,5 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        com.datomic/datomic-free {:mvn/version "0.9.5697"}}}
+        com.datomic/datomic-free {:mvn/version "0.9.5697"}
+        com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
+        com.googlecode.java-diff-utils/diffutils$sources {:mvn/version "1.3.0"}}}

--- a/cli/integration-test/sample-test/src/sample_test/java_interop/a.clj
+++ b/cli/integration-test/sample-test/src/sample_test/java_interop/a.clj
@@ -1,9 +1,11 @@
 (ns sample-test.java-interop.a
   (:import
    (clojure.lang PersistentVector)
-   (sample_test.java_interop SampleClass)))
+   (sample_test.java_interop SampleClass)
+   (difflib DiffUtils)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn my-function []
   (SampleClass.)
-  (PersistentVector.))
+  (PersistentVector.)
+  (type DiffUtils))

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -185,8 +185,8 @@
   (let [filename->uri (memoize #(shared/filename->uri % db))
         trade-filename-for-uri (fn [obj]
                                  (-> obj
-                                     (assoc :uri (or (some-> (:uri obj) shared/conform-uri-scheme)
-                                                     (filename->uri (:filename obj))))
+                                     (assoc :uri (or (some-> (:filename obj) filename->uri)
+                                                     (some-> (:uri obj) shared/conform-uri-scheme)))
                                      (dissoc :filename)))
         with-uris (fn [uris default coll]
                     (merge (zipmap uris (repeat default)) coll))


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)


This change fixes the behavior of going to the definition into a java file in a jar using correct `:dependency-scheme` #1653.



Is this a good place to fix the issue?

How can I write a test for this change?
