### PR TITLE
Adding custom linter params as a CLI option

### DIFF
--- a/cli/src/clojure_lsp/main.clj
+++ b/cli/src/clojure_lsp/main.clj
@@ -103,6 +103,11 @@
     :id :analysis
     :validate [#(try (edn/read-string %) true (catch Exception _ false))
                "Invalid --analysis EDN"]
+    :assoc-fn #(assoc %1 %2 (edn/read-string %3))]
+   [nil "--custom-linters-params PARAMS" "Optional PARAMS as edn to use for custom linters."
+    :id :custom-linters-params
+    :validate [#(try (edn/read-string %) true (catch Exception _ false))
+               "Invalid --custom-linters-params EDN"]
     :assoc-fn #(assoc %1 %2 (edn/read-string %3))]])
 
 (defn ^:private error-msg [errors]

--- a/lib/src/clojure_lsp/clj_depend.clj
+++ b/lib/src/clojure_lsp/clj_depend.clj
@@ -35,7 +35,8 @@
 
 (defn analyze-uri! [uri db]
   (when-let [project-root (some-> db :project-root-uri shared/uri->filename)]
-    (let [config (settings/get db [:clj-depend] {})]
+    (let [params (some-> db :custom-linters-params :clj-depend)
+          config (settings/get db [:clj-depend] {})]
       (when (configured? config project-root)
         ;; NOTE probably can't use dep-graph to find nses of uri, because
         ;; dep-graph won't exist until after kondo analysis is done, which is
@@ -43,18 +44,21 @@
         (when-let [namespace (some-> uri (shared/uri->namespace db) symbol)]
           (-> {:violations {namespace []}}
               (medley/deep-merge
-                (-> (clj-depend/analyze {:project-root (io/file project-root)
-                                         :config (config-with-source-paths config (relative-project-source-paths project-root db))
-                                         :namespaces #{namespace}})
+                (-> (clj-depend/analyze (merge params
+                                               {:project-root (io/file project-root)
+                                                :config (config-with-source-paths config (relative-project-source-paths project-root db))
+                                                :namespaces #{namespace}}))
                     (update :violations #(group-by :namespace %))))))))))
 
 (defn analyze-paths! [paths db]
   (when-let [project-root (some-> db :project-root-uri shared/uri->filename)]
-    (let [config (settings/get db [:clj-depend] {})]
+    (let [params (some-> db :custom-linters-params :clj-depend)
+          config (settings/get db [:clj-depend] {})]
       (when (configured? config project-root)
-        (-> (clj-depend/analyze {:project-root (io/file project-root)
-                                 :config (config-with-source-paths config (relative-project-source-paths project-root db))
-                                 :files (set (map io/file paths))})
+        (-> (clj-depend/analyze (merge params
+                                       {:project-root (io/file project-root) 
+                                        :config (config-with-source-paths config (relative-project-source-paths project-root db)) 
+                                        :files (set (map io/file paths))}))
             (update :violations #(group-by :namespace %)))))))
 
 (defn db-with-results

--- a/lib/src/clojure_lsp/internal_api.clj
+++ b/lib/src/clojure_lsp/internal_api.clj
@@ -197,6 +197,9 @@
       (swap! db* assoc :project-analysis-type :project-and-full-dependencies)
       (analyze! options components))))
 
+(defn ^:private setup-custom-linters-params! [{:keys [custom-linters-params] :as options} {:keys [db*]}]
+  (swap! db* assoc :custom-linters-params custom-linters-params))
+
 (defn ^:private setup-project-and-clojure-only-deps-analysis! [options {:keys [db*] :as components}]
   (let [db @db*]
     (when (or (not (:analysis db))
@@ -330,6 +333,7 @@
 
 (defn ^:private diagnostics* [{{:keys [format]} :output :as options} {:keys [db*] :as components}]
   (setup-api! components)
+  (setup-custom-linters-params! options components)
   (setup-project-and-clojure-only-deps-analysis! options components)
   (cli-println options "Finding diagnostics...")
   (let [db @db*


### PR DESCRIPTION
# Context
Example of use:
```
./clojure-lsp diagnostics --custom-linters-params "{:clj-depend {:snapshot? true}}"
```

# Checks
- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
