### PR TITLE
Remove restriction on simple keyword completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   - Bump clj-kondo to `2024.09.28-20241112.152908-13`
   - Add semantic version sorting in completion lib versions. #1913
 
+- Editor
+  - Change simple keyword completion to return all known keywords. #1920
+
 ## 2024.11.08-17.49.29
 
 - General
@@ -52,7 +55,7 @@
   - Use scope location instead of name location for folding feature.
   - Fix paredit commands to consider previous element when cursor inside a closing bracket.
   - Fix paredit commands to move cursor after applying command.
-  - Fix corner case on paredit comamnds duplicating forms.
+  - Fix corner case on paredit commands duplicating forms.
   - References of a var-definition now consider full quoted qualified symbols. #1804
 
 ## 2024.03.31-19.10.13

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -462,16 +462,12 @@
           (:analysis non-local-db))))
 
 (defn ^:private with-elements-from-keyword
-  [cursor-element cursor-loc matches-fn simple-cursor? caller-var-definition db resolve-support]
+  [cursor-element cursor-loc matches-fn _simple-cursor? caller-var-definition db resolve-support]
   (if (:arglist-kws caller-var-definition)
     (with-definition-kws-args-element-items cursor-loc matches-fn caller-var-definition resolve-support)
     (into [] (comp
                q/xf-analysis->keywords
                (bucket-elems-xf :keyword-usages matches-fn cursor-element)
-               (if simple-cursor?
-                 (filter #(and (:from cursor-element)
-                               (= (:from cursor-element) (:from %))))
-                 identity)
                (map #(element->completion-item % nil (if (= (:from cursor-element) (:from %))
                                                        :keyword-same-ns
                                                        :keyword) resolve-support)))

--- a/lib/test/clojure_lsp/feature/completion_test.clj
+++ b/lib/test/clojure_lsp/feature/completion_test.clj
@@ -522,9 +522,10 @@
          {:label ":foo/baq" :kind :keyword}
          {:label ":foo/bar" :kind :keyword}]
         (f.completion/completion (h/file-uri "file:///b.clj") foo-r foo-c (h/db))))
-    (testing "simple keywords are available only for the current ns"
+    (testing "simple keywords are available everywhere"
       (h/assert-submaps
-        [{:label ":ba" :kind :keyword}]
+        [{:label ":ba" :kind :keyword}
+         {:label ":bar" :kind :keyword}]
         (f.completion/completion (h/file-uri "file:///b.clj") bar-r bar-c (h/db))))))
 
 (deftest completing-aliased-keywords


### PR DESCRIPTION
Removed filter that would only complete simple keywords in the current namespace.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. #1920 
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
