### PR TITLE
unit tests for command actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - implement move to :let refactoring #1732
 - Measure performance of didOpen and didChange
 - if code-action selection end-position args aren't provided, don't try to use them #2276
+- add unit tests for command actions location args #2279
 
 ## 2026.02.20-16.08.58
 

--- a/lib/test/clojure_lsp/refactor/command_test.clj
+++ b/lib/test/clojure_lsp/refactor/command_test.clj
@@ -1,0 +1,24 @@
+(ns clojure-lsp.refactor.command-test
+  (:require
+   [clojure-lsp.feature.command :as f.command]
+   [clojure-lsp.test-helper.internal :as h]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest command-arguments
+  (testing "invoke command with 4 arguments, expecting second two to be cursor location"
+    (with-redefs [f.command/run-command (fn [arg]
+                                          (is (and (= ["new-fn"] (:args arg))
+                                                   (= 24 (:row arg))
+                                                   (= 37 (:col arg))
+                                                   (= 24 (:end-row arg))
+                                                   (= 37 (:end-col arg))))
+                                          {:no-op? true})]
+      (f.command/call-command :extract-function ["file:///a.clj" 23 36 "new-fn"] {:db* (h/db*)})))
+  (testing "invoke command with 6 arguments, expecting second two and last two to be cursor locations"
+    (with-redefs [f.command/run-command (fn [arg]
+                                          (is (and (= ["new-fn"] (:args arg))
+                                                   (= 24 (:row arg))
+                                                   (= 37 (:col arg))
+                                                   (= 25 (:end-row arg))
+                                                   (= 38 (:end-col arg)))) {:no-op? true})]
+      (f.command/call-command :extract-function ["file:///a.clj" 23 36 "new-fn" 24 37] {:db* (h/db*)}))))


### PR DESCRIPTION
This addresses issue 2279 which complains that there isn't unit test coverage for clojure-lsp.feature.command/run-command.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [-] I updated documentation if applicable (`docs` folder)
