### PR TITLE
Fix disabling `:clojure-lsp/unused-public-var` linter also disabling `:clojure-lsp/different-aliases` diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - General
   - Fix move-form double edit problem in cljc files.
+  - Fix disabling `:clojure-lsp/unused-public-var` linter also disabling `:clojure-lsp/different-aliases`
 
 ## 2024.08.05-18.16.00
 

--- a/lib/src/clojure_lsp/kondo.clj
+++ b/lib/src/clojure_lsp/kondo.clj
@@ -237,13 +237,14 @@
       (assoc-in [:config :linters :unresolved-var :report-duplicates] true))))
 
 (defn ^:private run-custom-lint? [config]
-  (not= :off (get-in config [:linters :clojure-lsp/unused-public-var :level])))
+  (or (-> config :linters :clojure-lsp/unused-public-var :level (not= :off))
+      (-> config :linters :clojure-lsp/different-aliases :level (not= :off))))
 
 (defn ^:private custom-lint-project!
   [db {:keys [config] :as kondo-ctx} normalization-config]
   (when (run-custom-lint? config)
     (shared/logging-time
-      "Linting whole project for unused-public-var took %s"
+      "Custom linting the whole project took %s"
       (let [db (db-with-analysis db (normalize kondo-ctx normalization-config db))]
         (f.diagnostic/custom-lint-project! db kondo-ctx)))))
 

--- a/lib/test/clojure_lsp/feature/diagnostics_test.clj
+++ b/lib/test/clojure_lsp/feature/diagnostics_test.clj
@@ -169,14 +169,7 @@
       {:reg-finding! #(swap! findings conj %)
        :config {:linters {:clojure-lsp/unused-public-var {:level :off}}}})
     (h/assert-submaps
-      [{:uri h/default-uri
-        :level :off
-        :type :clojure-lsp/unused-public-var
-        :message "Unused public var 'some-ns/foo'"
-        :row 1
-        :col 20
-        :end-row 1
-        :end-col 23}]
+      []
       @findings))
   (testing "linter level by default is :info"
     (reset! findings [])


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
https://github.com/clojure-lsp/clojure-lsp/issues/1869
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
