### PR TITLE
measure p90 for code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 - Measure performance of code actions
-
 - Avoid incorrect circular dependency errors from `:as-alias` by working around clj-depend bug.
 - Fix inline-def to work with defs with metas.
 - Bump clj-kondo to `2026.01.20-20260305.171638-23`.
+- bump up timeout for code action performance measurement, include p90 measurement #2236
 
 ## 2026.02.20-16.08.58
 

--- a/cli/integration-test/entrypoint.clj
+++ b/cli/integration-test/entrypoint.clj
@@ -76,7 +76,8 @@
 
   (apply require test-namespaces)
 
-  (let [timeout-minutes (if (re-find #"(?i)win|mac" (System/getProperty "os.name"))
+  (let [timeout-minutes (if (or (= test-namespaces namespaces-performance)
+                                (re-find #"(?i)win|mac" (System/getProperty "os.name")))
                           25 ;; win and mac ci runs take longer
                           15)
         test-results (timeout (* timeout-minutes 60 1000)

--- a/cli/integration-test/performance/code_action_test.clj
+++ b/cli/integration-test/performance/code_action_test.clj
@@ -1,6 +1,7 @@
 (ns performance.code-action-test
   "run performance tests for Code Actions"
   (:require
+   [clojure.math :as math]
    [clojure.test :refer [deftest is testing]]
    [integration.fixture :as fixture]
    [integration.lsp :as lsp]))
@@ -13,7 +14,8 @@
 (def ^:private sample-file-with-large-structures "../../../../../lib/src/clojure_lsp/common_symbols.clj")
 
 ;; test will fail if average is higher than this
-(def ^:private max-runtime-ms 500)
+(def ^:private median-max-runtime-ms 500)
+(def ^:private p90-max-runtime-ms 1000)
 
 (def ^:private execution-count 15)
 
@@ -30,7 +32,6 @@
              (let [end-time (System/nanoTime)]
                (nano->ms end-time start-time))))))
 
-;; TODO: also check P90 and median?
 (defn ^:private compute-mean [execution-times]
   (int (/ (apply + execution-times) (count execution-times))))
 
@@ -46,6 +47,12 @@
             top-val (nth sorted halfway)]
         (compute-mean [bottom-val top-val])))))
 
+(defn ^:private compute-percentile [p coll]
+  (let [sorted (sort coll)
+        cnt (count sorted)
+        index (int (math/ceil (* p (dec cnt))))]
+    (nth sorted index)))
+
 (lsp/clean-after-test)
 
 (deftest view-and-execute-code-action
@@ -60,31 +67,37 @@
   (testing "Verify code action requests aren't over max average runtime"
     (testing "measure only one location near top of file"
       (let [execution-times (execute-multiple #(lsp/request! (fixture/code-action-request sample-file-name 5 4)))]
-        (is (< (compute-mean execution-times) max-runtime-ms))
-        (is (< (compute-median execution-times) max-runtime-ms))))
+        (is (< (compute-mean execution-times) median-max-runtime-ms))
+        (is (< (compute-median execution-times) median-max-runtime-ms))
+        (is (< (compute-percentile 0.9 execution-times) p90-max-runtime-ms))))
 
     (testing "measure many locations in simple sample file"
       (doseq [line-num (range 1 301)]
         (let [execution-times (execute-multiple #(lsp/request! (fixture/code-action-request sample-file-name line-num 1)))]
-          (is (< (compute-median execution-times) max-runtime-ms)))))
+          (is (< (compute-median execution-times) median-max-runtime-ms))
+          (is (< (compute-percentile 0.9 execution-times) p90-max-runtime-ms)))))
 
     (testing "measure many locations in sample file with many lines"
       (doseq [line-num (range 1 301)]
         (let [execution-times (execute-multiple #(lsp/request! (fixture/code-action-request sample-file-with-many-lines line-num 1)))]
-          (is (< (compute-median execution-times) max-runtime-ms)))))
+          (is (< (compute-median execution-times) median-max-runtime-ms))
+          (is (< (compute-percentile 0.9 execution-times) p90-max-runtime-ms)))))
 
     (testing "measure many locations in sample file with many symbols"
       (doseq [line-num (range 1 301)]
         (let [execution-times (execute-multiple #(lsp/request! (fixture/code-action-request sample-file-with-many-symbols line-num 1)))]
-          (is (< (compute-median execution-times) max-runtime-ms)))))
+          (is (< (compute-median execution-times) median-max-runtime-ms))
+          (is (< (compute-percentile 0.9 execution-times) p90-max-runtime-ms)))))
 
     (testing "measure many locations in sample file with high fanout of imports"
       (doseq [line-num (range 1 301)]
         (let [execution-times (execute-multiple #(lsp/request! (fixture/code-action-request sample-file-with-high-fanout line-num 1)))]
-          (is (< (compute-median execution-times) max-runtime-ms)))))
+          (is (< (compute-median execution-times) median-max-runtime-ms))
+          (is (< (compute-percentile 0.9 execution-times) p90-max-runtime-ms)))))
 
     (testing "measure many locations in sample file with large structures"
       (doseq [line-num (range 1 301)]
         (let [execution-times (execute-multiple #(lsp/request! (fixture/code-action-request sample-file-with-large-structures line-num 1)))]
-          (is (< (compute-median execution-times) max-runtime-ms)))))))
+          (is (< (compute-median execution-times) median-max-runtime-ms))
+          (is (< (compute-percentile 0.9 execution-times) p90-max-runtime-ms)))))))
 


### PR DESCRIPTION

This is for #2236 - add p90 verification for the code action performance tests.  It also increases the timeout for performance tests

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [-] I updated documentation if applicable (`docs` folder)
