### PR TITLE
Use find-at-element-name in replace-refer-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - bb.pods: -> ed5e1f3
   - lsp4clj: 1.13.1 -> 2.0.1
 - Add selection to Extract Function code action #2118
+- Fix replace-refer-all mangling unrelated symbols #2150
 
 ## 2025.11.28-12.47.43
 

--- a/lib/src/clojure_lsp/feature/replace_refer_all.clj
+++ b/lib/src/clojure_lsp/feature/replace_refer_all.clj
@@ -29,8 +29,7 @@
               :loc alias-loc}]
             (when (seq usages)
               (mapv (fn [usage]
-                      (let [zloc (z/find-next-tag (edit/find-at-element loc usage) z/next :token)
-                            zloc (z/edit-> zloc
+                      (let [zloc (z/edit-> (edit/find-at-element-name loc usage)
                                            (edit/z-replace-preserving-meta (n/token-node (symbol fake-alias (str (:name usage))))))]
                         {:range (meta (z/node zloc))
                          :loc zloc}))

--- a/lib/test/clojure_lsp/feature/replace_refer_all_test.clj
+++ b/lib/test/clojure_lsp/feature/replace_refer_all_test.clj
@@ -38,3 +38,24 @@
                    "(an-alias/join [] \"\")"
                    "(an-alias/join [] \"\")")
            (h/changes->code result (h/db))))))
+
+(deftest replace-with-alias-does-not-mangle-forms-test
+  (h/load-code (h/code "(ns y)"
+                       "(defn y-f [& a] a)"
+                       "(def y-d \"a\")")
+               (h/file-uri "file:///y.clj"))
+  (let [zloc (h/load-code-and-zloc (h/code "(ns x"
+                                           " (:require"
+                                           "  [y :refer |:all]))"
+                                           "(update-in {} [:a :b] y-f 1)"
+                                           "(merge {:a y-d :b y-d :c y-d} {:a 1} {:a 2})"))
+        result (f.replace-refer-all/replace-with-alias
+                 zloc
+                 h/default-uri
+                 (h/db))]
+    (is (= (h/code "(ns x"
+                   " (:require"
+                   "  [y :as an-alias]))"
+                   "(update-in {} [:a :b] an-alias/y-f 1)"
+                   "(merge {:a an-alias/y-d :b an-alias/y-d :c an-alias/y-d} {:a 1} {:a 2})")
+           (h/changes->code result (h/db))))))


### PR DESCRIPTION
Fixes #2150

`find-at-element` would land on the opening form of `(join ....)` so we searched for next `:token`. However if the replaced symbol is not the calling element, `find-at-element` lands directly on the element and so calling `next` would get the item to the right of our target. By using `find-at-element-name` we always land directly on the element.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
