### PR TITLE
while adding :require, add a ns if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- add missing namespace form, guessing at the name if outside of project sources, 
+  when adding a missing :require or :import via the Add Require code action.  #1734
+
 
 ## 2026.05.05-12.58.26
 

--- a/lib/src/clojure_lsp/feature/add_missing_libspec.clj
+++ b/lib/src/clojure_lsp/feature/add_missing_libspec.clj
@@ -197,17 +197,23 @@
 
                    :else nil)}))
 
+(defn ^:private create-new-ns-loc [uri db]
+  (when-let [new-ns-name (shared/uri->safe-namespace uri db true)]
+    (z/of-string (str "(ns " new-ns-name ")"))))
+
 (defn add-to-namespace*
   [zloc
+   uri
    {libspec-type :type
     lib-sym :lib
     refer-sym :refer
     alias-sym :alias
     class-sym :class}
    db]
-  (let [ns-loc (edit/find-namespace zloc)
-        ns-zip (zsub/subzip ns-loc)]
-    (when (need-to-add-libspec? ns-zip lib-sym refer-sym alias-sym class-sym)
+  (let [existing-ns-loc (edit/find-namespace zloc)
+        ns-loc (or existing-ns-loc (create-new-ns-loc uri db))
+        ns-zip (when ns-loc (zsub/subzip ns-loc))]
+    (when (and ns-loc (need-to-add-libspec? ns-zip lib-sym refer-sym alias-sym class-sym))
       (let [add-form-type? (not (z/find-value ns-zip z/next libspec-type))
             form-type-loc (z/find-value (zsub/subzip ns-loc) z/next libspec-type)
             ns-inner-blocks-indentation (resolve-ns-inner-blocks-identation db)
@@ -247,8 +253,15 @@
                                              (not (fast= :same-line ns-inner-blocks-indentation))) (z/append-child* (n/newlines 1)))
                                         (z/append-child* (n/spaces (dec col)))
                                         (z/append-child form-to-add)))]
-        [{:range (meta (z/node result-loc))
-          :loc result-loc}]))))
+        (if existing-ns-loc
+          [{:range (meta (z/node result-loc))
+            :loc result-loc}]
+          ;; return two edits instead of form because clean-ns-edits will remove
+          ;; the newlines that are outside the ns expression
+          [{:range {:row 1 :col 1 :end-row 1 :end-col 1}
+            :loc result-loc}
+           {:range {:row 1 :col 1 :end-row 1 :end-col 1}
+            :loc (z/of-node (n/newlines 2))}])))))
 
 (defn ^:private add-to-rcf?
   "returns zloc of rcf when require/import should be added to rcf-form, otherwise nil"
@@ -342,7 +355,7 @@
                 :loc result-loc}])))))))
 
 (defn ^:private add-to-namespace
-  [zloc type ns-sym sym db]
+  [zloc uri type ns-sym sym db]
   (when (or (fast= :require-simple type) sym)
     (let [libspec (case type
                     :require-refer {:type :require :lib ns-sym :refer sym}
@@ -355,7 +368,7 @@
             (= :token (z/tag zloc))
             (= "comment" (z/string zloc)))
         (add-to-rcf* zloc libspec db)
-        (add-to-namespace* zloc libspec db)))))
+        (add-to-namespace* zloc uri libspec db)))))
 
 (defn add-missing-import [zloc uri import-name db {:keys [producer]}]
   (when-let [import-name (or import-name
@@ -365,23 +378,23 @@
           class-name (symbol (last split))
           rcf-zloc (add-to-rcf? zloc :import db producer)
           zloc (or rcf-zloc zloc)]
-      (cond->> (add-to-namespace zloc :import package-name class-name db)
+      (cond->> (add-to-namespace zloc uri :import package-name class-name db)
         (nil? rcf-zloc) (cleaning-ns-edits uri db)))))
 
 (defn add-known-alias
-  [zloc alias-to-add qualified-ns-to-add db]
+  [zloc uri alias-to-add qualified-ns-to-add db]
   (when (and qualified-ns-to-add alias-to-add)
-    (add-to-namespace zloc :require-alias qualified-ns-to-add alias-to-add db)))
+    (add-to-namespace zloc uri :require-alias qualified-ns-to-add alias-to-add db)))
 
 (defn add-simple-require
-  [zloc qualified-ns-to-add db]
+  [zloc uri qualified-ns-to-add db]
   (when qualified-ns-to-add
-    (add-to-namespace zloc :require-simple qualified-ns-to-add nil db)))
+    (add-to-namespace zloc uri :require-simple qualified-ns-to-add nil db)))
 
 (defn ^:private add-known-refer
-  [zloc refer-to-add qualified-ns-to-add db]
+  [zloc uri refer-to-add qualified-ns-to-add db]
   (when (and qualified-ns-to-add refer-to-add)
-    (add-to-namespace zloc :require-refer qualified-ns-to-add refer-to-add db)))
+    (add-to-namespace zloc uri :require-refer qualified-ns-to-add refer-to-add db)))
 
 (defn ^:private sub-segment?
   [alias-segs def-segs]
@@ -604,7 +617,7 @@
        (take-while (complement z/end?))
        (filter p?)))
 
