### PR TITLE
dir-uris->file-uris test fix

### DIFF
--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -283,7 +283,7 @@
 (deftest dir-uris->file-uris-test
   (testing "when the dir-uri is a dir inside source-path"
     (with-redefs [fs/glob (constantly [(h/file-path "/user/project/src/foo/bar.clj")
-                                       (h/file-uri "/user/project/src/foo/baz.clj")])
+                                       (h/file-path "/user/project/src/foo/baz.clj")])
                   fs/canonicalize identity]
       (is (= [(h/file-uri "file:///user/project/src/foo/bar.clj")
               (h/file-uri "file:///user/project/src/foo/baz.clj")]


### PR DESCRIPTION
# Fix dir-uris->file-uris test consistency on Windows

## Problem

The `dir-uris->file-uris-test` was failing on `windows-latest` unit tests due to an inconsistency in the mock setup. The test was mixing `h/file-uri` and `h/file-path` in the `fs/glob` mock, which caused drive letter mismatches on Windows:

```
FAIL in clojure-lsp.shared-test/dir-uris->file-uris-test (shared_test.clj:288)
when the dir-uri is a dir inside source-path
Expected:
  ["file:///C:/user/project/src/foo/bar.clj" "file:///C:/user/project/src/foo/baz.clj"]
Actual:
  ["file:///C:/user/project/src/foo/bar.clj"
   -"file:///C:/user/project/src/foo/baz.clj" +"file:///D:/user/project/src/foo/baz.clj"]
317 tests, 4035 assertions, 1 failures.
```

The issue was that one file was using `h/file-path` (correctly generating `C:` drive) while the other was using `h/file-uri` (incorrectly generating `D:` drive), leading to inconsistent drive letters in the expected vs actual results.

## Solution

Fixed the test by standardizing both file references to use `h/file-path` in the `fs/glob` mock:

```clojure
;; Before (inconsistent - caused Windows drive letter mismatch)
(h/file-path "/user/project/src/foo/bar.clj")    ; -> C: drive
(h/file-uri "/user/project/src/foo/baz.clj")     ; -> D: drive

;; After (consistent - both use same drive)
(h/file-path "/user/project/src/foo/bar.clj")    ; -> C: drive  
(h/file-path "/user/project/src/foo/baz.clj")    ; -> C: drive
```

This ensures that `fs/glob` returns consistent file paths that get properly converted to URIs with the same drive letter.

## Testing

- [x] Fixes the failing Windows unit test
- [x] Maintains test consistency across all platforms
- [x] Verified the test expectations remain valid

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

This fix resolves a Windows-specific test failure where inconsistent mock setup was causing drive letter mismatches in file URI generation.