### PR TITLE
Add textEdit to completion items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Editor
   - Change simple keyword completion to return all known keywords. #1920
+  - Return textEdit to CompletionItems to fix completion in Zed #1933
 
 ## 2024.11.08-17.49.29
 

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -599,6 +599,21 @@
                        [(:score %1) (:label %2) (:detail %2)]))
        not-empty))
 
+(defn ^:private completion-range [row col cursor-value cursor-element]
+  (or
+    (shared/->range cursor-element)
+    (shared/->range {:row row
+                     :col (- col (count (str cursor-value)))
+                     :end-row row
+                     :end-col col})))
+
+(defn ^:private add-text-edit [range items]
+  (map (fn [item]
+         (merge {:text-edit {:new-text (:label item)
+                             :range range}}
+                item))
+       items))
+
 (defn completion [uri row col db]
   (let [root-zloc (parser/safe-zloc-of-file db uri)
         ;; (dec col) because we're completing what's behind the cursor
@@ -710,7 +725,8 @@
              sorting-and-distincting-items
              ;; Limit the returned items for better performance.
              ;; If user needs more items one should be more specific in the completion query.
-             (take 600))))))
+             (take 600)
+             (add-text-edit (completion-range row col cursor-value cursor-element)))))))
 
 ;;;; Resolve Completion Item (completionItem/resolve)
 

--- a/lib/test/clojure_lsp/feature/completion_test.clj
+++ b/lib/test/clojure_lsp/feature/completion_test.clj
@@ -813,6 +813,8 @@
                                         :new-text (h/code "(ns aaa "
                                                           "  (:require"
                                                           "    [\"@mui/material/Grid$default\" :as Grid]))")}]
+               :text-edit {:new-text "Grid",
+                           :range {:end {:character 13, :line 0}, :start {:character 9, :line 0}}}
                :score 9}]
              (f.completion/completion (h/file-uri "file:///aaa.clj") row col (h/db)))))
 
@@ -830,3 +832,41 @@
                                                                        :uri (h/file-uri "file:///aaa.clj")
                                                                        :js-require true}]]}}
                                                 (h/db*)))))
+
+(deftest text-edit-range
+  (let [[[ns-end-r ns-end-c]
+         [ns-mid-r ns-mid-c]
+         [fn-end-r fn-end-c]
+         [fn-mid-r fn-mid-c]
+         [arg-end-r arg-end-c]
+         [arg-mid-r arg-mid-c]] (h/load-code-and-locs (h/code "(ns aaa"
+                                                              "  (:require [bbb]))"
+                                                              "(defn foo [whatsit]"
+                                                              "  (bb|)"
+                                                              "  (bb|b)"
+                                                              "  (bbb/thi|)"
+                                                              "  (bbb/thi|ng)"
+                                                              "  (bbb/thingy wh|)"
+                                                              "  (bbb/thingy wh|at))")
+                                                      (h/file-uri "file:///aaa.clj"))
+        _ (h/load-code (h/code "(ns bbb)"
+                               "(defn thingy [_a _b _c] nil)")
+                       (h/file-uri "file:///bbb.clj"))]
+    (testing "At end of ns"
+      (h/assert-submap {:text-edit {:range {:start {:line 3 :character 3} :end {:line 3 :character 5}}}}
+                       (first (f.completion/completion (h/file-uri "file:///aaa.clj") ns-end-r ns-end-c (h/db)))))
+    (testing "Within ns"
+      (h/assert-submap {:text-edit {:range {:start {:line 4 :character 3} :end {:line 4 :character 6}}}}
+                       (first (f.completion/completion (h/file-uri "file:///aaa.clj") ns-mid-r ns-mid-c (h/db)))))
+    (testing "At end of fn"
+      (h/assert-submap {:text-edit {:range {:start {:line 5 :character 3} :end {:line 5 :character 10}}}}
+                       (first (f.completion/completion (h/file-uri "file:///aaa.clj") fn-end-r fn-end-c (h/db)))))
+    (testing "Within fn"
+      (h/assert-submap {:text-edit {:range {:start {:line 6 :character 3} :end {:line 6 :character 12}}}}
+                       (first (f.completion/completion (h/file-uri "file:///aaa.clj") fn-mid-r fn-mid-c (h/db)))))
+    (testing "At end of arg"
+      (h/assert-submap {:text-edit {:range {:start {:line 7 :character 14} :end {:line 7 :character 16}}}}
+                       (first (f.completion/completion (h/file-uri "file:///aaa.clj") arg-end-r arg-end-c (h/db)))))
+    (testing "Within arg"
+      (h/assert-submap {:text-edit {:range {:start {:line 8 :character 14} :end {:line 8 :character 18}}}}
+                       (first (f.completion/completion (h/file-uri "file:///aaa.clj") arg-mid-r arg-mid-c (h/db)))))))


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)

Fixes #1933 and https://github.com/zed-extensions/clojure/issues/2

The bug arises from the fact that clojure-lsp is returning `CompletionItem`s without a text edit entry. As [the specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem) says:

> The `insertText` is subject to interpretation by the client side.
	 * Some tools might not take the string literally. For example
	 * VS Code when code complete is requested in this example
	 * `con<cursor position>` and a completion item with an `insertText` of
	 * `console` is provided it will only insert `sole`. Therefore it is
	 * recommended to use `textEdit` instead since it avoids additional client
	 * side interpretation.

Here's the behaviour in Zed after this change:

https://github.com/user-attachments/assets/2383a64f-c5fa-4130-af0e-a4399e01e32f

https://github.com/user-attachments/assets/7a618787-9916-4d03-aed3-4c3f5b1421bd

I've tested in VSCode and (as far as I can see) everything is still working as expected. I believe it should do so, as this change conforms to the Language Server Protocol specification.