### PR TITLE
[debug] Diagnose CI integration test hang (#2326)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
       - name: Run integration tests
         run: bb integration-test
 
+      - name: Upload integration server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-server-log-jvm-${{ matrix.os }}-${{ matrix.jdk }}
+          path: cli/integration-test/sample-test/*.out
+          if-no-files-found: warn
+
       - name: Run babashka pod tests
         run: bb pod-test
 
@@ -191,6 +199,14 @@ jobs:
 
       - name: Run integration tests
         run: bb integration-test
+
+      - name: Upload integration server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-server-log-graalvm
+          path: cli/integration-test/sample-test/*.out
+          if-no-files-found: warn
 
   performance-test:
     needs: graalvm-build

--- a/cli/integration-test/integration/definition_test.clj
+++ b/cli/integration-test/integration/definition_test.clj
@@ -84,15 +84,20 @@
   (lsp/notify! (fixture/did-open-source-path-notification "definition/a.clj"))
 
   (let [{:keys [uri]} (lsp/request! (fixture/definition-request (h/source-path->uri "definition/a.clj") 15 2))]
-    (lsp/notify! (fixture/did-open-external-path-notification uri (slurp uri)))
-
-    (testing "LSP features work on external clojure opened files"
-      (h/assert-submap
-        {:language "clojure"
-         :value "[x]\n [x message]"}
-        (-> (lsp/request! (fixture/hover-external-uri-request uri 7612 5))
-            :contents
-            (get 1))))))
+    (println "DEBUG#2326 jar-scheme: definition uri =" uri) (flush)
+    (let [content (slurp uri)]
+      (println "DEBUG#2326 jar-scheme: slurped" (count content) "chars") (flush)
+      (lsp/notify! (fixture/did-open-external-path-notification uri content))
+      (println "DEBUG#2326 jar-scheme: didOpen external sent") (flush)
+      (testing "LSP features work on external clojure opened files"
+        (let [result (lsp/request! (fixture/hover-external-uri-request uri 7612 5))]
+          (println "DEBUG#2326 jar-scheme: hover responded") (flush)
+          (h/assert-submap
+            {:language "clojure"
+             :value "[x]\n [x message]"}
+            (-> result
+                :contents
+                (get 1))))))))
 
 (deftest definition-external-dependency-zipfile-scheme
   (h/delete-project-file "../../.lsp/.cache/")


### PR DESCRIPTION
Not for merge. Debugging vehicle to capture the CI-only integration test hang.

CI integration tests have been hanging since #2316 at `integration.definition-test/definition-external-dependency-jar-scheme` (opening external `clojure/core.clj` from the jar and hovering). It does not reproduce locally (debug jvm, prod jvm, or cold caches), and no in-test timeout fires, so the cause is invisible.

This adds:
- println markers in that test to pinpoint where it stalls (after definition / slurp / didOpen / hover)
- an `if: failure()` step on the jvm and graalvm integration jobs to upload the sample-test server log (`*.out`) as an artifact

Once CI runs, the markers + uploaded server log should reveal the actual failure, then this becomes the fix (or is closed in favor of a clean fix PR).