### PR TITLE
Fix cyclic dependency check for as-alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added Performance integration tests for server initialization: Measuring Cold Start and Warm Start, ensuring that future changes don't regress the startup time of the LSP server.
+- Fix `cyclic-dependencies` linter falsely reporting cycles for `:as-alias` requires. #2108
 ## 2026.05.05-12.58.26
 
 - Fix `cyclic-dependencies` linter falsely reporting cycles for `(require ...)` calls inside `(comment ...)` forms. #2107

--- a/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
@@ -300,6 +300,28 @@
       (update-in dep-graph [from :dependencies] dissoc to)
       (update-in dep-graph path dec))))
 
+(defn ^:private text-between-name-and-alias
+  [text {:keys [name-end-row name-end-col alias-row alias-col]}]
+  (when (and text name-end-row name-end-col alias-row alias-col)
+    (let [lines (string/split text #"\r\n|\n|\r" -1)]
+      (if (= name-end-row alias-row)
+        (subs (nth lines (dec name-end-row))
+              (dec name-end-col)
+              (dec alias-col))
+        (str
+          (subs (nth lines (dec name-end-row)) (dec name-end-col))
+          "\n"
+          (string/join
+            "\n"
+            (subvec lines name-end-row (dec alias-row)))
+          "\n"
+          (subs (nth lines (dec alias-row)) 0 (dec alias-col)))))))
+
+(defn ^:private as-alias-usage? [documents {:keys [uri alias] :as usage}]
+  (when alias
+    (some-> (text-between-name-and-alias (get-in documents [uri :text]) usage)
+            (string/includes? ":as-alias"))))
+
 (defn ^:private remove-comment-form-deps
   "Remove dep-graph edges that originate from a (require ...) (or similar) call
    inside a (comment ...) form, so they don't participate in cycle detection."
@@ -317,13 +339,29 @@
             graph namespace-usages))))
     dep-graph analysis))
 
+(defn ^:private remove-as-alias-deps
+  "Remove dep-graph edges from :as-alias requires. They create aliases without
+   loading the target namespace, so they do not participate in cycle detection."
+  [dep-graph analysis documents]
+  (reduce-kv
+    (fn [graph _uri {:keys [namespace-usages]}]
+      (reduce
+        (fn [g {:keys [from name] :as usage}]
+          (cond-> g
+            (as-alias-usage? documents usage)
+            (decrement-dep-edge from name)))
+        graph namespace-usages))
+    dep-graph analysis))
+
 (defn ^:private cyclic-dependencies
   "Detects cyclic dependencies and generates diagnostics for each namespace in a cycle."
   [narrowed-db project-db settings]
   (let [level (get-in settings [:linters :clojure-lsp/cyclic-dependencies :level] :off)]
     (when-not (identical? :off level)
-      (let [dep-graph (remove-comment-form-deps
-                        (:dep-graph narrowed-db) (:analysis project-db))
+      (let [dep-graph (-> (:dep-graph narrowed-db)
+                          (remove-comment-form-deps (:analysis project-db))
+                          (remove-as-alias-deps 
+                            (:analysis project-db) (:documents project-db)))
             cycles (find-dependency-cycles dep-graph)
             exclude-namespaces (set (get-in settings [:linters :clojure-lsp/cyclic-dependencies :exclude-namespaces] #{}))
             ;; Create diagnostics for each namespace in each cycle

--- a/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
+++ b/lib/src/clojure_lsp/feature/diagnostics/built_in.clj
@@ -360,7 +360,7 @@
     (when-not (identical? :off level)
       (let [dep-graph (-> (:dep-graph narrowed-db)
                           (remove-comment-form-deps (:analysis project-db))
-                          (remove-as-alias-deps 
+                          (remove-as-alias-deps
                             (:analysis project-db) (:documents project-db)))
             cycles (find-dependency-cycles dep-graph)
             exclude-namespaces (set (get-in settings [:linters :clojure-lsp/cyclic-dependencies :exclude-namespaces] #{}))

--- a/lib/test/clojure_lsp/feature/diagnostics/built_in_test.clj
+++ b/lib/test/clojure_lsp/feature/diagnostics/built_in_test.clj
@@ -423,6 +423,30 @@
         (lint! [(h/file-uri "file:///a.clj") (h/file-uri "file:///b.clj") (h/file-uri "file:///c.clj")]
                {:linters {:clojure-lsp/cyclic-dependencies {:level :warning}}}))))
 
+  (testing ":as-alias require does not contribute to cycle"
+    (h/reset-components!)
+    (h/load-code-and-locs "(ns a (:require [b :as b]))" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs "(ns b (:require [a :as-alias a]))"
+                          (h/file-uri "file:///b.clj"))
+    (h/assert-submaps
+      []
+      (lint! [(h/file-uri "file:///a.clj") (h/file-uri "file:///b.clj")]
+             {:linters {:clojure-lsp/cyclic-dependencies {:level :warning}}})))
+
+  (testing "multiline :as-alias require does not contribute to cycle"
+    (h/reset-components!)
+    (h/load-code-and-locs "(ns a (:require [b :as b]))" (h/file-uri "file:///a.clj"))
+    (h/load-code-and-locs (h/code "(ns b"
+                                  "  (:require"
+                                  "   [a"
+                                  "    :as-alias"
+                                  "    a]))")
+                          (h/file-uri "file:///b.clj"))
+    (h/assert-submaps
+      []
+      (lint! [(h/file-uri "file:///a.clj") (h/file-uri "file:///b.clj")]
+             {:linters {:clojure-lsp/cyclic-dependencies {:level :warning}}})))
+
   (testing "self-dependency cycle"
     (h/reset-components!)
     (h/load-code-and-locs "(ns self (:require [self :as s]))" (h/file-uri "file:///self.clj"))


### PR DESCRIPTION
Aliases created with :as-alias do not load the target namespace, so they should not count as dependency edges when detecting namespace cycles.

Add same-line and multiline regression coverage for :as-alias requires.

Fixes: #2108

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [x] I updated documentation if applicable (`docs` folder)
