### PR TITLE
Support find-definition for fully qualified vars even when the namespace is not explicitly required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support find-definition for fully qualified vars even when the namespace is not explicitly required. #2028
 - Fix `create-test` code action appending a duplicate `deftest` when one with the matching name already exists, now navigating to the existing deftest instead. #2274
 - Change the default of `:clean :ns-inner-blocks-indentation` from `:next-line` to `:keep`, so `clean-ns` (including the automatic run after `add-missing-libspec`, `add-require-suggestion`, `add-missing-import`, and `move-form`) no longer reflows the `:require`/`:import` block when the user has not configured an indentation style. Users who want the previous behavior can set `:clean :ns-inner-blocks-indentation :next-line` explicitly. #2261
 - Fix `add-missing-require` refer suggestions leaking across languages, so a `.clj` file no longer offers refers defined only in `.cljs` files (and vice versa). #2271
@@ -494,7 +495,7 @@
 ## 2022.10.05-16.39.51
 
 - General
-  - Improve clj-depend merge config to overwrite `source-paths` only if it is nil or empty.  #1264
+  - Improve clj-depend merge config to overwrite `source-paths` only if it is nil or empty. #1264
   - Fix stubs generation issue on MS-Windows, coming out of enabling all integrations tests on windows. #1211
   - Improve MS-Windows support by fixing various path, URI and line ending issues coming out of repairing the unit tests suite on windows. #1211
   - End dep-graph-queries experiment; clojure-lsp now uses the dep-graph to optimize queries whenever possible
@@ -505,7 +506,7 @@
   - Bump graalvm version for MS-Windows to 22.2.0, in sync with the other archs. #1211
 
 - Editor
-  - Fix to avoid error when checking code actions from an #_x uneval node. #1227
+  - Fix to avoid error when checking code actions from an #\_x uneval node. #1227
   - Add support to decompile jar as a java project when finding the definition of a java class, allowing to have LSP features on that java project. #1187
   - Add refactorings similar to `Sort map`: `Sort vector`, `Sort list`, `Sort set`, and `Sort clauses` for functions like `assoc`. #1155
   - Support java class decompilation for zipfile scheme (vim users).
@@ -691,10 +692,10 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Improve completion performance for most cases, reducing time to compute clj/cljs core symbols.
   - completion: suggest functions defined in Clojure 1.10 and 1.11
   - completion: Fix to no require extra ns when alias is already required. #920
-  - promote-fn: *new feature* Promote a fn to a top-level defn. #783 @mainej
+  - promote-fn: _new feature_ Promote a fn to a top-level defn. #783 @mainej
     - promote-fn can also promote a literal #() to a fn
   - demote-fn: Demote a fn to a literal #()
-  - *breaking* remove cycle-fn-literal, since the same refactorings can be performed with the more clearly named promote-fn and demote-fn
+  - _breaking_ remove cycle-fn-literal, since the same refactorings can be performed with the more clearly named promote-fn and demote-fn
   - drag: Fix to drag element-wise in destructured keys, not pair-wise. #927
   - test-tree: reduce CPU usage, especially during startup
 
@@ -748,7 +749,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Avoid infinite loops when several files are changed simultaneously. #796 @mainej
   - Fix "incoming call hierarchy" not considering usages inside defmethods. #808
   - range-formatting: more efficiently locate extent of range and reduce number of calls to cljfmt, improving performance especially when formatting large ranges. #795 @mainej
-  - cycle-fn-literal: *new feature* convert between function-literal syntaxes `(fn [] ...)` <-> `#(...)`. #774
+  - cycle-fn-literal: _new feature_ convert between function-literal syntaxes `(fn [] ...)` <-> `#(...)`. #774
   - Add find-implementation feature to `defmulti` and `defmethod`. #751
   - Make find-implementation of `defprotocol` names find its implementations and find-implementation on `deftype`/`defrecord` methods find other implementations.
   - Add new code action `Introduce let` for existing command. #825
@@ -881,7 +882,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Change call hierarchy to return selection range of usage, not function definition.
   - Return `edits` in `codeAction/resolve` responses rather than `commands`. #655
   - Improve `:linters :clj-kondo :async-custom-lint?` to avoid infinite loops and default to `true`.
