### PR TITLE
Share usage tracking for all vars at same location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `as->` to the "Resolve macro as" list
 - New code actions: refactor cond to if, and refactor if to cond
 - Allow finding references of multiple definitions at cursor. #2176
+- All var definitions sharing a location are considered used if a single member has a usage. #2192
 - Fix CLI format `:style/indent` support via project type flag.
 - Fix format `:style/indent` conflicts with core macros. #2197
 - Lots of bumps:

--- a/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
@@ -172,8 +172,19 @@
                                 (q/var-usage-signature e)))))
                      nses-and-dependents)
         var-used? (fn [var-def]
-                    (some usages (q/var-definition-signatures var-def)))]
-    (remove var-used? var-definitions)))
+                    (some usages (q/var-definition-signatures var-def)))
+        used-var-definition-locations (into #{}
+                                            (comp
+                                              (filter var-used?)
+                                              (map q/var-definition-location-key))
+                                            var-definitions)
+        macro-var-used? (fn [var-def]
+                          (contains? used-var-definition-locations
+                                     (q/var-definition-location-key var-def)))]
+    (remove (fn [var-def]
+              (or (var-used? var-def)
+                  (macro-var-used? var-def)))
+            var-definitions)))
 
 (defn ^:private unused-public-vars [narrowed-db project-db settings]
   (when-not (identical? :off (get-in settings [:linters :clojure-lsp/unused-public-var :level] :info))

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -158,6 +158,14 @@
                [(:ns var-def) var-name]))
         (var-definition-names var-def)))
 
+(defn var-definition-location-key [var-def]
+  (let [uri (:uri var-def)
+        name-row (or (:name-row var-def) (:row var-def))
+        name-col (or (:name-col var-def) (:col var-def))
+        name-end-row (or (:name-end-row var-def) (:end-row var-def))
+        name-end-col (or (:name-end-col var-def) (:end-col var-def))]
+    [uri name-row name-col name-end-row name-end-col]))
+
 (defn xf-same-ns
   ([ns] (xf-same-ns ns :ns))
   ([ns get-ns]


### PR DESCRIPTION
A macro which produces more than 1 var should be considered used if any of the vars it produces has a usage.

To word this differently: All vars that share a location should be considered used if any member of the group has a usage.

Note: This patch was produced entirely by AI.

Fixes #2192

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
