### PR TITLE
Improve wording in Emacs config section

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -21,7 +21,10 @@ exec /usr/local/bin/clojure-lsp
 
 ## Emacs
 
-[lsp-mode](https://emacs-lsp.github.io/lsp-mode) has built in support for `clojure-lsp`. With `use-package`, add the following to your emacs config:
+[eglot](https://www.gnu.org/software/emacs/manual/html_node/eglot/index.html)
+and [lsp-mode](https://emacs-lsp.github.io/lsp-mode) are the two LSP clients for Emacs. Both of them have built-in support for `clojure-lsp` out of the box if it is on your `$PATH`.
+
+With `lsp-mode` and `use-package`, you can add the following to your emacs config:
 
 ```elisp
 (use-package lsp-mode


### PR DESCRIPTION
Improve the wording of the Emacs section of client config.

Clarify that lsp-mode is not required to use clojure-lsp with Emacs.

I don't know much about use-package or lsp-mode so I couldn't really
do much with the rest of the config section, but it could probably
still be clarified more.

In particular, if clojure-lsp is already supported by lsp-mode, why
would you need to add additional config yourself on top of that
existing support?

In addition, it seems the suggested config will automatically activate
clojure-lsp every time you open a clojure-mode file; this should not be
suggested without a warning given that clojure-lsp is not safe to use
on untrusted projects:

https://github.com/clojure-lsp/clojure-lsp/issues/1747

Probably such a warning belongs somewhere more general than just the
Emacs section, but the Emacs section should at least link to that
warning before suggesting any auto-activation.
