### PR TITLE
Upload integration server logs as a CI artifact on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
       - name: Run integration tests
         run: bb integration-test
 
+      - name: Upload integration server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-server-log-jvm-${{ matrix.os }}-${{ matrix.jdk }}
+          path: cli/integration-test/sample-test/*.out
+          if-no-files-found: warn
+
       - name: Run babashka pod tests
         run: bb pod-test
 
@@ -191,6 +199,14 @@ jobs:
 
       - name: Run integration tests
         run: bb integration-test
+
+      - name: Upload integration server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-server-log-graalvm
+          path: cli/integration-test/sample-test/*.out
+          if-no-files-found: warn
 
   performance-test:
     needs: graalvm-build


### PR DESCRIPTION
## Summary
- The jvm and graalvm integration jobs upload the sample-test server log (`cli/integration-test/sample-test/*.out`) as an artifact when they fail, so integration failures can be diagnosed from the run instead of only the test assertion output.

Replaces #2327, which also carried throwaway debug markers.