### PR TITLE
include functions in special cases for zloc-in-range?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix replace-refer-all mangling unrelated symbols #2150
 - Fix unused-public-var :exclude-when-contains-meta not being considered for .lsp/config.edn.
 - Fix unused-public-var not working with :config-in-ns in kondo config.
+- Include reader functions in special cases for finding the last element in a container
 
 ## 2025.11.28-12.47.43
 

--- a/lib/src/clojure_lsp/refactor/edit.clj
+++ b/lib/src/clojure_lsp/refactor/edit.clj
@@ -39,7 +39,7 @@
       (and (= (-> loc z/node meta :end-col)
               (:end-col pos))
            (z/rightmost? loc)
-           (contains? #{:list :vector :map :set} (z/tag (z/up loc)))
+           (contains? #{:list :vector :map :set :fn} (z/tag (z/up loc)))
            (some-> loc z/up z/node meta (in-range? pos)))))
 
 (defn find-by-heritability

--- a/lib/test/clojure_lsp/refactor/edit_test.clj
+++ b/lib/test/clojure_lsp/refactor/edit_test.clj
@@ -14,6 +14,7 @@
   (is (= "1" (-> "1 #?(+ 1 2) 3" z/of-string (edit/find-at-pos 1 1) z/string)))
   (is (= "2" (-> "1 #?(+ 1 2) 3" z/of-string (edit/find-at-pos 1 10) z/string)))
   (is (= "3" (-> "1 #?(+ 1 2) 3" z/of-string (edit/find-at-pos 1 13) z/string)))
+  (is (= "x" (-> "#(+ x)" z/of-string (edit/find-at-pos 1 6) z/string)))
   (is (= "some" (-> "some (def other {:foo/bar 1})" z/of-string (edit/find-at-pos 1 1) z/string)))
   (is (= "some" (-> "some (def other #:foo{:bar 1})" z/of-string (edit/find-at-pos 1 1) z/string)))
   (testing "finds in any branch"


### PR DESCRIPTION
This address issue #2208, that reader functions aren't included in the special cases for finding an element at the end of a container.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [-] I updated documentation if applicable (`docs` folder)
