### PR TITLE
Fix create test duplicate deftest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `create-test` code action appending a duplicate `deftest` when one with the matching name already exists, now navigating to the existing deftest instead.
+- Fix `create-test` code action appending a duplicate `deftest` when one with the matching name already exists, now navigating to the existing deftest instead. #2274
 - Change the default of `:clean :ns-inner-blocks-indentation` from `:next-line` to `:keep`, so `clean-ns` (including the automatic run after `add-missing-libspec`, `add-require-suggestion`, `add-missing-import`, and `move-form`) no longer reflows the `:require`/`:import` block when the user has not configured an indentation style. Users who want the previous behavior can set `:clean :ns-inner-blocks-indentation :next-line` explicitly. #2261
 - Fix `add-missing-require` refer suggestions leaking across languages, so a `.clj` file no longer offers refers defined only in `.cljs` files (and vice versa). #2271
 - Add `:private-by-default-on-extract?` setting to control whether extracted functions and defs are private by default. #2258

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `create-test` code action appending a duplicate `deftest` when one with the matching name already exists, now navigating to the existing deftest instead.
 - Change the default of `:clean :ns-inner-blocks-indentation` from `:next-line` to `:keep`, so `clean-ns` (including the automatic run after `add-missing-libspec`, `add-require-suggestion`, `add-missing-import`, and `move-form`) no longer reflows the `:require`/`:import` block when the user has not configured an indentation style. Users who want the previous behavior can set `:clean :ns-inner-blocks-indentation :next-line` explicitly. #2261
 - Fix `add-missing-require` refer suggestions leaking across languages, so a `.clj` file no longer offers refers defined only in `.cljs` files (and vice versa). #2271
 - Add `:private-by-default-on-extract?` setting to control whether extracted functions and defs are private by default. #2258

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -1683,6 +1683,22 @@
         (create-function-for-alias local-zloc ns-or-alias defn-loc uri db)
         [(prepend-preserving-comment (edit/to-top local-zloc) defn-loc)]))))
 
+(defn- deftest-loc-with-name
+  "Returns the zloc of the first top-level `(deftest <test-name> ...)` form
+  in `text`, or nil. Matches the deftest op by unqualified name."
+  [text test-name]
+  (loop [loc (z/of-string text)]
+    (cond
+      (nil? loc) nil
+      
+      (and (= :list (z/tag loc))
+           (let [op (some-> loc z/down z/sexpr)]
+             (and (symbol? op) (= "deftest" (name op))))
+           (= test-name (some-> loc z/down z/right z/sexpr))) 
+      loc
+
+      :else (recur (z/right loc)))))
+
 (defn ^:private create-test-for-source-path
   [uri function-name-loc source-path db]
   (let [file-type (shared/uri->file-type uri)
@@ -1692,14 +1708,24 @@
         test-filename (shared/namespace+source-path->filename namespace-test source-path file-type)
         test-uri (shared/filename->uri test-filename db)]
     (if-let [existing-text (shared/slurp-uri test-uri)]
-      (let [lines (count (string/split existing-text #"\n"))
-            test-text (format "(deftest %s\n  (is (= 1 1)))" (str function-name "-test"))
-            test-zloc (z/up (z/of-string (str "\n" test-text)))]
-        {:show-document-after-edit {:uri test-uri
-                                    :take-focus true}
-         :changes-by-uri
-         {test-uri [{:loc test-zloc
-                     :range {:row (inc lines) :col 1 :end-row (+ 3 lines) :end-col 1}}]}})
+      (let [test-name    (symbol (str function-name "-test"))
+            existing-loc (deftest-loc-with-name existing-text test-name)]
+        (if existing-loc
+          {:show-document-after-edit
+           {:uri        test-uri
+            :take-focus true
+            :range      (-> existing-loc z/node meta)}}
+          (let [lines     (count (string/split existing-text #"\n"))
+                test-text (format "(deftest %s\n  (is (= 1 1)))" test-name)
+                test-zloc (z/up (z/of-string (str "\n" test-text)))]
+            {:show-document-after-edit {:uri        test-uri
+                                        :take-focus true}
+             :changes-by-uri
+             {test-uri [{:loc   test-zloc
+                         :range {:row     (inc lines)
+                                 :col     1
+                                 :end-row (+ 3 lines)
+                                 :end-col 1}}]}})))
       (let [ns-text (format "(ns %s\n  (:require\n   [%s.test :refer [deftest is]]\n   [%s :as subject]))"
                             namespace-test
                             (if (= :cljs file-type) "cljs" "clojure")

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -1690,11 +1690,11 @@
   (loop [loc (z/of-string text)]
     (cond
       (nil? loc) nil
-      
+
       (and (= :list (z/tag loc))
            (let [op (some-> loc z/down z/sexpr)]
              (and (symbol? op) (= "deftest" (name op))))
-           (= test-name (some-> loc z/down z/right z/sexpr))) 
+           (= test-name (some-> loc z/down z/right z/sexpr)))
       loc
 
       :else (recur (z/right loc)))))

--- a/lib/src/clojure_lsp/refactor/transform.clj
+++ b/lib/src/clojure_lsp/refactor/transform.clj
@@ -1683,7 +1683,7 @@
         (create-function-for-alias local-zloc ns-or-alias defn-loc uri db)
         [(prepend-preserving-comment (edit/to-top local-zloc) defn-loc)]))))
 
-(defn- deftest-loc-with-name
+(defn ^:private deftest-loc-with-name
   "Returns the zloc of the first top-level `(deftest <test-name> ...)` form
   in `text`, or nil. Matches the deftest op by unqualified name."
   [text test-name]

--- a/lib/test/clojure_lsp/refactor/transform_test.clj
+++ b/lib/test/clojure_lsp/refactor/transform_test.clj
@@ -2530,6 +2530,36 @@
                               "  (is (= 1 1)))"),
                  :range {:row 3 :col 1 :end-row 5 :end-col 1}}]}
               results-to-assert)))))
