### PR TITLE
don't use command end-selection args if not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bump rewrite-clj to `1.2.54`.
 - implement move to :let refactoring #1732
 - Measure performance of didOpen and didChange
+- if code-action selection end-position args aren't provided, don't try to use them #2276
 
 ## 2026.02.20-16.08.58
 

--- a/lib/src/clojure_lsp/feature/command.clj
+++ b/lib/src/clojure_lsp/feature/command.clj
@@ -230,7 +230,7 @@
   ;; had already hardcoded array values (such as Calva changing the new function name
   ;; in args[3]) won't need to change
   (let [[uri line character & args] arguments
-        selection? (= :extract-function command)
+        selection? (and (= :extract-function command) (> (count args) 2))
         line-end (if selection? (nth args 1) line)
         character-end (if selection? (nth args 2) character)
         fn-args (if selection? (drop-last 2 args) args)


### PR DESCRIPTION
addresses issue #2276 - when only 4 arguments are sent to a command action, the command fails with an index out of bounds exception.  This just checks if the selection endpoints are present before trying to use them.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [-] I updated documentation if applicable (`docs` folder)
