### PR TITLE
Bump clj-depend to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Improve overall performance using GraalVM 21 PGO (Profile-Guided Optimizations).
   - Extract the responsibility for merging clj-depend config #1265
   - Support passing configurations to clj-depend via CLI #1694
+  - Bump clj-depend to `0.9.1`
 
 - Editor
   - New paredit refactorings:

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.fabiodomingues</groupId>
       <artifactId>clj-depend</artifactId>
-      <version>0.6.1</version>
+      <version>0.9.1</version>
     </dependency>
     <dependency>
       <groupId>medley</groupId>

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -12,7 +12,7 @@
                              #_#_:local/root "../../clj-kondo"
                              :exclude [com.cognitect/transit-clj
                                        babashka/fs]}
-        com.fabiodomingues/clj-depend {:mvn/version "0.9.0"}
+        com.fabiodomingues/clj-depend {:mvn/version "0.9.1"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"}
         com.github.clj-easy/stub {:mvn/version "0.2.3"}
         org.benf/cfr {:mvn/version "0.152"}

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.fabiodomingues</groupId>
       <artifactId>clj-depend</artifactId>
-      <version>0.9.0</version>
+      <version>0.9.1</version>
     </dependency>
     <dependency>
       <groupId>medley</groupId>


### PR DESCRIPTION
Bump clj-depend to `0.9.1`

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [X] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