+    (testing "when the deftest already exists, navigates without editing"
+      (doseq [[label test-code expected-row]
+              [["unqualified deftest"
+                (h/code "(ns some.ns-test)"
+                        "(deftest some-other-test)"
+                        "(deftest foo-test"
+                        "  (is (= 1 1)))")
+                3]
+               ["qualified clojure.test/deftest"
+                (h/code "(ns some.ns-test)"
+                        "(clojure.test/deftest foo-test"
+                        "  (is (= 1 1)))")
+                2]]]
+        (testing label
+          (swap! (h/db*) shared/deep-merge {:settings {:source-paths #{(h/file-path "/project/src")
+                                                                       (h/file-path "/project/test")}}
+                                            :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}
+                                            :project-root-uri (h/file-uri "file:///project")})
+          (with-redefs [shared/file-exists? #(not (string/ends-with? % "config.edn"))
+                        shared/slurp-uri (constantly test-code)]
+            (h/load-code-and-locs test-code (h/file-uri "file:///project/test/some/ns_test.clj"))
+            (let [zloc (h/load-code-and-zloc "(ns some.ns) (defn |foo [b] (+ 1 2))"
+                                             (h/file-uri "file:///project/src/some/ns.clj"))
+                  {:keys [changes-by-uri resource-changes
+                          show-document-after-edit]} (transform/create-test zloc (h/file-uri "file:///project/src/some/ns.clj") (h/db) (h/components))]
+              (is (= nil resource-changes))
+              (is (= nil changes-by-uri))
+              (is (= (h/file-uri "file:///project/test/some/ns_test.clj")
+                     (:uri show-document-after-edit)))
+              (is (= expected-row (get-in show-document-after-edit [:range :row]))))))))
     (testing "when the current source path is already a test"
       (swap! (h/db*) shared/deep-merge {:settings {:source-paths #{(h/file-path "/project/src") (h/file-path "/project/test")}}
                                         :client-capabilities {:workspace {:workspace-edit {:document-changes true}}}


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)

Fix `create-test` code action appending a duplicate `deftest` when one with the matching name already exists, now navigating to the existing deftest instead.
Fixes #2274