### PR TITLE
additional code coverage for inline-function and move-to-for-let code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix unreachable "Classpath not found" error branch on stubs generation.
 - Fix db cache write failure when a `#_{:clj-kondo/ignore [...]}` hint precedes java interop code, leaking non-serializable data into the analysis. #2380
 - Fix completion error in deps.edn/project.clj when the map is transiently unbalanced while typing a new key. #2384
+- Additional unit tests for code-actions for inline-function and move-to-for-let #2429
 
 ## 2026.07.06-14.34.19
 

--- a/lib/test/clojure_lsp/feature/code_actions_test.clj
+++ b/lib/test/clojure_lsp/feature/code_actions_test.clj
@@ -288,6 +288,61 @@
                             :range {:start {:line 6 :character 2}}}] {}
                           (h/db)))))
 
+(deftest inline-function-code-action
+  (h/load-code (string/join "\n"
+                            ["(ns a)"
+                             "(defn my-add [my-a my-b my-c]"
+                             "  (+ my-a my-b my-c))"
+                             "(my-add 5 3 6)"])
+               (h/file-uri "file:///b.clj"))
+  (testing "when not in a function"
+    (is (not-any? #(= (:title %) "Inline function")
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
+                                      (h/file-uri "file:///b.clj")
+                                      1
+                                      3
+                                      [] {}
+                                      (h/db)))))
+  (testing "when in a function"
+    (h/assert-contains-submaps
+      [{:title "Inline function"
+        :command {:command "inline-function"}}]
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
+                          (h/file-uri "file:///b.clj")
+                          2
+                          3
+                          []
+                          {}
+                          (h/db)))))
+
+(deftest move-to-for-let-code-action
+  (h/load-code (string/join "\n"
+                            ["(for [x [1 2 3 4]"
+                             "      :let [a (* 2 x)]]"
+                             "  a)"
+                             "(xyz 1 2)"])
+               (h/file-uri "file:///b.clj"))
+  (testing "when not inside a form that allows :let"
+    (is (not-any? #(= (:title %) "Move to :let")
+                  (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
+                                      (h/file-uri "file:///b.clj")
+                                      4
+                                      3
+                                      []
+                                      {}
+                                      (h/db)))))
+  (testing "when inside a form that allows :let"
+    (h/assert-contains-submaps
+      [{:title "Move to :let"
+        :command {:command "move-to-for-let"}}]
+      (f.code-actions/all (zloc-of (h/file-uri "file:///b.clj"))
+                          (h/file-uri "file:///b.clj")
+                          3
+                          3
+                          []
+                          {}
+                          (h/db)))))
+
 (deftest inline-symbol-code-action
   (h/load-code-and-locs (str "(ns other-ns (:require [some-ns :as sns]))\n"
                              "(def bar 1)\n"


### PR DESCRIPTION
Just two additional code-actions tests that I missed earlier, for #2429

- [x] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)
- [-] I updated documentation if applicable (`docs` folder)
