### PR TITLE
Fix call to ns-groups when :filename-pattern in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - General
   - Bump clj-kondo to `2024.05.22` fixing high memory usage issue.
+  - Fix use of `:filename-pattern` from kondo breaking references.
 
 ## 2024.04.22-11.50.26
 

--- a/lib/src/clojure_lsp/feature/diagnostics.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics.clj
@@ -43,7 +43,7 @@
 (defn ^:private unused-public-var->finding [element kondo-config]
   (let [keyword-def? (identical? :keyword-definitions (:bucket element))
         kondo-config (if (:ns element)
-                       (kondo-config-for-ns kondo-config (:ns element) (:filename element))
+                       (kondo-config-for-ns kondo-config (:ns element) (-> element :uri shared/uri->filename))
                        kondo-config)]
     {:uri (:uri element)
      :row (:name-row element)
@@ -59,7 +59,7 @@
      :type :clojure-lsp/unused-public-var}))
 
 (defn ^:private exclude-public-diagnostic-definition? [db kondo-config definition]
-  (let [kondo-config (kondo-config-for-ns kondo-config (:ns definition) (:filename definition))
+  (let [kondo-config (kondo-config-for-ns kondo-config (:ns definition) (-> definition :uri shared/uri->filename))
         excluded-syms-regex (get-in kondo-config [:linters :clojure-lsp/unused-public-var :exclude-regex] #{})
         excluded-defined-by-syms-regex (get-in kondo-config [:linters :clojure-lsp/unused-public-var :exclude-when-defined-by-regex] #{})
         excluded-metas (get-in kondo-config [:linters :clojure-lsp/unused-public-var :exclude-when-contains-meta] #{})


### PR DESCRIPTION
- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
