### PR TITLE
Bump rewrite-clj to 1.2.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Publish startup diagnostics directly and off the `initialize` critical path, so large projects become interactive much sooner (warm `initialize` dropped from ~73s to ~8s on a large monorepo, with diagnostics streaming in right after). #2326
 - Added Performance integration tests for server initialization: Measuring Cold Start and Warm Start, ensuring that future changes don't regress the startup time of the LSP server.
 - Bump clj-kondo to `2026.05.26-20260612.132029-18`.
+- Bump rewrite-clj to `1.2.55`.
 - Fix crash when using `:exclude-when-defined-by` as a vector and not a set. #2292
 - Fix `cyclic-dependencies` linter falsely reporting cycles for `:as-alias` requires. #2108
 - Bumps:

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -1,5 +1,5 @@
 {:deps {org.clojure/clojure {:mvn/version "1.12.5"}
-        rewrite-clj/rewrite-clj {:mvn/version "1.2.54"}
+        rewrite-clj/rewrite-clj {:mvn/version "1.2.55"}
         borkdude/rewrite-edn {:mvn/version "0.5.9" :exclusions [rewrite-clj/rewrite-clj]}
         org.clojure/core.async {:mvn/version "1.9.865"}
         dev.weavejester/cljfmt {:mvn/version "0.16.4"


### PR DESCRIPTION
A bunch of performance improvements got into this release, see https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc#v1255---2026-06-19.
