### PR TITLE
Fix `:style/indent [[:inner 0] ...]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix unreachable "Classpath not found" error branch on stubs generation.
 - Fix db cache write failure when a `#_{:clj-kondo/ignore [...]}` hint precedes java interop code, leaking non-serializable data into the analysis. #2380
 - Fix completion error in deps.edn/project.clj when the map is transiently unbalanced while typing a new key. #2384
+- Fix `:style/indent [[...] ...]`. #2415
 
 ## 2026.07.06-14.34.19
 

--- a/lib/src/clojure_lsp/feature/format.clj
+++ b/lib/src/clojure_lsp/feature/format.clj
@@ -48,7 +48,7 @@
 
   See the details at https://docs.cider.mx/cider/indent_spec.html but a quick sketch follows.
   - Top-level numbers or keywords are shorthand for [x].
-  - The first element of the list is a number, `:defn` or `:form`.
+  - The first element of the list is a vector, number, `:defn` or `:form`.
     - Numbers give the number of special args (`[:block N]` in cljfmt)
     - `:defn` means indent like a `defn` (`[:inner 0]` in cljfmt)
     - `:form` means indent like a normal `(f a b)` form.
@@ -60,6 +60,7 @@
                               spec
                               [spec])
         sym-spec            (cond
+                              (vector? sym) sym
                               (number? sym) [:block sym]
                               (= sym :defn) [:inner 0])
         arg-specs           (keep-indexed arg-spec->cljfmt-arg args)

--- a/lib/test/clojure_lsp/feature/format_test.clj
+++ b/lib/test/clojure_lsp/feature/format_test.clj
@@ -32,6 +32,10 @@
     [:defn]                [[:inner 0]]
     [:form]                nil
 
+    ;; preserve vec sym spec
+    [[:block 0]]           [[:block 0]]
+    [[:inner 0]]           [[:inner 0]]
+
        ;; letfn
     [1 [[:defn]] :form]    [[:block 1] [:inner 2 0]]
        ;; defrecord


### PR DESCRIPTION
Updates `style-indent->cljfmt-spec` to preserve a vector rule in position 0.

Fixes #2415.

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
