### PR TITLE
Add process-after-changes to linked edits

### DIFF
--- a/lib/src/clojure_lsp/handlers.clj
+++ b/lib/src/clojure_lsp/handlers.clj
@@ -468,8 +468,9 @@
       (f.call-hierarchy/outgoing uri row col components))))
 
 (defn linked-editing-ranges
-  [{:keys [db*]} {:keys [text-document position]}]
-  (shared/logging-task
+  [{:keys [db*] :as components} {:keys [text-document position]}]
+  (process-after-changes
+    components (:uri text-document)
     :linked-editing-range
     (let [db @db*
           [row col] (shared/position->row-col position)]


### PR DESCRIPTION
- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)

@ericdallo as discussed.

This makes things *much* better in both VSCode and Zed, but:

* I still see errors in VSCode if I type quickly (nowhere near as many as before this change, but it still happens pretty frequently with my "normal" typing speed.
* It seems to be entirely reliable in Zed (no matter how fast I type). There is a Zed-specific error with hyphens `-` which I've already [reported](https://github.com/zed-industries/zed/issues/23063).