-(defn add-ns-to-loc-change [loc chosen-alias]
+(defn ^:private add-ns-to-loc-change [loc chosen-alias]
   (let [replaced-loc (-> loc
                          (z/replace (-> (symbol (name chosen-alias) (-> loc safe-sym name))
                                         n/token-node
@@ -625,13 +638,13 @@
       (->> (concat
              (cond->> (cond
                         chosen-refer
-                        (add-known-refer zloc (symbol chosen-refer) chosen-ns db)
+                        (add-known-refer zloc uri (symbol chosen-refer) chosen-ns db)
 
                         chosen-alias
-                        (add-known-alias zloc (symbol chosen-alias-or-ns) chosen-ns db)
+                        (add-known-alias zloc uri (symbol chosen-alias-or-ns) chosen-ns db)
 
                         :else
-                        (add-simple-require zloc chosen-ns db))
+                        (add-simple-require zloc uri chosen-ns db))
                to-ns? (cleaning-ns-edits uri db))
              (when chosen-alias-or-ns
                (cond

--- a/lib/src/clojure_lsp/feature/completion.clj
+++ b/lib/src/clojure_lsp/feature/completion.clj
@@ -162,13 +162,13 @@
                                            documentation))))))
 
 (defn ^:private completion-item-with-alias-edit
-  [completion-item cursor-loc alias-to-add ns-to-add rcf-pos db]
+  [uri completion-item cursor-loc alias-to-add ns-to-add rcf-pos db]
   (let [zloc (cond-> cursor-loc
                rcf-pos edit/to-root
                rcf-pos (edit/find-at-pos
                          (:row rcf-pos) (:col rcf-pos)))
         edits (some-> zloc
-                      (f.add-missing-libspec/add-known-alias alias-to-add ns-to-add db)
+                      (f.add-missing-libspec/add-known-alias uri alias-to-add ns-to-add db)
                       r.transform/result)]
     (cond-> completion-item
       (seq edits) (assoc :additional-text-edits (mapv #(update % :range shared/->range)
@@ -197,7 +197,7 @@
                                :uri          uri}
                         (string? ns-to-add) (assoc :js-require true)))
     ;; client can't postpone the edit calculation, so do it now, even though it's expensive
-      (completion-item-with-alias-edit completion-item cursor-loc alias-to-add ns-to-add rcf-pos db))))
+      (completion-item-with-alias-edit uri completion-item cursor-loc alias-to-add ns-to-add rcf-pos db))))
 
 (defn ^:private generic-priority->specific-priority
   [element priority]
@@ -768,7 +768,7 @@
     (let [ns-to-add (if js-require
                       ns-to-add
                       (symbol ns-to-add))]
-      (completion-item-with-alias-edit item zloc (symbol alias-to-add) ns-to-add rcf-pos db))
+      (completion-item-with-alias-edit uri item zloc (symbol alias-to-add) ns-to-add rcf-pos db))
     item))
 
 (defn resolve-item [{:keys [data] :as item} db*]

--- a/lib/src/clojure_lsp/feature/file_management.clj
+++ b/lib/src/clojure_lsp/feature/file_management.clj
@@ -24,9 +24,7 @@
 
 (defn create-ns-changes [uri text db]
   (when-let [new-ns (and (string/blank? text)
-                         (contains? #{:clj :cljs :cljc} (shared/uri->file-type uri))
-                         (not (get (:create-ns-blank-files-denylist db) uri))
-                         (shared/uri->namespace uri db))]
+                         (shared/uri->safe-namespace uri db))]
     (when (settings/get db [:auto-add-ns-to-new-files?] true)
       (let [new-text (format "(ns %s)" new-ns)
             changes [{:text-document {:version (get-in db [:documents uri :v] 0) :uri uri}

--- a/lib/src/clojure_lsp/feature/move_form.clj
+++ b/lib/src/clojure_lsp/feature/move_form.clj
@@ -48,7 +48,7 @@
                                       (:namespace-usages local-buckets)))
         remove-source-require? (and source-require (empty? other-source-usages))
         namespace-loc (edit/find-namespace file-loc)]
-    (if-let [add-to-ns-changes (f.add-missing-libspec/add-to-namespace* file-loc libspec db)]
+    (if-let [add-to-ns-changes (f.add-missing-libspec/add-to-namespace* file-loc uri libspec db)]
       (cond-> add-to-ns-changes
         remove-source-require?
         (update-in

--- a/lib/src/clojure_lsp/shared.clj
+++ b/lib/src/clojure_lsp/shared.clj
@@ -16,7 +16,7 @@
    [java.nio.charset StandardCharsets]
    [java.nio.file Paths]
    [java.security MessageDigest]
-   [java.util.regex Matcher]))
+   [java.util.regex Matcher Pattern]))
 
 (set! *warn-on-reflection* true)
 
@@ -365,32 +365,78 @@
     (ensure-ends-with-slash path)
     path))
 
+(defn ^:private filename-uri-part->namespace
+  "given a (native) filename, turn it into a namespace by lopping off
+   the extension, replacing slashes with dots, and replacing underscores
+   with dashes"
+  [filename]
+  (some-> filename
+          (->> (re-find #"^(.+)\.\S+$"))  ;; group everything except file extension
+          (nth 1)
+          (string/replace "/" ".")
+          (string/replace #"[_\s]" "-")))
+
+(defn ^:private guess-filename-from-root [uri project-root-uri]
+  (let [project-root-ending-with-slash (if (string/ends-with? project-root-uri "/") project-root-uri (str project-root-uri "/"))
+        quoted-project-root (Pattern/quote project-root-ending-with-slash)]
+    (second (re-matches (re-pattern (str quoted-project-root "(.*)")) uri))))
+
+(defn ^:private guess-filename-from-name [uri]
+  ;; take only the part after the last slash
+  (last (string/split uri #"/")))
+
+(defn ^:private to-uri-part
+  "converts a native filepath into a piece of a URI suitable for converting to a namespace
+   (should handle backslashes in windows due to converting to a file first)"
+  [native-filepath]
+  (some-> native-filepath
+          io/file
+          .getPath
+          (string/replace fs/file-separator "/")))
+
 (defn uri->namespace
-  [uri db]
-  (let [filename (uri->filename uri)
-        project-root-uri (:project-root-uri db)
-        source-paths (get-in db [:settings :source-paths])
-        in-project? (when project-root-uri
-                      (string/starts-with? uri project-root-uri))
-        file-type (uri->file-type uri)]
-    (when (and in-project? (not= :unknown file-type))
-      (->> source-paths
-           (map path->folder-with-slash)
-           (filename->source-paths filename)
-           (keep (fn [source-path]
-                   (some-> (relativize-filepath filename source-path)
-                           (->> (re-find #"^(.+)\.\S+$"))
-                           (nth 1)
-                           (string/replace (System/getProperty "file.separator") ".")
-                           (string/replace #"_" "-"))))
-           (reduce (fn [source-path-a source-path-b]
-                     (cond
-                       (not source-path-b) source-path-a
-                       (not source-path-a) source-path-b
-                       :else (if (> (count source-path-a)
-                                    (count source-path-b))
-                               source-path-b
-                               source-path-a))) nil)))))
+  ([uri db] (uri->namespace uri db false))
+  ([uri db guess-ns?]
+   (let [filename (uri->filename uri)
+         project-root-uri (:project-root-uri db)
+         source-paths (get-in db [:settings :source-paths])
+         in-project? (when project-root-uri
+                       (string/starts-with? uri project-root-uri))
+         file-type (uri->file-type uri)]
+     (cond
+       (and in-project? (not= :unknown file-type))
+       (or
+         (->> source-paths
+              (map path->folder-with-slash)
+              (filename->source-paths filename)
+              (keep (fn [source-path]
+                      (some-> (relativize-filepath filename source-path)
+                              (to-uri-part)
+                              filename-uri-part->namespace)))
+              (reduce (fn [source-path-a source-path-b]
+                        (cond
+                          (not source-path-b) source-path-a
+                          (not source-path-a) source-path-b
+                          :else (if (> (count source-path-a)
+                                       (count source-path-b))
+                                  source-path-b
+                                  source-path-a))) nil))
+         (when guess-ns?
+           (filename-uri-part->namespace (guess-filename-from-root uri project-root-uri))))
+
+       (and (not= :unknown file-type) guess-ns?)
+       (filename-uri-part->namespace (guess-filename-from-name uri))
+
+       :else
+       nil))))
+
+(defn uri->safe-namespace
+  ([uri db]
+   (uri->safe-namespace uri db false))
+  ([uri db guess-ns?]
+   (and (contains? #{:clj :cljs :cljc} (uri->file-type uri))
+        (not (get (:create-ns-blank-files-denylist db) uri))
+        (uri->namespace uri db guess-ns?))))
 
 (defn inside?
   "Checks if element `a` is inside element `b` scope."

--- a/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
+++ b/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
@@ -227,6 +227,15 @@
 
 (deftest add-missing-libspec-test
   (testing "aliases"
+    (testing "when namespace is missing, create namespace"
+      (h/reset-components!)
+      (h/load-code-and-locs "(ns b (:require [foo.s :as s]))" "file:///b.clj")
+      (is (= (h/code "(ns a \n  (:require\n    [foo.s :as s]))")
+             (-> "|s/thing"
+                 add-missing-libspec
+                 first
+                 :loc
+                 z/root-string))))
     (testing "known aliases in project"
       (h/reset-components!)
       (h/load-code-and-locs "(ns a (:require [foo.s :as s]))" "file:///b.clj")
@@ -388,6 +397,13 @@
   (f.add-missing-libspec/add-missing-import (h/load-code-and-zloc code) "file:///a.clj" import-name (h/db) {}))
 
 (deftest add-missing-import-test
+  (testing "when namespace form doesn't exist"
+    (is (= (h/code "(ns a "
+                   "  (:import"
+                   "    [java.util Date]))")
+           (-> "|Date."
+               (add-missing-import "java.util.Date")
+               as-root-str))))
   (testing "when there is no :import form"
     (is (= (h/code "(ns foo.bar "
                    "  (:import"
@@ -570,9 +586,13 @@
                        "  |Date.)")
                (add-missing-import-to-rcf "java.util.Date"))))))
 
-(defn add-require-suggestion [code chosen-ns chosen-alias chosen-refer js-require]
-  (swap! (h/db*) shared/deep-merge {:settings {:clean {:ns-inner-blocks-indentation :next-line}}})
-  (f.add-missing-libspec/add-require-suggestion (h/zloc-from-code code) "file:///a.clj" chosen-ns chosen-alias chosen-refer js-require (h/db) {}))
+(defn add-require-suggestion
+  ([code chosen-ns chosen-alias chosen-refer js-require]
+   (add-require-suggestion code "file:///a.clj" chosen-ns chosen-alias chosen-refer js-require {}))
+  ([code uri chosen-ns chosen-alias chosen-refer js-require additional-db]
+   (h/reset-components!)
+   (swap! (h/db*) shared/deep-merge {:settings {:clean {:ns-inner-blocks-indentation :next-line}}} additional-db)
+   (f.add-missing-libspec/add-require-suggestion (h/zloc-from-code code) uri chosen-ns chosen-alias chosen-refer js-require (h/db) {})))
 
 (deftest add-require-suggestion-test
   (h/load-code-and-locs (h/code "(ns clojure.string) (defn split [])") "file:///clojure/string.clj")
@@ -613,7 +633,82 @@
     (testing "on invalid location"
       (is (nil? (-> (h/code "(ns foo.bar)"
                             "|;; comment")
-                    (add-require-suggestion "clojure.string" "str" nil nil))))))
+                    (add-require-suggestion "clojure.string" "str" nil nil)))))
+    (testing "when missing ns, create new namespace form based on filename"
+      (is (= (h/code "(ns a "
+                     "  (:require"
+                     "   [clojure.string :as str]))")
+             (-> (h/code
+                   ""
+                   "|str/a")
+                 (add-require-suggestion "clojure.string" "str" nil nil)
+                 as-root-str))))
+    (testing "when missing ns, don't create new namespace form if filename extension is unknown"
+      (is (nil?
+            (-> (h/code
+                  ""
+                  "|str/a")
+                (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.my-clojure" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                as-root-str))))
+    (testing "adds newlines after ns form, for new namespace"
+      (is (= (h/code ""
+                     ""
+                     "")
+             (-> (h/code
+                   "(|str/a)")
+                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                 second
+                 :loc
+                 z/root-string))))
+    (testing "no new newlines added after ns form, when file has an existing namespace"
+      (is (nil?
+            (-> (h/code "(ns foo.a "
+                        "  (:require"
+                        "   [clojure.string :as str]))"
+                        ""
+                        "(|str/a)")
+                (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                second))))
+    (testing "subdirectory from project root, no ns -> uses subdir and filename as part of namespace"
+      (is (= (h/code "(ns foo.a "
+                     "  (:require"
+                     "   [clojure.string :as str]))")
+             (-> (h/code
+                   ""
+                   "|str/a")
+                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri  (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                 as-root-str))))
+    (testing "from project source root, no ns -> uses subdir and filename to determine namespace"
+      (is (= (h/code "(ns foo.a "
+                     "  (:require"
+                     "   [clojure.string :as str]))")
+             (-> (h/code
+                   ""
+                   "|str/a")
+                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/lib/src/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
+                                                                                                                                  :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
+                 as-root-str))))
+    (testing "from project source root, no ns -> use filename only to determine namespace"
+      (is (= (h/code "(ns a "
+                     "  (:require"
+                     "   [clojure.string :as str]))")
+             (-> (h/code
+                   ""
+                   "|str/a")
+                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/lib/src/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
+                                                                                                                              :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
+                 as-root-str))))
+    (testing "subdirectory from project source root, no ns -> use subdir and filename to determine namespace"
+      (is (= (h/code "(ns foo.a "
+                     "  (:require"
+                     "   [clojure.string :as str]))")
+             (-> (h/code
+                   ""
+                   "|str/a")
+                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/lib/src/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
+                                                                                                                                  :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
+                 as-root-str)))))
+
   (testing "refer"
     (testing "on empty ns"
       (is (= (h/code "(ns foo.bar "
@@ -621,6 +716,14 @@
                      "   [clojure.string :refer [split]]))")
              (-> (h/code "(ns foo.bar)"
                          "|split")
+                 (add-require-suggestion "clojure.string" nil "split" nil)
+                 as-root-str))))
+    (testing "when missing ns, create new namespace form based on filename"
+      (is (= (h/code "(ns a "
+                     "  (:require"
+                     "   [clojure.string :refer [split]]))")
+             (-> (h/code
+                   "|split")
                  (add-require-suggestion "clojure.string" nil "split" nil)
                  as-root-str))))
     (testing "on non empty ns"

--- a/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
+++ b/lib/test/clojure_lsp/feature/add_missing_libspec_test.clj
@@ -588,7 +588,7 @@
 
 (defn add-require-suggestion
   ([code chosen-ns chosen-alias chosen-refer js-require]
-   (add-require-suggestion code "file:///a.clj" chosen-ns chosen-alias chosen-refer js-require {}))
+   (add-require-suggestion code (h/file-uri "file:///a.clj") chosen-ns chosen-alias chosen-refer js-require {}))
   ([code uri chosen-ns chosen-alias chosen-refer js-require additional-db]
    (h/reset-components!)
    (swap! (h/db*) shared/deep-merge {:settings {:clean {:ns-inner-blocks-indentation :next-line}}} additional-db)
@@ -648,7 +648,8 @@
             (-> (h/code
                   ""
                   "|str/a")
-                (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.my-clojure" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                (add-require-suggestion (h/file-uri "file:///path/to/Projects/clojure-lsp/foo/a.my-clojure") "clojure.string" "str" nil nil
+                                        {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
                 as-root-str))))
     (testing "adds newlines after ns form, for new namespace"
       (is (= (h/code ""
@@ -656,7 +657,8 @@
                      "")
              (-> (h/code
                    "(|str/a)")
-                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                 (add-require-suggestion (h/file-uri "file:///path/to/Projects/clojure-lsp/foo/a.clj") "clojure.string" "str" nil nil
+                                         {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
                  second
                  :loc
                  z/root-string))))
@@ -667,7 +669,8 @@
                         "   [clojure.string :as str]))"
                         ""
                         "(|str/a)")
-                (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                (add-require-suggestion (h/file-uri "file:///path/to/Projects/clojure-lsp/foo/a.clj") "clojure.string" "str" nil nil
+                                        {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")})
                 second))))
     (testing "subdirectory from project root, no ns -> uses subdir and filename as part of namespace"
       (is (= (h/code "(ns foo.a "
@@ -676,7 +679,8 @@
              (-> (h/code
                    ""
                    "|str/a")
-                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri  (h/file-uri "file:///path/to/Projects/clojure-lsp")})
+                 (add-require-suggestion (h/file-uri "file:///path/to/Projects/clojure-lsp/foo/a.clj") "clojure.string" "str" nil nil
+                                         {:project-root-uri  (h/file-uri "file:///path/to/Projects/clojure-lsp")})
                  as-root-str))))
     (testing "from project source root, no ns -> uses subdir and filename to determine namespace"
       (is (= (h/code "(ns foo.a "
@@ -685,8 +689,9 @@
              (-> (h/code
                    ""
                    "|str/a")
-                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/lib/src/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
-                                                                                                                                  :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
+                 (add-require-suggestion (h/file-uri "file:///path/to/Projects/clojure-lsp/lib/src/foo/a.clj") "clojure.string" "str" nil nil
+                                         {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
+                                          :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
                  as-root-str))))
     (testing "from project source root, no ns -> use filename only to determine namespace"
       (is (= (h/code "(ns a "
@@ -695,18 +700,9 @@
              (-> (h/code
                    ""
                    "|str/a")
-                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/lib/src/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
-                                                                                                                              :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
-                 as-root-str))))
-    (testing "subdirectory from project source root, no ns -> use subdir and filename to determine namespace"
-      (is (= (h/code "(ns foo.a "
-                     "  (:require"
-                     "   [clojure.string :as str]))")
-             (-> (h/code
-                   ""
-                   "|str/a")
-                 (add-require-suggestion "file:///path/to/Projects/clojure-lsp/lib/src/foo/a.clj" "clojure.string" "str" nil nil {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
-                                                                                                                                  :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
+                 (add-require-suggestion (h/file-uri "file:///path/to/Projects/clojure-lsp/lib/src/a.clj") "clojure.string" "str" nil nil
+                                         {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
+                                          :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
                  as-root-str)))))
 
   (testing "refer"

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -82,15 +82,59 @@
     (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root and not a source-path"
     (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
-                                                 :source-paths #{(h/file-uri "file:///user/project/bla")}}
+                                                 :source-paths #{(h/file-path "file:///user/project/bla")}}
                                       :project-root-uri (h/file-uri "file:///user/project")})
     (is (nil? (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
+  (testing "when has to guess namespace from uri and there is no project root or source path"
+    (h/reset-components!)
+    (is (= "bar" (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db) true))))
+  (testing "when has to guess namespace from uri and there is no project root or source path and uri has a space"
+    (h/reset-components!)
+    (is (= "bar" (shared/uri->namespace (h/file-uri "file:///user/project/%20src/foo/bar.clj") (h/db) true))))
+  (testing "when has to guess namespace from uri and there is no project root or source path and uri has a regex char"
+    (h/reset-components!)
+    (is (= "bar" (shared/uri->namespace (h/file-uri "file:///user/project/src+/foo/bar.clj") (h/db) true))))
+  (testing "when has to guess namespace from uri and there is a project root no source path"
+    (h/reset-components!)
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true}
+                                      :project-root-uri (h/file-uri "file:///user/project")})
+    (is (= "foo.bar" (shared/uri->namespace (h/file-uri "file:///user/project/foo/bar.clj") (h/db) true))))
+
+  (testing "when has to guess namespace from uri and there is a source path that encompasses the uri"
+    (h/reset-components!)
+    (swap! (h/db*) shared/deep-merge {:project-root-uri (h/file-uri "file:///path/to/Projects/clojure-lsp")
+                                      :settings {:source-paths [(h/file-path "/path/to/Projects/clojure-lsp/lib/src")]}})
+    (is (= "foo.a" (shared/uri->namespace (h/file-uri "file:///path/to/Projects/clojure-lsp/lib/src/foo/a.clj") (h/db) true))))
+
+  (testing "when has to guess namespace from uri and there is a project root with ending slash, but no source path"
+    (h/reset-components!)
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true}
+                                      :project-root-uri (h/file-uri "file:///user/project/")})
+    (is (= "foo.bar" (shared/uri->namespace (h/file-uri "file:///user/project/foo/bar.clj") (h/db) true))))
+  (testing "when has to guess namespace from uri and there is a project root but file uri isn't in source paths"
+    (h/reset-components!)
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+                                                 :source-paths #{(h/file-path "/user/project/bla")}}
+                                      :project-root-uri (h/file-uri "file:///user/project")})
+    (is (= "foo.bar" (shared/uri->namespace (h/file-uri "file:///user/project/foo/bar.clj") (h/db) true))))
+  (testing "when has to guess namespace from uri and there is a project root with a uri that is inside the source paths"
+    (h/reset-components!)
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+                                                 :source-paths #{(h/file-path "/user/project/src")}}
+                                      :project-root-uri (h/file-uri "file:///user/project")})
+    (is (= "foo.bar" (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db) true))))
   (testing "when it has a project root and a source-path"
     (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                  :source-paths #{(h/file-path "/user/project/src")}}
                                       :project-root-uri (h/file-uri "file:///user/project")})
     (is (= "foo.bar"
            (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
+  (testing "when it has a project root with regex special chars and a source-path"
+    (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
+                                                 :source-paths #{(h/file-path "/user.*/project/src")}}
+                                      :project-root-uri (h/file-uri "file:///user.*/project")})
+    (is (= "foo.bar"
+           (shared/uri->namespace (h/file-uri "file:///user.*/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root a source-path on mono repos"
     (swap! (h/db*) medley/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                  :source-paths #{(h/file-path "/user/project/src/clj")

--- a/lib/test/clojure_lsp/shared_test.clj
+++ b/lib/test/clojure_lsp/shared_test.clj
@@ -131,10 +131,10 @@
            (shared/uri->namespace (h/file-uri "file:///user/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root with regex special chars and a source-path"
     (swap! (h/db*) shared/deep-merge {:settings {:auto-add-ns-to-new-files? true
-                                                 :source-paths #{(h/file-path "/user.*/project/src")}}
-                                      :project-root-uri (h/file-uri "file:///user.*/project")})
+                                                 :source-paths #{(h/file-path "/user.+/project/src")}}
+                                      :project-root-uri (h/file-uri "file:///user.+/project")})
     (is (= "foo.bar"
-           (shared/uri->namespace (h/file-uri "file:///user.*/project/src/foo/bar.clj") (h/db)))))
+           (shared/uri->namespace (h/file-uri "file:///user.+/project/src/foo/bar.clj") (h/db)))))
   (testing "when it has a project root a source-path on mono repos"
     (swap! (h/db*) medley/deep-merge {:settings {:auto-add-ns-to-new-files? true
                                                  :source-paths #{(h/file-path "/user/project/src/clj")


### PR DESCRIPTION
This addresses #1734, it adds a namespace form, if needed, when a :require (or :import) is added via a code action

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [-] I updated documentation if applicable (`docs` folder)