-  - Add new custom LSP feature __Test Tree__, which shows all test hierarchy of a file. #653
+  - Add new custom LSP feature **Test Tree**, which shows all test hierarchy of a file. #653
   - Improve function name finding to consider other function definition types for some features. #666
   - Make `textDocument/hover` return the correct range from LSP spec, the element range instead of the element scope range.
 
@@ -983,7 +984,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Fix expand-let bug that occurs when a list form precedes let. #590
   - Add new command to create test for function at point. #582
   - Add new code action to create test for current function/var
-  - Add `private` to documentSymbol to make clear that a var or function is  `private`.
+  - Add `private` to documentSymbol to make clear that a var or function is `private`.
   - Add new code action `Suppress xxx diagnostic`, adding clj-kondo comment code to ignore the diagnostic. #591
   - Add more semantic tokens: aliases for macros, variable and function definitions.
   - Add [clojuredocs](https://clojuredocs.org/) information during symbol hover. #571
@@ -1347,7 +1348,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
 ## 2021.03.06-17.05.35
 
 - Fix incremental didChange, debouncing distincting by uri, fixing some inconsistent file changes
-when multiple files are changed at same time (rename, iedit, etc).
+  when multiple files are changed at same time (rename, iedit, etc).
 - Make unused-public-var ignore -main public functions.
 - Add `:exclude-when-defined-by` option to `unused-public-var` linter, check settings documentation for more information.
 
@@ -1456,7 +1457,7 @@ when multiple files are changed at same time (rename, iedit, etc).
 
 ## 2021.02.04-02.08.58
 
- - Fix --version on graalvm native compiled binaries
+- Fix --version on graalvm native compiled binaries
 
 ## 2021.02.04-01.09.21
 
@@ -1523,8 +1524,8 @@ Huge refactor https://github.com/clojure-lsp/clojure-lsp/pull/261 which uses clj
 
 ## 2021.01.14-23.15.54
 
-- Check for the whole line to add-miising-* code actions instead of expect the cursor at the ns to be required/imported - Fixes #258
-- Return all possible add-missing-* code actions to the same line.
+- Check for the whole line to add-miising-\* code actions instead of expect the cursor at the ns to be required/imported - Fixes #258
+- Return all possible add-missing-\* code actions to the same line.
 
 ## 2021.01.14-17.19.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -495,7 +495,7 @@
 ## 2022.10.05-16.39.51
 
 - General
-  - Improve clj-depend merge config to overwrite `source-paths` only if it is nil or empty. #1264
+  - Improve clj-depend merge config to overwrite `source-paths` only if it is nil or empty.  #1264
   - Fix stubs generation issue on MS-Windows, coming out of enabling all integrations tests on windows. #1211
   - Improve MS-Windows support by fixing various path, URI and line ending issues coming out of repairing the unit tests suite on windows. #1211
   - End dep-graph-queries experiment; clojure-lsp now uses the dep-graph to optimize queries whenever possible
@@ -506,7 +506,7 @@
   - Bump graalvm version for MS-Windows to 22.2.0, in sync with the other archs. #1211
 
 - Editor
-  - Fix to avoid error when checking code actions from an #\_x uneval node. #1227
+  - Fix to avoid error when checking code actions from an #_x uneval node. #1227
   - Add support to decompile jar as a java project when finding the definition of a java class, allowing to have LSP features on that java project. #1187
   - Add refactorings similar to `Sort map`: `Sort vector`, `Sort list`, `Sort set`, and `Sort clauses` for functions like `assoc`. #1155
   - Support java class decompilation for zipfile scheme (vim users).
@@ -692,10 +692,10 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Improve completion performance for most cases, reducing time to compute clj/cljs core symbols.
   - completion: suggest functions defined in Clojure 1.10 and 1.11
   - completion: Fix to no require extra ns when alias is already required. #920
-  - promote-fn: _new feature_ Promote a fn to a top-level defn. #783 @mainej
+  - promote-fn: *new feature* Promote a fn to a top-level defn. #783 @mainej
     - promote-fn can also promote a literal #() to a fn
   - demote-fn: Demote a fn to a literal #()
-  - _breaking_ remove cycle-fn-literal, since the same refactorings can be performed with the more clearly named promote-fn and demote-fn
+  - *breaking* remove cycle-fn-literal, since the same refactorings can be performed with the more clearly named promote-fn and demote-fn
   - drag: Fix to drag element-wise in destructured keys, not pair-wise. #927
   - test-tree: reduce CPU usage, especially during startup
 
@@ -749,7 +749,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Avoid infinite loops when several files are changed simultaneously. #796 @mainej
   - Fix "incoming call hierarchy" not considering usages inside defmethods. #808
   - range-formatting: more efficiently locate extent of range and reduce number of calls to cljfmt, improving performance especially when formatting large ranges. #795 @mainej
-  - cycle-fn-literal: _new feature_ convert between function-literal syntaxes `(fn [] ...)` <-> `#(...)`. #774
+  - cycle-fn-literal: *new feature* convert between function-literal syntaxes `(fn [] ...)` <-> `#(...)`. #774
   - Add find-implementation feature to `defmulti` and `defmethod`. #751
   - Make find-implementation of `defprotocol` names find its implementations and find-implementation on `deftype`/`defrecord` methods find other implementations.
   - Add new code action `Introduce let` for existing command. #825
@@ -882,7 +882,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Change call hierarchy to return selection range of usage, not function definition.
   - Return `edits` in `codeAction/resolve` responses rather than `commands`. #655
   - Improve `:linters :clj-kondo :async-custom-lint?` to avoid infinite loops and default to `true`.
-  - Add new custom LSP feature **Test Tree**, which shows all test hierarchy of a file. #653
+  - Add new custom LSP feature __Test Tree__, which shows all test hierarchy of a file. #653
   - Improve function name finding to consider other function definition types for some features. #666
   - Make `textDocument/hover` return the correct range from LSP spec, the element range instead of the element scope range.
 
@@ -984,7 +984,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
   - Fix expand-let bug that occurs when a list form precedes let. #590
   - Add new command to create test for function at point. #582
   - Add new code action to create test for current function/var
-  - Add `private` to documentSymbol to make clear that a var or function is `private`.
+  - Add `private` to documentSymbol to make clear that a var or function is  `private`.
   - Add new code action `Suppress xxx diagnostic`, adding clj-kondo comment code to ignore the diagnostic. #591
   - Add more semantic tokens: aliases for macros, variable and function definitions.
   - Add [clojuredocs](https://clojuredocs.org/) information during symbol hover. #571
@@ -1348,7 +1348,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
 ## 2021.03.06-17.05.35
 
 - Fix incremental didChange, debouncing distincting by uri, fixing some inconsistent file changes
-  when multiple files are changed at same time (rename, iedit, etc).
+when multiple files are changed at same time (rename, iedit, etc).
 - Make unused-public-var ignore -main public functions.
 - Add `:exclude-when-defined-by` option to `unused-public-var` linter, check settings documentation for more information.
 
@@ -1457,7 +1457,7 @@ This release was supported by [Clojurists Together](https://www.clojuriststogeth
 
 ## 2021.02.04-02.08.58
 
-- Fix --version on graalvm native compiled binaries
+ - Fix --version on graalvm native compiled binaries
 
 ## 2021.02.04-01.09.21
 
@@ -1524,8 +1524,8 @@ Huge refactor https://github.com/clojure-lsp/clojure-lsp/pull/261 which uses clj
 
 ## 2021.01.14-23.15.54
 
-- Check for the whole line to add-miising-\* code actions instead of expect the cursor at the ns to be required/imported - Fixes #258
-- Return all possible add-missing-\* code actions to the same line.
+- Check for the whole line to add-miising-* code actions instead of expect the cursor at the ns to be required/imported - Fixes #258
+- Return all possible add-missing-* code actions to the same line.
 
 ## 2021.01.14-17.19.10
 

--- a/cli/integration-test/integration/definition_test.clj
+++ b/cli/integration-test/integration/definition_test.clj
@@ -14,6 +14,7 @@
   (lsp/notify! (fixture/initialized-notification))
   (lsp/notify! (fixture/did-open-source-path-notification "definition/a.clj"))
   (lsp/notify! (fixture/did-open-source-path-notification "definition/b.clj"))
+  (lsp/notify! (fixture/did-open-source-path-notification "definition/c.clj"))
 
   (testing "common vars"
     (testing "find definition on same ns"
@@ -35,7 +36,15 @@
         {:uri (h/source-path->uri "definition/a.clj")
          :range {:start {:line 5 :character 6}
                  :end {:line 5 :character 22}}}
-        (lsp/request! (fixture/definition-request (h/source-path->uri "definition/b.clj") 3 4)))))
+        (lsp/request! (fixture/definition-request (h/source-path->uri "definition/b.clj") 3 4))))
+
+    (testing "find definition of fully qualified var without require"
+      (h/assert-submap
+        {:uri (h/source-path->uri "definition/a.clj")
+         :range {:start {:line 5 :character 6}
+                 :end {:line 5 :character 22}}}
+        (lsp/request! (fixture/definition-request
+                        (h/source-path->uri "definition/c.clj") 2 27)))))
 
   (testing "keywords"
     (testing "definition of local simple keyword is the keyword itself"

--- a/cli/integration-test/sample-test/src/sample_test/definition/c.clj
+++ b/cli/integration-test/sample-test/src/sample_test/definition/c.clj
@@ -1,0 +1,3 @@
+(ns sample-test.definition.c)
+
+(sample-test.definition.a/some-public-func 3)

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -269,25 +269,40 @@
           (xf-same-lang namespace-usage))
     (db-with-ns-analysis db (:name namespace-usage))))
 
