### PR TITLE
Fix range formatting end of doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - General
   - Bump clj-kondo to `2024.09.28-20241112.152908-13`
   - Add semantic version sorting in completion lib versions. #1913
+  - Fix internal error in range formatting. #1931
 
 - Editor
   - Change simple keyword completion to return all known keywords. #1920

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -136,7 +136,8 @@
           start-top-loc (edit/to-top start-loc)
           end-loc (or (parser/to-pos start-top-loc (:end-row format-pos) (:end-col format-pos))
                       (z/rightmost* root-loc))
-          end-top-loc (edit/to-top end-loc)
+          end-top-loc (or (edit/to-top end-loc)
+                          root-loc)
 
           forms (->> start-top-loc
                      (iterate z/right*) ;; maintain comments and whitespace between nodes

--- a/lib/test/clojure_lsp/feature/format_test.clj
+++ b/lib/test/clojure_lsp/feature/format_test.clj
@@ -117,7 +117,15 @@
     (is (= [{:range {:start {:line 0 :character 0}
                      :end {:line 0 :character 5}}
              :new-text "(a)"}]
-           (range-formatting "(a | |)\n(b  )\n(c d)"))))
+           (range-formatting "(a | |)\n(b  )\n(c d)")))
+    (is (= [{:range {:start {:line 0 :character 0}
+                     :end {:line 1 :character 0}}
+             :new-text "(a)\n"}]
+           (range-formatting "|(a  )|\n(b  )\n(c d)")))
+    (is (= [{:range {:start {:line 2 :character 0}
+                     :end {:line 2 :character 5}}
+             :new-text "(c d)"}]
+           (range-formatting "(a  )\n(b  )\n|(c d)|"))))
   (testing "when parens are unbalenced"
     (is (= nil
            (let [[[row col] [end-row end-col]] (h/load-code-and-locs "(str :foo :bar :baz))")]


### PR DESCRIPTION
Fixes #1931

It seemed to me that the caller of `edit/to-top` should account for the possible `nil` value. Let me know if something else should be changed instead and I can adjust the PR.

I added a couple of test cases to cover the start and end ranges. 

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
