### PR TITLE
Fix cyclic-dependencies linter for comment forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `cyclic-dependencies` linter falsely reporting cycles for `(require ...)` calls inside `(comment ...)` forms. #2107
 - Support find-definition for fully qualified vars even when the namespace is not explicitly required. #2028
 - Fix `create-test` code action appending a duplicate `deftest` when one with the matching name already exists, now navigating to the existing deftest instead. #2274
 - Change the default of `:clean :ns-inner-blocks-indentation` from `:next-line` to `:keep`, so `clean-ns` (including the automatic run after `add-missing-libspec`, `add-require-suggestion`, `add-missing-import`, and `move-form`) no longer reflows the `:require`/`:import` block when the user has not configured an indentation style. Users who want the previous behavior can set `:clean :ns-inner-blocks-indentation :next-line` explicitly. #2261

--- a/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
@@ -285,12 +285,46 @@
           (dfs-visit namespace)))
       @cycles)))
 
+(defn ^:private comment-form-bounds
+  "Var-usages of `comment` define regions of code that are not
+   evaluated. Returns those usages from a single uri's analysis."
+  [var-usages]
+  (filter (fn [{:keys [to name]}]
+            (and (or (fast= 'clojure.core to) (fast= 'cljs.core to))
+                 (fast= 'comment name)))
+          var-usages))
+
+(defn ^:private decrement-dep-edge [dep-graph from to]
+  (let [path [from :dependencies to]]
+    (if (<= (or (get-in dep-graph path) 0) 1)
+      (update-in dep-graph [from :dependencies] dissoc to)
+      (update-in dep-graph path dec))))
+
+(defn ^:private remove-comment-form-deps
+  "Remove dep-graph edges that originate from a (require ...) (or similar) call
+   inside a (comment ...) form, so they don't participate in cycle detection."
+  [dep-graph analysis]
+  (reduce-kv
+    (fn [graph _uri {:keys [namespace-usages var-usages]}]
+      (let [bounds (comment-form-bounds var-usages)]
+        (if (empty? bounds)
+          graph
+          (reduce
+            (fn [g {:keys [from name] :as usage}]
+              (cond-> g
+                (some #(shared/inside? usage %) bounds)
+                (decrement-dep-edge from name)))
+            graph namespace-usages))))
+    dep-graph analysis))
+
 (defn ^:private cyclic-dependencies
   "Detects cyclic dependencies and generates diagnostics for each namespace in a cycle."
-  [narrowed-db _project-db settings]
+  [narrowed-db project-db settings]
   (let [level (get-in settings [:linters :clojure-lsp/cyclic-dependencies :level] :off)]
     (when-not (identical? :off level)
-      (let [cycles (find-dependency-cycles (:dep-graph narrowed-db))
+      (let [dep-graph (remove-comment-form-deps 
+                        (:dep-graph narrowed-db) (:analysis project-db))
+            cycles (find-dependency-cycles dep-graph)
             exclude-namespaces (set (get-in settings [:linters :clojure-lsp/cyclic-dependencies :exclude-namespaces] #{}))
             ;; Create diagnostics for each namespace in each cycle
             cycle-diagnostics (for [cycle cycles

--- a/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
@@ -322,7 +322,7 @@
   [narrowed-db project-db settings]
   (let [level (get-in settings [:linters :clojure-lsp/cyclic-dependencies :level] :off)]
     (when-not (identical? :off level)
-      (let [dep-graph (remove-comment-form-deps 
+      (let [dep-graph (remove-comment-form-deps
                         (:dep-graph narrowed-db) (:analysis project-db))
             cycles (find-dependency-cycles dep-graph)
             exclude-namespaces (set (get-in settings [:linters :clojure-lsp/cyclic-dependencies :exclude-namespaces] #{}))

--- a/lib/test/clojure_lsp/feature/diagnostics/built_in_test.clj
+++ b/lib/test/clojure_lsp/feature/diagnostics/built_in_test.clj
@@ -496,7 +496,46 @@
         (lint! [(h/file-uri "file:///main.clj") (h/file-uri "file:///util.clj") (h/file-uri "file:///core.clj")]
                {:linters {:clojure-lsp/cyclic-dependencies {:level :info}}}))))
 
-  ;; TODO: Fix ignore comment functionality for cyclic dependencies  
+  (testing "require inside (comment ...) does not contribute to cycle"
+    (h/reset-components!)
+    (h/load-code-and-locs (h/code "(ns a (:require [b :as b]))"
+                                  "(comment"
+                                  "  (require '[b] :reload))")
+                          (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs (h/code "(ns b)"
+                                  "(comment"
+                                  "  (require '[a :as a] :reload))")
+                          (h/file-uri "file:///b.clj"))
+    (h/assert-submaps
+      []
+      (lint! [(h/file-uri "file:///a.clj") (h/file-uri "file:///b.clj")]
+             {:linters {:clojure-lsp/cyclic-dependencies {:level :warning}}})))
+
+  (testing "self-require inside (comment ...) does not flag self-cycle"
+    (h/reset-components!)
+    (h/load-code-and-locs (h/code "(ns my.ns)"
+                                  "(comment"
+                                  "  (require '[my.ns] :reload))")
+                          (h/file-uri "file:///my/ns.clj"))
+    (h/assert-submaps
+      []
+      (lint! [(h/file-uri "file:///my/ns.clj")]
+             {:linters {:clojure-lsp/cyclic-dependencies {:level :warning}}})))
+
+  (testing "real cycle still detected when comment-form require is present"
+    (h/reset-components!)
+    (h/load-code-and-locs (h/code "(ns a (:require [b :as b]))"
+                                  "(comment"
+                                  "  (require '[unrelated]))")
+                          (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns b (:require [a :as a]))" (h/file-uri "file:///b.clj"))
+    (h/assert-submaps
+      [{:message "Cyclic dependency detected: a -> b -> a"}
+       {:message "Cyclic dependency detected: a -> b -> a"}]
+      (lint! [(h/file-uri "file:///a.clj") (h/file-uri "file:///b.clj")]
+             {:linters {:clojure-lsp/cyclic-dependencies {:level :warning}}})))
+
+  ;; TODO: Fix ignore comment functionality for cyclic dependencies
   #_(testing "cycle with ignore comment"
       (h/reset-components!)
       (h/load-code-and-locs (h/code "#_{:clojure-lsp/ignore [:clojure-lsp/cyclic-dependencies :clojure-lsp/unused-public-var]}"


### PR DESCRIPTION


The `cyclic-dependencies` linter falsely reported cycles caused by `(require ...)` calls inside `(comment ...)` forms. This change excludes those usages from cycle detection.

Before running cycle detection, walk each file's analysis for `clojure.core/comment` (and `cljs.core/comment`) var-usages, and decrement any dep-graph edges whose `:namespace-usages` fall inside those bounds. 

It is scoped to the linter and other features are unchanged.

Fixes #2107

## Checklist

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists. (#2107)
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder) — N/A, no user-facing setting changed
