### PR TITLE
Bump clj-kondo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 - Measure performance of code actions
 - Avoid incorrect circular dependency errors from `:as-alias` by working around clj-depend bug.
 - Fix inline-def to work with defs with metas.
-- Bump clj-kondo to `2026.01.20-20260305.171638-23`.
+- Bump clj-kondo to `2026.01.20-20260325.162821-29`.
 - bump up timeout for code action performance measurement, include p90 measurement #2236
 - Fix initialization crash when a source file has syntax errors (e.g. unbalanced parens) by using safe parser in unused-public-var linter's `:gen-class` check. #2242
-
 - Bump rewrite-clj to `1.2.54`.
 
 ## 2026.02.20-16.08.58

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -8,7 +8,7 @@
         com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
         medley/medley {:mvn/version "1.4.0"}
         anonimitoraf/clj-flx {:mvn/version "1.2.0"}
-        clj-kondo/clj-kondo {:mvn/version "2026.01.20-20260305.171638-23"
+        clj-kondo/clj-kondo {:mvn/version "2026.01.20-20260325.162821-29"
                              #_#_:local/root "../../clj-kondo"
                              :exclude [com.cognitect/transit-clj
                                        babashka/fs]}


### PR DESCRIPTION
This latest snapshot version of Kondo contains a few more performance improvements (https://github.com/clj-kondo/clj-kondo/pull/2794).

---

- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
