### PR TITLE
Fix clean ns using correct uri to gather data of unused requires.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - General
   - Fix move-form double edit problem in cljc files.
+  - Use correct uri when cleaning ns:es in move-form.
 
 ## 2024.08.05-18.16.00
 

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -172,7 +172,7 @@
                                                               (when source-refer
                                                                 {:refer (:name source-refer)}))
 
-                                                    ns-changes (determine-ns-edits local-buckets file-loc def-to-move source-ns source-refer libspec source-uri db)
+                                                    ns-changes (determine-ns-edits local-buckets file-loc def-to-move source-ns source-refer libspec usage-uri db)
                                                     replacement-ns (cond
                                                                      (:alias libspec)
                                                                      (:alias libspec)


### PR DESCRIPTION
The wrong uri was used when cleaning ns:es as part of moving a form.

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