+(defn ^:private resolved-unknown-var-usage-namespace
+  [db {:keys [alias to] :as var-usage}]
+  (when (and (identical? :clj-kondo/unknown-namespace to)
+             alias
+             (find-last-order-by-project-analysis
+               (comp xf-analysis->namespace-definitions
+                     (xf-same-name alias)
+                     (xf-same-lang var-usage))
+               (db-with-ns-analysis db alias)))
+    alias))
+
 (defmethod find-definition :var-usages
   [db var-usage]
-  (or
-    (find-last-order-by-project-analysis
-      (comp xf-analysis->var-definitions
-            (xf-same-fqn (:to var-usage) (:name var-usage))
-            (xf-same-lang var-usage))
-      (db-with-ns-analysis db (:to var-usage)))
-    (when (contains? (elem-langs var-usage) :cljs)
-      ;; maybe loaded by :require-macros, in which case, def will be in a clj file.
-      (let [definition (find-definition db (assoc var-usage :lang :clj))]
-        (when (:macro definition)
-          definition)))
-    ;; Fallback to navigate from clojure to clojurescript vars, see #1403
-    (when-not (:fallbacking? var-usage)
-      (find-definition db (assoc var-usage :lang :cljs :fallbacking? true)))
-    ;; If alias exists but not var, go to the ns definition
-    (when-let [alias (:alias var-usage)]
-      (find-definition db (find-namespace-usage-by-alias db (:uri var-usage) alias)))))
+  (let [resolved-ns (resolved-unknown-var-usage-namespace db var-usage)
+        var-usage (cond-> var-usage 
+                   resolved-ns (assoc var-usage :to resolved-ns))]
+    (or
+      (find-last-order-by-project-analysis
+        (comp xf-analysis->var-definitions
+              (xf-same-fqn (:to var-usage) (:name var-usage))
+              (xf-same-lang var-usage))
+        (db-with-ns-analysis db (:to var-usage)))
+      (when (contains? (elem-langs var-usage) :cljs)
+        ;; maybe loaded by :require-macros, in which case, def will be in a clj file.
+        (let [definition (find-definition db (assoc var-usage :lang :clj))]
+          (when (:macro definition)
+            definition)))
+      ;; Fallback to navigate from clojure to clojurescript vars, see #1403
+      (when-not (:fallbacking? var-usage)
+        (find-definition db (assoc var-usage :lang :cljs :fallbacking? true)))
+      ;; If alias exists but not var, go to the ns definition
+      (when-let [alias (:alias var-usage)]
+        (find-definition db (find-namespace-usage-by-alias db (:uri var-usage) 
+                                                           alias))))))
 
 (defmethod find-definition :symbols
   [db quoted-symbol]

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -284,7 +284,7 @@
   [db var-usage]
   (let [resolved-ns (resolved-unknown-var-usage-namespace db var-usage)
         var-usage (cond-> var-usage
-                    resolved-ns (assoc var-usage :to resolved-ns))]
+                    resolved-ns (assoc :to resolved-ns))]
     (or
       (find-last-order-by-project-analysis
         (comp xf-analysis->var-definitions

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -283,8 +283,7 @@
 (defmethod find-definition :var-usages
   [db var-usage]
   (let [resolved-ns (resolved-unknown-var-usage-namespace db var-usage)
-        var-usage (cond-> var-usage
-                    resolved-ns (assoc :to resolved-ns))]
+        var-usage (cond-> var-usage resolved-ns (assoc :to resolved-ns))]
     (or
       (find-last-order-by-project-analysis
         (comp xf-analysis->var-definitions

--- a/lib/src/clojure_lsp/queries.clj
+++ b/lib/src/clojure_lsp/queries.clj
@@ -283,8 +283,8 @@
 (defmethod find-definition :var-usages
   [db var-usage]
   (let [resolved-ns (resolved-unknown-var-usage-namespace db var-usage)
-        var-usage (cond-> var-usage 
-                   resolved-ns (assoc var-usage :to resolved-ns))]
+        var-usage (cond-> var-usage
+                    resolved-ns (assoc var-usage :to resolved-ns))]
     (or
       (find-last-order-by-project-analysis
         (comp xf-analysis->var-definitions
@@ -301,7 +301,7 @@
         (find-definition db (assoc var-usage :lang :cljs :fallbacking? true)))
       ;; If alias exists but not var, go to the ns definition
       (when-let [alias (:alias var-usage)]
-        (find-definition db (find-namespace-usage-by-alias db (:uri var-usage) 
+        (find-definition db (find-namespace-usage-by-alias db (:uri var-usage)
                                                            alias))))))
 
 (defmethod find-definition :symbols

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -708,6 +708,18 @@
       {:name 'foo :ns 'exec-ns :row 1 :col 14}
       (q/find-definition-from-cursor db (h/file-uri "file:///deps.edn") exec-fn-r exec-fn-c))))
 
+(deftest find-definition-from-cursor-with-fully-qualified-symbol-without-require
+  (h/load-code-and-locs "(ns some.foo) (def my-var 1)" (h/file-uri "file:///some/foo.clj"))
+  (let [[[usage-r usage-c]]
+        (h/load-code-and-locs (h/code "(ns other.bar)"
+                                      "some.foo/|my-var")
+                              (h/file-uri "file:///other/bar.clj"))
+        db (h/db)]
+    (h/assert-submap
+      {:name 'my-var :ns 'some.foo :uri (h/file-uri "file:///some/foo.clj")}
+      (q/find-definition-from-cursor db (h/file-uri "file:///other/bar.clj")
+                                     usage-r usage-c))))
+
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
   (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "zipfile:///some.jar::some-jar.clj")
         _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "file:///a.clj"))

--- a/lib/test/clojure_lsp/queries_test.clj
+++ b/lib/test/clojure_lsp/queries_test.clj
@@ -720,6 +720,17 @@
       (q/find-definition-from-cursor db (h/file-uri "file:///other/bar.clj")
                                      usage-r usage-c))))
 
+(deftest find-definition-from-cursor-with-non-fully-qualified-symbol-without-require
+  (h/load-code-and-locs "(ns some.foo) (def my-var 1)"
+                        (h/file-uri "file:///some/foo.clj"))
+  (let [[[usage-r usage-c]]
+        (h/load-code-and-locs (h/code "(ns other.bar)"
+                                      "|foo.my-var")
+                              (h/file-uri "file:///other/bar.clj"))
+        db (h/db)]
+    (is (nil? (q/find-definition-from-cursor
+                db (h/file-uri "file:///other/bar.clj") usage-r usage-c)))))
+
 (deftest find-definition-from-cursor-when-duplicate-from-external-analysis
   (let [_ (h/load-code-and-locs (h/code "(ns foo) (def bar)") "zipfile:///some.jar::some-jar.clj")
         _ (h/load-code-and-locs (h/code "(ns foo) (def bar)") (h/file-uri "file:///a.clj"))


### PR DESCRIPTION
- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)

- Create `resolved-unknown-var-usage-namespace` to resolve unknown namespace usages for variables. When it is resolved, it adds `:to` keyword to `var-usage`
- Add unit tests:
    + namespace is resolved (alias is the full namespace)
    + namespace is not resolved
- Add integration tests for resolved namespace

Fixes #2028 
