### PR TITLE
Fix Issue 1851

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - New feature: Add `clojure-lsp/cyclic-dependencies` linter to detect cyclic dependencies between namespaces in the project.
   - New optional `:kondo-config-dir` setting to configure clj-kondo execution.
   - Parallelize and log the time spent on built-in linters execution.
+  - Fix #1851: Error when source files have non-ASCII characters in their path or name
 
 ## 2025.06.13-20.45.44
 

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -205,6 +205,12 @@
     (catch IllegalArgumentException _
       uri)))
 
+(defn ^:private escape-uri
+  [^URI uri]
+  (-> uri
+      (.toASCIIString)
+      (URI.)))
+
 (defn ^:private uri->canonical-path
   "Returns the URI's canonical path as a string using
   `java.io.file/getCanonicalPath`, of which see."
@@ -238,7 +244,7 @@
                                                (re-find #"^(.*\.jar)::(.*)" (.getPath uri-obj)))]
         (if jar-uri-path
           (str (uri->canonical-path (URI. jar-uri-path)) ":" nested-file)
-          (uri-obj->filepath uri-obj))))))
+          (uri-obj->filepath (escape-uri uri-obj)))))))
 
 (defn ensure-jarfile [uri db]
   (let [jar-scheme? (fast= "jar" (get db [:settings :dependency-scheme]))]

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -5,7 +5,8 @@
    [clojure-lsp.test-helper.internal :as h]
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as medley])
-  (:import java.net.URI))
+  (:import
+   java.net.URI))
 
 (h/reset-components-before-test)
 

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -4,7 +4,8 @@
    [clojure-lsp.shared :as shared]
    [clojure-lsp.test-helper.internal :as h]
    [clojure.test :refer [are deftest is testing]]
-   [medley.core :as medley]))
+   [medley.core :as medley])
+  (:import java.net.URI))
 
 (h/reset-components-before-test)
 
@@ -30,6 +31,9 @@
   (testing "should decode special characters in file URI"
     (is (= (h/file-path "/path+/encoded characters!")
            (shared/uri->filename (h/file-uri "file:///path%2B/encoded%20characters%21")))))
+  (testing "should handle unicode characters in a file URI"
+    (is (= (h/file-path "/home/foo/hôpital.clj")
+           (shared/uri->filename (h/file-uri "file:///home/foo/hôpital.clj")))))
   (testing "when it is a jar via zipfile"
     (is (= (h/file-path "/something.jar:something/file.cljc")
            (shared/uri->filename (h/file-uri "zipfile:///something.jar::something/file.cljc")))))
@@ -155,6 +159,16 @@
   (testing "URI should remain the same as IllegalArgumentException is thrown."
     (is (= "file:///home/foo/bar.jar%%"
            (unescape-uri "file:///home/foo/bar.jar%%")))))
+
+(def escape-uri #'shared/escape-uri)
+
+(deftest escape-uri-test
+  (testing "URI should be escaped"
+    (is (= (URI. "file:///home/foo/h%C3%B4pital.clj")
+           (escape-uri (URI. "file:///home/foo/hôpital.clj")))))
+  (testing "URI should remain the same"
+    (is (= (URI. "file:///home/foo/h%C3%B4pital.clj")
+           (escape-uri (URI. "file:///home/foo/h%C3%B4pital.clj"))))))
 
 (deftest inside?
   (testing "when b has end scope"


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)

Fixes #1851 

This PR fixes the issue successfully, and is written to require minimal changes to make it easy to review. However... 

We might need a deeper review of how URLs and URIs are handled. It's unclear (to me at least) when exactly they should be either escaped or unescaped (or canonicalised) and the code is a mix of direct string manipulation, regular expressions, and use of the `URI` and `URL` classes. I strongly suspect there may, as a result, be other instances of this kind of problem elsewhere.