### PR TITLE
Respect :max-line-length wrt. :refer when there are a lot of symbols

### DIFF
--- a/lib/test/clojure_lsp/feature/clean_ns_test.clj
+++ b/lib/test/clojure_lsp/feature/clean_ns_test.clj
@@ -578,6 +578,18 @@
                              "                blowning Dee"
                              "                foo]]))"
                              "   foo bar baz Dee bla blowning"))
+      (test-clean-ns {:settings {:clean {:sort {:refer {:max-line-length 30}}}}}
+                     (h/code "(ns foo.bar"
+                             " (:require"
+                             "   [some :refer [Dee foo bar baz bla blowning cat car clown cobble doo did done danger fear fight]]))"
+                             "   foo bar baz Dee bla blowning cat car clown cobble doo did done danger fear fight")
+                     (h/code "(ns foo.bar"
+                             " (:require"
+                             "  [some :refer [bar baz bla"
+                             "                blowning car"
+                             "                cat clown cobble danger Dee"
+                             "                did done doo fear fight foo]]))"
+                             "   foo bar baz Dee bla blowning cat car clown cobble doo did done danger fear fight"))
       (test-clean-ns {:settings {:clean {:sort {:refer {:max-line-length 40}}}}}
                      (h/code "(ns foo.bar"
                              " (:require"

--- a/lib/test/clojure_lsp/feature/clean_ns_test.clj
+++ b/lib/test/clojure_lsp/feature/clean_ns_test.clj
@@ -587,8 +587,12 @@
                              " (:require"
                              "  [some :refer [bar baz bla"
                              "                blowning car"
-                             "                cat clown cobble danger Dee"
-                             "                did done doo fear fight foo]]))"
+                             "                cat clown"
+                             "                cobble"
+                             "                danger Dee"
+                             "                did done doo"
+                             "                fear fight"
+                             "                foo]]))"
                              "   foo bar baz Dee bla blowning cat car clown cobble doo did done danger fear fight"))
       (test-clean-ns {:settings {:clean {:sort {:refer {:max-line-length 40}}}}}
                      (h/code "(ns foo.bar"


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)

Just for fun I tried if I could fix #1729. 

I could not fully understand the existing algorithm, but it felt like it was calculating something wrong.

The approach I took was
- Calculate how much capacity we have for each line for the actual symbols (`bar baz ..`, `max-chars-per-line`), excluding the initial indentation
- Reduce over the nodes and check if there's enough capacity left on the current line for the new node (+ separator) or if we should spill over to a new line.