### PR TITLE
Navigation from `declare` to actual definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Editor
   - Improve timbre context log.
   - Fix suggestion for add require code action. #2017
+  - Improve find definition so it works on `declare` forms too. #1986
 
 ## 2025.03.27-20.21.36
 

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -319,12 +319,28 @@
       keyword-usage))
 
 (defmethod find-definition :var-definitions
-  [db {:keys [imported-ns] :as var-definition}]
-  (if (some #(safe-equal? 'potemkin/import-vars %) (defined-bys var-definition))
-    (find-definition db (assoc var-definition
-                               :bucket :var-usages
-                               :to imported-ns))
-    var-definition))
+  [db {:keys [imported-ns defined-by name ns] :as var-definition}]
+  (let [xf-declared-definition (comp xf-analysis->var-definitions
+                                     (xf-same-fqn ns name)
+                                     (filter #(not= 'clojure.core/declare (:defined-by %)))
+                                     (xf-same-lang var-definition))
+        actual-definition (find-last-order-by-project-analysis
+                            xf-declared-definition
+                            (db-with-ns-analysis db ns))]
+    (cond
+      ;; Handle potemkin/import-vars
+      (some #(safe-equal? 'potemkin/import-vars %) (defined-bys var-definition))
+      (find-definition db (assoc var-definition
+                                 :bucket :var-usages
+                                 :to imported-ns))
+
+      ;; Handle navigating from declare to actual definition
+      (and (= defined-by 'clojure.core/declare)
+           actual-definition)
+      actual-definition
+
+      ;; Default case, return the definition as-is
+      :else var-definition)))
 
 (defmethod find-definition :protocol-impls
   [db protocol-impl]

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -732,7 +732,18 @@
           db (h/db)]
       (h/assert-submap
         {:name 'bar :uri (h/file-uri "file:///a.clj") :defined-by 'clojure.core/declare :row decl-r}
-        (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") usage-r usage-c)))))
+        (q/find-definition-from-cursor db (h/file-uri "file:///a.clj") usage-r usage-c))))
+  (testing "navigating from declare to definition"
+    (let [positions (h/load-code-and-locs
+                      (h/code "(ns foo)"
+                              "(declare |bar)"
+                              "(defn something [] (bar))"
+                              "(defn |bar [] 1)") (h/file-uri "file:///a.clj"))
+          [decl-r decl-c] (first positions)
+          definition (q/find-definition-from-cursor (h/db) (h/file-uri "file:///a.clj") decl-r decl-c)]
+      (h/assert-submap
+        {:name 'bar :uri (h/file-uri "file:///a.clj") :defined-by 'clojure.core/defn}
+        definition))))
 
 (deftest find-definition-from-namespace-alias
   (h/load-code-and-locs (h/code "(ns foo.bar) (def a 1)") (h/file-uri "file:///a.clj"))


### PR DESCRIPTION
Enhance navigation by extending `find-definition` to work with declarations too. Check for existence of actual definition as a guard, because without it LSP returns `nil` and some editors have "cascades" for navigation handlers (i.e. Doom Emacs) and they try to find symbol using more naive search methods. #1986 

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
